### PR TITLE
M1/#4: Strip OpenRAVE imports from vendored ikfast generator

### DIFF
--- a/src/ikfastpy/_vendor/UPSTREAM.md
+++ b/src/ikfastpy/_vendor/UPSTREAM.md
@@ -1,19 +1,27 @@
 # Vendored upstream
 
-Files in this directory are vendored verbatim from [rdiankov/openrave](https://github.com/rdiankov/openrave) at the pinned commit below. **Do not modify these files directly in this PR.** Modifications (stripping `openravepy` imports, sympy modernization, etc.) are tracked in separate issues and PRs (see [#4](https://github.com/siddhss5/ikfastpy/issues/4) and [#6](https://github.com/siddhss5/ikfastpy/issues/6)).
+Files in this directory originate from [rdiankov/openrave](https://github.com/rdiankov/openrave) at the pinned commit below. **Local modifications have been applied** — see the *Local modifications* section. Treat this directory as a vendored fork that we maintain on top of an upstream baseline; never edit these files in ways that aren't tracked here.
 
-## Source
+## Upstream baseline
 
 - Repository: <https://github.com/rdiankov/openrave>
 - Pinned commit: `ec22ecfaf006688cbc5ee0fdd8fa05d2c5676d37` (2024-08-16)
 
-## Files
-
-| Vendored path | Upstream path | License | Lines | SHA-256 |
+| File | Upstream path | License | Upstream lines | Upstream SHA-256 |
 |---|---|---|---|---|
 | `ikfast.py` | `python/ikfast.py` | LGPL-3.0-or-later | 9683 | `aa1aeb592c6f82701598f6d6dc33559bec10c225e3054f0fd9c3e969b2bdb4cf` |
 | `ikfast_generator_cpp.py` | `python/ikfast_generator_cpp.py` | LGPL-3.0-or-later | 2967 | `b471e0795f12072f3caabceb6de03a5c31d9c09dfc2a1cc10ffbe3afdb6431c4` |
 | `ikfast.h` | `python/ikfast.h` | Apache-2.0 | 600 | `bb78d2a3664dee323f165765601d89e84fe7f735b2628fd9245ce2eb043f3442` |
+
+The SHA-256s above are the **upstream** hashes at the pinned commit, not the current vendored content. Use them when re-pinning to confirm the starting baseline.
+
+## Local modifications
+
+Each entry below documents a tracked PR that modifies these files. Re-pinning requires re-applying every entry in order.
+
+| PR | Issue | Files touched | Summary |
+|---|---|---|---|
+| [#?](https://github.com/siddhss5/ikfastpy/pulls) | [#4](https://github.com/siddhss5/ikfastpy/issues/4) | `ikfast.py`, `ikfast_generator_cpp.py` | Strip OpenRAVE imports (keep fallback branches inline); rename loggers to `ikfastpy.ikfast`; replace `ikfast.py` `__main__` CLI with a `NotImplementedError` stub; remove the docstring section describing the now-removed CLI. |
 
 ## What was deliberately not vendored
 
@@ -30,4 +38,7 @@ curl -sSf "$BASE/ikfast.h"                   -o src/ikfastpy/_vendor/ikfast.h
 shasum -a 256 src/ikfastpy/_vendor/{ikfast.py,ikfast_generator_cpp.py,ikfast.h}
 ```
 
-Then update this file with the new SHA, date, and hashes, and re-apply any local patches tracked in subsequent PRs.
+Then:
+1. Update the *Upstream baseline* section above with the new SHA, date, and hashes.
+2. Re-apply every entry in the *Local modifications* table (each PR is the canonical reference).
+3. Add a row for the re-pin itself if any conflicts had to be resolved.

--- a/src/ikfastpy/_vendor/ikfast.py
+++ b/src/ikfastpy/_vendor/ikfast.py
@@ -76,21 +76,6 @@ The main file ikfast.py can be used both as a library and as an executable progr
 
 **However, the recommended way of using IKFast** is through the OpenRAVE :mod:`.databases.inversekinematics` database generator which directly loads the IK into OpenRAVE as an interface. 
 
-Stand-alone Executable
-======================
-
-To get help and a description of the ikfast arguments type
-
-.. code-block:: bash
-
-  python `openrave-config --python-dir`/openravepy/_openravepy_/ikfast.py --help
-
-A simple example to generate IK for setting the 3rd joint free of the Barrett WAM is
-
-.. code-block:: bash
-
-  python `openrave-config --python-dir`/openravepy/_openravepy_/ikfast.py --robot=robots/barrettwam.robot.xml --baselink=0 --eelink=7 --savefile=ik.cpp --freeindex=2
-
 Through Python
 ==============
 
@@ -202,13 +187,13 @@ else:
     import builtins as __builtin__
 
 from optparse import OptionParser
-try:
-    from openravepy.metaclass import AutoReloader
-    from openravepy import axisAngleFromRotationMatrix
-except:
-    axisAngleFromRotationMatrix = None
-    class AutoReloader:
-        pass
+
+# Both helpers had try/except fallbacks upstream so ikfast could run without
+# OpenRAVE installed. We are OpenRAVE-free by design, so the fallbacks are
+# now the only path.
+axisAngleFromRotationMatrix = None
+class AutoReloader:
+    pass
 
 import numpy # required for fast eigenvalue computation
 
@@ -278,7 +263,7 @@ except ImportError:
 
 import six
 import logging
-log = logging.getLogger('openravepy.ikfast')
+log = logging.getLogger('ikfastpy.ikfast')
 
 try:
     # not necessary, just used for testing
@@ -9619,65 +9604,11 @@ class IKFastSolver(AutoReloader):
                 }
 
 if __name__ == '__main__':
-    import openravepy
-    parser = OptionParser(description="""IKFast: The Robot Kinematics Compiler                                             
-Software License Agreement (Lesser GPL v3). 
-Copyright (C) 2009-2011 Rosen Diankov. 
-IKFast is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-IKFast is part of OpenRAVE. This program can be used with robots or kinbodies defined and is independent of the OpenRAVE databases.
-                                                  
-Example usage for 7 DOF Barrett WAM where the 3rd joint is a free parameter:                               
-
-python ikfast.py --robot=robots/barrettwam.robot.xml --baselink=0 --eelink=7 --savefile=ik.cpp --freeindex=2
-
-""",version=__version__)
-    parser.add_option('--robot', action='store', type='string', dest='robot',default=None,
-                      help='robot file (COLLADA or OpenRAVE XML)')
-    parser.add_option('--savefile', action='store', type='string', dest='savefile',default='ik.cpp',
-                      help='filename where to store the generated c++ code')
-    parser.add_option('--baselink', action='store', type='int', dest='baselink',
-                      help='base link index to start extraction of ik chain')
-    parser.add_option('--eelink', action='store', type='int', dest='eelink',
-                      help='end effector link index to end extraction of ik chain')
-    parser.add_option('--freeindex', action='append', type='int', dest='freeindices',default=[],
-                      help='Optional joint index specifying a free parameter of the manipulator. If not specified, assumes all joints not solving for are free parameters. Can be specified multiple times for multiple free parameters.')
-    parser.add_option('--iktype', action='store', dest='iktype',default='transform6d',
-                      help='The iktype to generate the ik for. Possible values are: %s'%(', '.join(name for name,fn in IKFastSolver.GetSolvers().items())))
-    parser.add_option('--maxcasedepth', action='store', type='int', dest='maxcasedepth',default=3,
-                      help='The max depth to go into degenerate cases. If ikfast file is too big, try reducing this, (default=%default).')
-    parser.add_option('--lang', action='store',type='string',dest='lang',default='cpp',
-                      help='The language to generate the code in (default=%default), available=('+','.join(name for name,value in CodeGenerators.items())+')')
-    parser.add_option('--debug','-d', action='store', type='int',dest='debug',default=logging.INFO,
-                      help='Debug level for python nose (smaller values allow more text).')
-    
-    (options, args) = parser.parse_args()
-    if options.robot is None or options.baselink is None or options.eelink is None:
-        print('Error: Not all arguments specified')
-        sys.exit(1)
-
-    format = logging.Formatter('%(levelname)s: %(message)s')
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(format)
-    log.addHandler(handler)
-    log.setLevel(options.debug)
-
-    solvefn=IKFastSolver.GetSolvers()[options.iktype.lower()]
-    if options.robot is not None:
-        try:
-            env=openravepy.Environment()
-            kinbody=env.ReadRobotXMLFile(options.robot)
-            env.Add(kinbody)
-            solver = IKFastSolver(kinbody,kinbody)
-            solver.maxcasedepth = options.maxcasedepth
-            chaintree = solver.generateIkSolver(options.baselink,options.eelink,options.freeindices,solvefn=solvefn)
-            code=solver.writeIkSolver(chaintree,lang=options.lang)
-        finally:
-            openravepy.RaveDestroy()
-
-    if len(code) > 0:
-        with open(options.savefile,'w') as f:
-            f.write(code)
+    # The original CLI lived here and accepted an OpenRAVE XML/COLLADA robot
+    # file on argv. The ikfastpy package replaces it with a Python entry point
+    # that accepts URDF / DH / axes / per-joint transforms — see issue #12 and
+    # `ikfastpy.Manipulator`. This module is now an importable library only.
+    raise NotImplementedError(
+        "ikfast.py is the vendored ikfast generator and is not invokable as a script. "
+        "Use ikfastpy.Manipulator (e.g. `Manipulator.from_urdf(...)`) instead."
+    )

--- a/src/ikfastpy/_vendor/ikfast_generator_cpp.py
+++ b/src/ikfastpy/_vendor/ikfast_generator_cpp.py
@@ -31,34 +31,29 @@ try:
 except ImportError:
     from io import StringIO
 
-try:
-    from openravepy.metaclass import AutoReloader
-except:
-    class AutoReloader:
-        pass
+# The AutoReloader stub and the IkType enum are kept inline because ikfastpy
+# is OpenRAVE-free by design. Constants below are the canonical ikfast type
+# IDs preserved from upstream.
+class AutoReloader:
+    pass
 
-# import the correct iktypes from openravepy (if present)
-try:
-    from openravepy import IkParameterization
-    IkType = IkParameterization.Type
-except:
-    class IkType:
-        Transform6D=0x67000001
-        Rotation3D=0x34000002
-        Translation3D=0x33000003
-        Direction3D=0x23000004
-        Ray4D=0x46000005
-        Lookat3D=0x23000006
-        TranslationDirection5D=0x56000007
-        TranslationXY2D=0x22000008
-        TranslationXYOrientation3D=0x33000009
-        TranslationLocalGlobal6D=0x3600000a
-        TranslationXAxisAngle4D=0x4400000b
-        TranslationYAxisAngle4D=0x4400000c
-        TranslationZAxisAngle4D=0x4400000d
-        TranslationXAxisAngleZNorm4D=0x4400000e
-        TranslationYAxisAngleXNorm4D=0x4400000f
-        TranslationZAxisAngleYNorm4D=0x44000010
+class IkType:
+    Transform6D=0x67000001
+    Rotation3D=0x34000002
+    Translation3D=0x33000003
+    Direction3D=0x23000004
+    Ray4D=0x46000005
+    Lookat3D=0x23000006
+    TranslationDirection5D=0x56000007
+    TranslationXY2D=0x22000008
+    TranslationXYOrientation3D=0x33000009
+    TranslationLocalGlobal6D=0x3600000a
+    TranslationXAxisAngle4D=0x4400000b
+    TranslationYAxisAngle4D=0x4400000c
+    TranslationZAxisAngle4D=0x4400000d
+    TranslationXAxisAngleZNorm4D=0x4400000e
+    TranslationYAxisAngleXNorm4D=0x4400000f
+    TranslationZAxisAngleYNorm4D=0x44000010
 
 from sympy import *
 from sympy.simplify import cse_main
@@ -76,7 +71,7 @@ except ImportError:
     using_swiginac = False
 
 import logging
-log = logging.getLogger('openravepy.ikfast')
+log = logging.getLogger('ikfastpy.ikfast')
 
 from sympy.core import function # for sympy 0.7.1+
 class fmod(function.Function):


### PR DESCRIPTION
## Summary
First modification of the vendored sources (PR #25 was a faithful import; this PR is the first divergence). After this lands, `grep -r openravepy src/ikfastpy/_vendor/` returns zero matches.

**`ikfast.py`:**
- Drop the `try/except` around `openravepy.metaclass.AutoReloader` and `openravepy.axisAngleFromRotationMatrix`; keep the inline fallback stubs (already present upstream as the except-branch).
- Rename logger from `'openravepy.ikfast'` to `'ikfastpy.ikfast'`.
- Replace the OpenRAVE-bound `__main__` CLI (lines 9621–9683) with a `NotImplementedError` that points users at `ikfastpy.Manipulator` (the public entry point landing in #12).
- Remove the now-stale "Stand-alone Executable" section from the module docstring.

**`ikfast_generator_cpp.py`:**
- Drop both `try/except` blocks (AutoReloader stub; IkType enum); keep the fallback definitions as the sole path.
- Rename logger to `'ikfastpy.ikfast'`.

**`UPSTREAM.md`:**
- Restructured. The upstream baseline (commit + license + SHA-256) is preserved as historical reference. A new **Local modifications** table tracks every PR that diverges from upstream, so re-pinning has a checklist of patches to re-apply.

## Why this shape
The fallback branches already existed upstream — ikfast was always designed to run without OpenRAVE if openravepy wasn't importable. So this isn't a logic change; it's a coupling-removal that was effectively a no-op at runtime once openravepy was absent.

The `__main__` CLI is the only piece that genuinely required OpenRAVE (`env.ReadRobotXMLFile`, `RaveDestroy()`). Replaced with a `NotImplementedError` rather than rewriting it here — our entry point lives at the package level and accepts URDF/DH/axes/transforms (issue #12), which is fundamentally different shape.

## Verification
```
grep -r openravepy src/ikfastpy/_vendor/   →  no matches
uv run ruff check                          →  All checks passed
uv run ruff format --check                 →  3 files already formatted
uv run mypy                                →  Success: no issues found in 4 source files
uv run pytest                              →  1 passed
```

The vendored modules can't yet be _imported_ at runtime (they need sympy, which isn't in deps until #6), but they parse cleanly via `ast.parse` and the `__main__` stub fires correctly when sympy is present.

## Out of scope
- Pre-existing `SyntaxWarning`s in upstream regex literals (`'\d'` should be `r'\d'`, etc.). Will surface again in any future re-pin and are not worth modifying upstream code over.
- The kinbody shim (`#5`) and sympy modernization (`#6`) — both are tracked separately.

## Test plan
- [ ] CI matrix passes
- [ ] `grep -r openravepy src/ikfastpy/_vendor/` returns nothing on the merged main
- [ ] `UPSTREAM.md` renders correctly on GitHub

Closes #4.