### PR TITLE
M0/#2: GitHub Actions CI (uv + ruff + mypy + pytest matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs git history for version derivation
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Sync dependencies
+        run: uv sync --dev --python ${{ matrix.python-version }}
+
+      - name: ruff check
+        run: uv run ruff check
+
+      - name: ruff format --check
+        run: uv run ruff format --check
+
+      - name: mypy
+        run: uv run mypy
+
+      - name: pytest
+        run: uv run pytest


### PR DESCRIPTION
> Replaces #20, which auto-closed when the stacked-PR base branch was deleted on merge of #19. Same content; now targets `main` directly.

## Summary
- `.github/workflows/ci.yml` runs `ruff check`, `ruff format --check`, `mypy`, `pytest`
- Matrix: `ubuntu-latest` × Python 3.11/3.12/3.13 + `macos-latest` × 3.13 (user dev platform)
- `astral-sh/setup-uv@v4` with `enable-cache: true` keyed on `uv.lock`
- `fetch-depth: 0` so `hatch-vcs` can derive `__version__` from git
- Concurrency cancels in-progress runs on the same branch; least-privilege `permissions: contents: read`
- Steps split per check so failures point straight at the responsible tool

## Verification
- `python -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` → ok
- `actionlint .github/workflows/ci.yml` → silent

## Test plan
- [ ] All four matrix jobs go green on this PR (this is the workflow's first live run)

Closes #2.