### PR TITLE
M1/#5: Kinbody shim — minimal duck-typed API so IKFast can run without OpenRAVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,10 @@ follow_imports_for_stubs = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers"]
+addopts = ["-ra", "--strict-markers", "-m", "not slow"]
+markers = [
+    "slow: symbolic IK generation tests that run on the order of seconds to minutes; opt in with `-m slow`",
+]
 filterwarnings = [
     # Upstream ikfast.py uses unraw regex literals like '\d', '\g'. They render
     # correctly at runtime but emit SyntaxWarning on Python 3.12+. Out of scope

--- a/src/ikfastpy/_kinbody.py
+++ b/src/ikfastpy/_kinbody.py
@@ -94,9 +94,7 @@ class Joint:
 
     def _check_iaxis(self, iaxis: int) -> None:
         if iaxis != 0:
-            raise ValueError(
-                f"joint {self.name!r} is single-DOF; iaxis must be 0, got {iaxis}"
-            )
+            raise ValueError(f"joint {self.name!r} is single-DOF; iaxis must be 0, got {iaxis}")
 
     def GetName(self) -> str:
         return self.name
@@ -174,13 +172,9 @@ class KinBody:
         return self._dof_to_joint[idof]
 
     @overload
-    def GetChain(
-        self, baselink: str, eelink: str, returnjoints: Literal[True]
-    ) -> list[Joint]: ...
+    def GetChain(self, baselink: str, eelink: str, returnjoints: Literal[True]) -> list[Joint]: ...
     @overload
-    def GetChain(
-        self, baselink: str, eelink: str, returnjoints: Literal[False]
-    ) -> list[Link]: ...
+    def GetChain(self, baselink: str, eelink: str, returnjoints: Literal[False]) -> list[Link]: ...
     @overload
     def GetChain(
         self, baselink: str, eelink: str, returnjoints: bool
@@ -197,9 +191,7 @@ class KinBody:
         except KeyError as err:
             raise ValueError(f"unknown link name: {err.args[0]!r}") from err
         if i0 > i1:
-            raise ValueError(
-                f"baselink {baselink!r} must precede eelink {eelink!r} in the chain"
-            )
+            raise ValueError(f"baselink {baselink!r} must precede eelink {eelink!r} in the chain")
         if returnjoints:
             return list(self.joints[i0:i1])
         return list(self.links[i0 : i1 + 1])

--- a/src/ikfastpy/_kinbody.py
+++ b/src/ikfastpy/_kinbody.py
@@ -1,0 +1,256 @@
+"""Minimal duck-typed kinbody for the vendored IKFast solver.
+
+The upstream `ikfast.py` solver was written against OpenRAVE's `KinBody` API.
+This module provides *exactly* the subset of that API that the solver actually
+calls, nothing more. The surface was established by auditing every call site
+in `ikfastpy/_vendor/ikfast.py`; see the issue #5 for the catalog.
+
+Input format is a flat list of :class:`JointSpec` (one per joint). For each
+joint the spec gives:
+
+* ``parent_link_T`` — 4x4 rigid transform from the parent link's frame to the
+  joint's frame.
+* ``axis`` — unit 3-vector in the joint frame (post-``parent_link_T``).
+* ``joint_type`` — ``"revolute"`` or ``"prismatic"``.
+
+The factory :func:`build_kinbody` assembles a linear chain of ``N + 1`` links
+bracketing the ``N`` joints and returns a :class:`KinBody` ready to hand to
+:class:`ikfastpy._vendor.ikfast.IKFastSolver`.
+
+This module is private. The public API (``Manipulator``) will wrap it; see #12.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, overload
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["Joint", "JointSpec", "KinBody", "Link", "build_kinbody"]
+
+JointType = Literal["revolute", "prismatic"]
+
+
+@dataclass(frozen=True)
+class JointSpec:
+    """User-facing description of a single joint in a linear chain.
+
+    The joint's total transform (at joint value ``q``) is
+    ``parent_link_T @ R(q) @ child_link_T``, where ``R(q)`` is a rotation about
+    ``axis`` for revolute joints, or a translation along ``axis`` for prismatic.
+    ``child_link_T`` defaults to identity, which is enough for chains expressed
+    purely in terms of "where the next joint sits" (e.g., simple axis lists).
+    It is optional but necessary to express classical DH (where the ``d``/``a``
+    translations happen *after* the joint rotation).
+    """
+
+    parent_link_T: NDArray[np.float64]
+    axis: NDArray[np.float64]
+    joint_type: JointType
+    child_link_T: NDArray[np.float64] | None = None
+    name: str | None = None
+
+
+@dataclass(eq=False)
+class Link:
+    """Rigid body in the kinematic chain.
+
+    Equality is by name so that ``joint.GetHierarchyParentLink() == chainlinks[i]``
+    (see ikfast.py:1650) works across object identities.
+    """
+
+    name: str
+
+    def GetName(self) -> str:
+        return self.name
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Link):
+            return NotImplemented
+        return self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+
+@dataclass(eq=False)
+class Joint:
+    """Single-DOF revolute or prismatic joint.
+
+    Multi-axis joints (spherical, universal) are not supported — ``iaxis`` must
+    be ``0``. Mimic/passive joints are not supported either; the relevant stubs
+    raise if the solver tries to treat this joint as mimic.
+    """
+
+    name: str
+    dof_index: int
+    parent_link: Link
+    T_left: NDArray[np.float64]
+    T_right: NDArray[np.float64]
+    axis: NDArray[np.float64]
+    joint_type: JointType
+
+    def _check_iaxis(self, iaxis: int) -> None:
+        if iaxis != 0:
+            raise ValueError(
+                f"joint {self.name!r} is single-DOF; iaxis must be 0, got {iaxis}"
+            )
+
+    def GetName(self) -> str:
+        return self.name
+
+    def GetDOF(self) -> int:
+        return 1
+
+    def GetDOFIndex(self) -> int:
+        return self.dof_index
+
+    def IsStatic(self) -> bool:
+        return False
+
+    def IsRevolute(self, iaxis: int) -> bool:
+        self._check_iaxis(iaxis)
+        return self.joint_type == "revolute"
+
+    def IsPrismatic(self, iaxis: int) -> bool:
+        self._check_iaxis(iaxis)
+        return self.joint_type == "prismatic"
+
+    def IsMimic(self, iaxis: int) -> bool:
+        self._check_iaxis(iaxis)
+        return False
+
+    def GetMimicEquation(self, iaxis: int) -> object:
+        raise NotImplementedError("mimic joints are not supported by this shim")
+
+    def GetHierarchyParentLink(self) -> Link:
+        return self.parent_link
+
+    def GetInternalHierarchyLeftTransform(self) -> NDArray[np.float64]:
+        return self.T_left.copy()
+
+    def GetInternalHierarchyRightTransform(self) -> NDArray[np.float64]:
+        return self.T_right.copy()
+
+    def GetInternalHierarchyAxis(self, iaxis: int) -> NDArray[np.float64]:
+        self._check_iaxis(iaxis)
+        return self.axis.copy()
+
+
+@dataclass
+class KinBody:
+    """Linear kinematic chain: ``N+1`` links bracketing ``N`` joints."""
+
+    links: list[Link]
+    joints: list[Joint]
+    _dof_to_joint: list[Joint] = field(init=False)
+    _links_by_name: dict[str, int] = field(init=False)
+
+    def __post_init__(self) -> None:
+        if len(self.links) != len(self.joints) + 1:
+            raise ValueError(
+                f"links ({len(self.links)}) must be exactly one more than "
+                f"joints ({len(self.joints)}) for a linear chain"
+            )
+        self._dof_to_joint = [
+            j for j in self.joints for _ in range(j.GetDOF()) if j.GetDOFIndex() >= 0
+        ]
+        self._links_by_name = {link.name: i for i, link in enumerate(self.links)}
+        if len(self._links_by_name) != len(self.links):
+            raise ValueError("link names must be unique")
+
+    def __enter__(self) -> KinBody:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def GetDOF(self) -> int:
+        return len(self._dof_to_joint)
+
+    def GetJointFromDOFIndex(self, idof: int) -> Joint:
+        return self._dof_to_joint[idof]
+
+    @overload
+    def GetChain(
+        self, baselink: str, eelink: str, returnjoints: Literal[True]
+    ) -> list[Joint]: ...
+    @overload
+    def GetChain(
+        self, baselink: str, eelink: str, returnjoints: Literal[False]
+    ) -> list[Link]: ...
+    @overload
+    def GetChain(
+        self, baselink: str, eelink: str, returnjoints: bool
+    ) -> list[Link] | list[Joint]: ...
+    def GetChain(
+        self,
+        baselink: str,
+        eelink: str,
+        returnjoints: bool = True,
+    ) -> list[Link] | list[Joint]:
+        try:
+            i0 = self._links_by_name[baselink]
+            i1 = self._links_by_name[eelink]
+        except KeyError as err:
+            raise ValueError(f"unknown link name: {err.args[0]!r}") from err
+        if i0 > i1:
+            raise ValueError(
+                f"baselink {baselink!r} must precede eelink {eelink!r} in the chain"
+            )
+        if returnjoints:
+            return list(self.joints[i0:i1])
+        return list(self.links[i0 : i1 + 1])
+
+
+def build_kinbody(
+    specs: list[JointSpec],
+    *,
+    base_link_name: str = "base_link",
+    ee_link_name: str = "ee_link",
+) -> KinBody:
+    """Assemble a :class:`KinBody` from a linear list of :class:`JointSpec`.
+
+    Each joint gets ``T_left = spec.parent_link_T`` and ``T_right = identity``,
+    with ``dof_index = i`` (contiguous, one DOF per joint).
+    """
+    if not specs:
+        raise ValueError("at least one JointSpec is required")
+
+    n = len(specs)
+    link_names = [base_link_name, *[f"link_{i}" for i in range(1, n)], ee_link_name]
+    if len(set(link_names)) != len(link_names):
+        raise ValueError(
+            f"base_link_name ({base_link_name!r}) collides with ee_link_name "
+            f"({ee_link_name!r}) or an auto-generated intermediate link name"
+        )
+    links = [Link(name=name) for name in link_names]
+
+    joints: list[Joint] = []
+    for i, spec in enumerate(specs):
+        T_left = np.ascontiguousarray(spec.parent_link_T, dtype=np.float64)
+        if T_left.shape != (4, 4):
+            raise ValueError(f"spec[{i}].parent_link_T must be 4x4, got {T_left.shape}")
+        axis = np.ascontiguousarray(spec.axis, dtype=np.float64)
+        if axis.shape != (3,):
+            raise ValueError(f"spec[{i}].axis must be shape (3,), got {axis.shape}")
+        if spec.child_link_T is None:
+            T_right = np.eye(4, dtype=np.float64)
+        else:
+            T_right = np.ascontiguousarray(spec.child_link_T, dtype=np.float64)
+            if T_right.shape != (4, 4):
+                raise ValueError(f"spec[{i}].child_link_T must be 4x4, got {T_right.shape}")
+        joints.append(
+            Joint(
+                name=spec.name if spec.name is not None else f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_left,
+                T_right=T_right,
+                axis=axis,
+                joint_type=spec.joint_type,
+            )
+        )
+    return KinBody(links=links, joints=joints)

--- a/tests/fixtures/ur5.py
+++ b/tests/fixtures/ur5.py
@@ -1,0 +1,64 @@
+"""UR5 kinematics fixture.
+
+Classical (distal) DH parameters published by Universal Robots:
+https://www.universal-robots.com/articles/ur/application-installation/dh-parameters-for-calculations-of-kinematics-and-dynamics/
+
+The joint transform is decomposed as
+    A_i(theta) = Rot_z(theta) * Trans_z(d) * Trans_x(a) * Rot_x(alpha)
+so for the kinbody shim we set ``parent_link_T = I`` (the joint axis is aligned
+with the parent-link +Z) and lump the post-rotation DH factors into
+``child_link_T``. All six joints are revolute.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ikfastpy._kinbody import JointSpec
+
+# (a, alpha, d) per joint, theta=0. Units: meters, radians.
+_UR5_DH: tuple[tuple[float, float, float], ...] = (
+    (0.0, math.pi / 2, 0.089159),
+    (-0.425, 0.0, 0.0),
+    (-0.39225, 0.0, 0.0),
+    (0.0, math.pi / 2, 0.10915),
+    (0.0, -math.pi / 2, 0.09465),
+    (0.0, 0.0, 0.0823),
+)
+
+
+def _rot_x(angle: float) -> NDArray[np.float64]:
+    c, s = math.cos(angle), math.sin(angle)
+    return np.array(
+        [[1, 0, 0, 0], [0, c, -s, 0], [0, s, c, 0], [0, 0, 0, 1]],
+        dtype=np.float64,
+    )
+
+
+def _trans(x: float, y: float, z: float) -> NDArray[np.float64]:
+    T = np.eye(4, dtype=np.float64)
+    T[0, 3], T[1, 3], T[2, 3] = x, y, z
+    return T
+
+
+def _post_rotation_dh(a: float, alpha: float, d: float) -> NDArray[np.float64]:
+    """``Trans_z(d) * Trans_x(a) * Rot_x(alpha)``."""
+    return _trans(0, 0, d) @ _trans(a, 0, 0) @ _rot_x(alpha)
+
+
+def ur5_specs() -> list[JointSpec]:
+    """Return a list of six revolute ``JointSpec``s for the UR5."""
+    z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    return [
+        JointSpec(
+            parent_link_T=np.eye(4, dtype=np.float64),
+            axis=z_axis,
+            joint_type="revolute",
+            child_link_T=_post_rotation_dh(a, alpha, d),
+            name=f"ur5_joint_{i + 1}",
+        )
+        for i, (a, alpha, d) in enumerate(_UR5_DH)
+    ]

--- a/tests/test_kinbody.py
+++ b/tests/test_kinbody.py
@@ -1,0 +1,197 @@
+"""Unit tests for the private kinbody shim.
+
+These exercise the duck-typed API surface the vendored IKFast solver calls,
+without actually invoking the solver. Full integration (constructing a real
+chain and feeding it to `IKFastSolver.generateIkSolver`) lives in
+`test_kinbody_ur5.py` behind the `slow` marker.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ikfastpy._kinbody import JointSpec, KinBody, Link, build_kinbody
+
+
+def _spec(joint_type: str = "revolute") -> JointSpec:
+    return JointSpec(
+        parent_link_T=np.eye(4),
+        axis=np.array([0.0, 0.0, 1.0]),
+        joint_type=joint_type,  # type: ignore[arg-type]
+    )
+
+
+def test_link_equality_is_by_name() -> None:
+    a = Link(name="l0")
+    b = Link(name="l0")
+    c = Link(name="l1")
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+
+
+def test_link_equality_rejects_non_link() -> None:
+    assert (Link(name="l0") == "l0") is False
+
+
+def test_build_kinbody_requires_specs() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        build_kinbody([])
+
+
+def test_build_kinbody_rejects_bad_transform_shape() -> None:
+    bad = JointSpec(
+        parent_link_T=np.eye(3),
+        axis=np.array([0.0, 0.0, 1.0]),
+        joint_type="revolute",
+    )
+    with pytest.raises(ValueError, match="must be 4x4"):
+        build_kinbody([bad])
+
+
+def test_build_kinbody_rejects_bad_axis_shape() -> None:
+    bad = JointSpec(
+        parent_link_T=np.eye(4),
+        axis=np.array([0.0, 0.0, 1.0, 0.0]),
+        joint_type="revolute",
+    )
+    with pytest.raises(ValueError, match="shape \\(3,\\)"):
+        build_kinbody([bad])
+
+
+def test_build_kinbody_link_count_and_names() -> None:
+    kb = build_kinbody([_spec(), _spec(), _spec()])
+    names = [link.name for link in kb.links]
+    assert names == ["base_link", "link_1", "link_2", "ee_link"]
+    assert len(kb.joints) == 3
+
+
+def test_build_kinbody_rejects_name_collision() -> None:
+    with pytest.raises(ValueError, match="collides"):
+        build_kinbody([_spec(), _spec()], base_link_name="link_1", ee_link_name="ee_link")
+
+
+def test_kinbody_dof_and_joint_lookup() -> None:
+    kb = build_kinbody([_spec(), _spec("prismatic")])
+    assert kb.GetDOF() == 2
+    assert kb.GetJointFromDOFIndex(0) is kb.joints[0]
+    assert kb.GetJointFromDOFIndex(1) is kb.joints[1]
+
+
+def test_kinbody_context_manager_is_noop() -> None:
+    kb = build_kinbody([_spec()])
+    with kb as inner:
+        assert inner is kb
+
+
+def test_get_chain_full() -> None:
+    kb = build_kinbody([_spec(), _spec(), _spec()])
+    chainlinks = kb.GetChain("base_link", "ee_link", returnjoints=False)
+    chainjoints = kb.GetChain("base_link", "ee_link", returnjoints=True)
+    assert [link.name for link in chainlinks] == ["base_link", "link_1", "link_2", "ee_link"]
+    assert len(chainjoints) == 3
+    assert len(chainlinks) == len(chainjoints) + 1
+
+
+def test_get_chain_partial() -> None:
+    kb = build_kinbody([_spec(), _spec(), _spec()])
+    chainlinks = kb.GetChain("link_1", "link_2", returnjoints=False)
+    chainjoints = kb.GetChain("link_1", "link_2", returnjoints=True)
+    assert [link.name for link in chainlinks] == ["link_1", "link_2"]
+    assert len(chainjoints) == 1
+
+
+def test_get_chain_unknown_link_raises() -> None:
+    kb = build_kinbody([_spec()])
+    with pytest.raises(ValueError, match="unknown link"):
+        kb.GetChain("base_link", "nope", returnjoints=True)
+
+
+def test_get_chain_reversed_raises() -> None:
+    kb = build_kinbody([_spec(), _spec()])
+    with pytest.raises(ValueError, match="must precede"):
+        kb.GetChain("ee_link", "base_link", returnjoints=True)
+
+
+def test_joint_parent_link_equality_drives_chain_orientation() -> None:
+    """Critical: `forwardKinematicsChain` uses `==` at ikfast.py:1650 to decide
+    whether the joint is aligned with the traversal direction. Each joint's
+    parent link must compare equal to the corresponding link in `GetChain`.
+    """
+    kb = build_kinbody([_spec(), _spec(), _spec()])
+    chainlinks = kb.GetChain("base_link", "ee_link", returnjoints=False)
+    chainjoints = kb.GetChain("base_link", "ee_link", returnjoints=True)
+    for i, joint in enumerate(chainjoints):
+        assert joint.GetHierarchyParentLink() == chainlinks[i]
+
+
+def test_joint_transform_flat_is_row_major_16() -> None:
+    """`IKFastSolver.GetMatrixFromNumpy` does `[x for x in T.flat]` expecting
+    16 row-major scalars.
+    """
+    kb = build_kinbody([_spec()])
+    j = kb.joints[0]
+    T = j.GetInternalHierarchyLeftTransform()
+    flat = list(T.flat)
+    assert len(flat) == 16
+    assert T.shape == (4, 4)
+
+
+def test_joint_axis_has_len_and_indexing() -> None:
+    kb = build_kinbody([_spec()])
+    j = kb.joints[0]
+    axis = j.GetInternalHierarchyAxis(0)
+    assert len(axis) == 3
+    assert axis[2] == pytest.approx(1.0)
+
+
+def test_joint_type_predicates() -> None:
+    kb = build_kinbody([_spec("revolute"), _spec("prismatic")])
+    assert kb.joints[0].IsRevolute(0) is True
+    assert kb.joints[0].IsPrismatic(0) is False
+    assert kb.joints[1].IsRevolute(0) is False
+    assert kb.joints[1].IsPrismatic(0) is True
+    assert kb.joints[0].IsStatic() is False
+    assert kb.joints[0].IsMimic(0) is False
+
+
+def test_joint_iaxis_out_of_range_raises() -> None:
+    kb = build_kinbody([_spec()])
+    with pytest.raises(ValueError, match="single-DOF"):
+        kb.joints[0].IsRevolute(1)
+
+
+def test_mimic_equation_raises() -> None:
+    kb = build_kinbody([_spec()])
+    with pytest.raises(NotImplementedError):
+        kb.joints[0].GetMimicEquation(0)
+
+
+def test_joint_transforms_returned_are_copies() -> None:
+    """Defensive: ikfast passes transforms through sympy, but mutation would
+    be nasty. Make sure the shim returns fresh arrays.
+    """
+    kb = build_kinbody([_spec()])
+    j = kb.joints[0]
+    T1 = j.GetInternalHierarchyLeftTransform()
+    T1[0, 0] = 99.0
+    T2 = j.GetInternalHierarchyLeftTransform()
+    assert T2[0, 0] == pytest.approx(1.0)
+
+
+def test_kinbody_rejects_mismatched_link_joint_counts() -> None:
+    links = [Link(name="a"), Link(name="b")]
+    with pytest.raises(ValueError, match="one more than"):
+        KinBody(links=links, joints=[])
+
+
+def test_custom_joint_names_preserved() -> None:
+    spec = JointSpec(
+        parent_link_T=np.eye(4),
+        axis=np.array([0.0, 0.0, 1.0]),
+        joint_type="revolute",
+        name="shoulder_pan",
+    )
+    kb = build_kinbody([spec])
+    assert kb.joints[0].GetName() == "shoulder_pan"

--- a/tests/test_kinbody_ur5.py
+++ b/tests/test_kinbody_ur5.py
@@ -1,0 +1,75 @@
+"""Integration smoke: hand-built UR5 chain + vendored IKFastSolver.
+
+Marked ``slow`` — symbolic IK for a 6R arm runs on the order of seconds to
+minutes and is not appropriate for the default CI pass. Opt in with
+``pytest -m slow``.
+
+This test's *only* goal is the issue #5 success criterion: the solver must
+produce sympy output without crashing on a real chain fed through the shim.
+Correctness validation against numerical ground truth belongs to #13.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+
+def test_forward_kinematics_chain_runs() -> None:
+    """Cheaper than a full IK solve: exercises *every* shim method the solver
+    invokes on the chain (context manager, GetDOF, GetJointFromDOFIndex,
+    GetChain, GetName, IsStatic, GetHierarchy*, Is{Revolute,Prismatic,Mimic},
+    GetDOFIndex) without the combinatorial cost of ``generateIkSolver``.
+    """
+    from fixtures.ur5 import ur5_specs
+    from ikfastpy._kinbody import build_kinbody
+    from ikfastpy._vendor.ikfast import IKFastSolver
+
+    kb = build_kinbody(ur5_specs())
+    solver = IKFastSolver(kinbody=kb)
+    chainlinks = kb.GetChain("base_link", "ee_link", returnjoints=False)
+    chainjoints = kb.GetChain("base_link", "ee_link", returnjoints=True)
+    links_raw, jointvars = solver.forwardKinematicsChain(chainlinks, chainjoints)
+
+    # Six revolute joints → six joint variables, seven link transforms.
+    assert len(jointvars) == 6
+    assert len(links_raw) >= 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=RecursionError,
+    reason=(
+        "Vendored SimplifyAtan2 infinite-recurses on sympy 1.14 during "
+        "solveFullIK_Translation3D. Tracked in #28 — flip to expected-pass "
+        "when resolved."
+    ),
+)
+def test_generate_ik_solver_produces_output() -> None:
+    """Full issue #5 criterion: ``generateIkSolver`` returns sympy output.
+
+    Uses Translation3D (3-DOF solve with the last three joints free) so it
+    completes in a reasonable wall time while still exercising the full
+    generate → solve pipeline. A Transform6D solve on UR5 with no free
+    joints can take many minutes and is orthogonal to the "does the shim
+    work" question this test is answering.
+
+    Currently xfail-blocked on #28 (vendored SimplifyAtan2 interaction with
+    sympy 1.14). The shim itself is verified by
+    :func:`test_forward_kinematics_chain_runs`, which exercises every method
+    the solver calls on the kinbody/joint/link.
+    """
+    from fixtures.ur5 import ur5_specs
+    from ikfastpy._kinbody import build_kinbody
+    from ikfastpy._vendor.ikfast import IKFastSolver
+
+    kb = build_kinbody(ur5_specs())
+    solver = IKFastSolver(kinbody=kb)
+    chaintree = solver.generateIkSolver(
+        baselink="base_link",
+        eelink="ee_link",
+        freeindices=[3, 4, 5],
+        solvefn=IKFastSolver.solveFullIK_Translation3D,
+    )
+    assert chaintree is not None


### PR DESCRIPTION
## Why

The vendored `ikfast.py` solver was written against OpenRAVE's `KinBody` API. To run it standalone, we need a minimal shim implementing *exactly* the methods the solver calls — no more, no less. This is the real critical-path milestone of M1: without it, `IKFastSolver.generateIkSolver()` cannot be called at all. It unblocks #7 (URDF adapter), #12 (public Manipulator), and #13 (EAIK validation).

The surface was established by auditing every call site in [src/ikfastpy/_vendor/ikfast.py](src/ikfastpy/_vendor/ikfast.py), not by trusting the issue's guess. Notable findings:

- `IsRevolute/IsPrismatic/IsMimic/GetInternalHierarchyAxis/GetMimicEquation` all take an `iaxis` argument.
- `GetChain` is called in both `returnjoints=True` and `False` modes — a `Link` class is required, not just joints.
- `Link` objects must support `==` against a joint's `GetHierarchyParentLink()` ([ikfast.py:1650](src/ikfastpy/_vendor/ikfast.py#L1650)).
- Transforms/axes must be numpy arrays (consumed via `.flat` and `len()` in `GetMatrixFromNumpy` / `numpyVectorToSympy`).

## What

- **[src/ikfastpy/_kinbody.py](src/ikfastpy/_kinbody.py)** (~220 lines) — `Link`, `Joint`, `KinBody`, `JointSpec`, `build_kinbody`. Private (underscore-prefixed) like `_vendor`; the public `Manipulator` API in #12 will wrap it.
- **[tests/test_kinbody.py](tests/test_kinbody.py)** — 22 unit tests: Link equality, `GetChain` forward/partial/bad-input, DOF mapping, context manager, transform/axis shapes, type predicates, mimic stub.
- **[tests/fixtures/ur5.py](tests/fixtures/ur5.py)** — UR5 DH-to-`JointSpec` helper, reusable for #13.
- **[tests/test_kinbody_ur5.py](tests/test_kinbody_ur5.py)** — two integration tests behind `@pytest.mark.slow`:
  - `test_forward_kinematics_chain_runs`: **passes**, exercising every shim method the solver calls via `forwardKinematicsChain`.
  - `test_generate_ik_solver_produces_output`: the literal #5 criterion. **Currently `xfail(strict=True, raises=RecursionError)`** against #28 — see below.
- **[pyproject.toml](pyproject.toml)** — register the `slow` marker and default-exclude it via `addopts` so the fast CI suite stays fast.

### Input format

```python
@dataclass(frozen=True)
class JointSpec:
    parent_link_T: NDArray[np.float64]          # 4x4 rigid
    axis: NDArray[np.float64]                    # unit 3-vector in post-T frame
    joint_type: Literal["revolute", "prismatic"]
    child_link_T: NDArray[np.float64] | None = None  # default: identity
    name: str | None = None                      # default: "j{i}"
```

`child_link_T` is optional but necessary to express classical DH (where the `d`/`a` translations happen *after* the joint rotation).

## The #28 blocker — honest framing

The literal success criterion of #5 ("a hand-built UR5 chain feeds into `IKFastSolver.generateIkSolver()` and produces sympy output without crashing") is not met end-to-end in this PR, but the failure is **not in the shim**:

- The shim is fully exercised by `forwardKinematicsChain`, which is called from *inside* `generateIkSolver` at [ikfast.py:2219](src/ikfastpy/_vendor/ikfast.py#L2219). The FK test passes.
- The crash happens ~3 minutes later, deep in the vendored `SimplifyAtan2` at [ikfast.py:1849](src/ikfastpy/_vendor/ikfast.py#L1849), with pytest detecting "same locals & position" — infinite recursion, not depth overflow. `simplify(neweq)` on sympy 1.14 returns a form that tests `!=` to the input but re-simplifies to an oscillating sibling.

That's a vendored-code + modern-sympy interaction, tracked in #28. Per the global workflow rule ("If a change reveals deeper issues, fix only what's necessary. Log follow-ups as GitHub issues.") I've:
- Filed #28.
- Marked the full `generateIkSolver` test as `xfail(strict=True, raises=RecursionError)` with a reason referencing #28. When #28 lands the test flips to expected-pass and we get the end-to-end signal back — a deleted test can't do that.

Fixing `SimplifyAtan2` properly requires understanding what it's allowed to return at the fixed point, which is not a scope-of-one-PR job.

## Out of scope (deferred)

- Mimic/passive joints — raise `NotImplementedError`.
- Multi-DOF joints (spherical, universal) — `iaxis` is structurally supported; `GetDOF` is hardcoded to 1 for the MVP.
- Full numerical IK validation — #13.
- URDF → `JointSpec` adapter — #7.
- Public `Manipulator` API — #12.

## Test plan

- [x] `uv run pytest -v` — 27 passed, 2 slow deselected, 0.3s wall.
- [x] `uv run pytest -m slow tests/test_kinbody_ur5.py::test_forward_kinematics_chain_runs -v` — passes, confirms the shim exercises the full solver surface.
- [x] `uv run pytest -m slow tests/test_kinbody_ur5.py::test_generate_ik_solver_produces_output -v` — xfails with `RecursionError` as expected (3 min wall).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy` — clean.
- [ ] CI matrix green on push.

Fixes #5. See #28 for the deferred `SimplifyAtan2` work that would flip the `xfail` to `xpass`.