### PR TITLE
M0/#2: GitHub Actions CI (uv + ruff + mypy + pytest matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs git history for version derivation
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Sync dependencies
+        run: uv sync --dev --python ${{ matrix.python-version }}
+
+      - name: ruff check
+        run: uv run ruff check
+
+      - name: ruff format --check
+        run: uv run ruff format --check
+
+      - name: mypy
+        run: uv run mypy
+
+      - name: pytest
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` runs the same four checks I run locally: `ruff check`, `ruff format --check`, `mypy`, `pytest`
- Matrix: `ubuntu-latest` × Python 3.11 / 3.12 / 3.13, plus `macos-latest` × 3.13 (user dev platform)
- Uses `astral-sh/setup-uv@v4` with `enable-cache: true` keyed on `uv.lock` so warm runs are fast
- `fetch-depth: 0` on checkout so `hatch-vcs` can derive `__version__` from git history
- Concurrency cancels in-progress runs on the same branch; least-privilege `permissions: contents: read`

## Why this shape
Using uv directly (rather than `pip install -e .[dev]`) keeps CI behaviour identical to local dev. The matrix covers our supported Python range from `requires-python = ">=3.11"`. macOS is included because that's the user's primary dev platform — we want regressions there caught at PR time, not after a merge.

Steps are split per check so a failed line item points straight at the responsible tool instead of a long combined log.

## Verification
- `python -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` → ok
- `actionlint .github/workflows/ci.yml` → silent (no warnings)
- The workflow itself will validate on this PR

## Test plan
- [ ] All four matrix jobs go green on this PR
- [ ] Cache is populated on first run, hit on subsequent runs (visible in the setup-uv step)

## Stacked on #19
Based on `m0-1-package-skeleton`. Once #19 lands, this can be retargeted to `main` (or merged via that path).

Closes #2.