### PR TITLE
Phase A.3: kinematic predicates + TolerancePolicy

### DIFF
--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -1,5 +1,13 @@
-"""ssik — pluggable analytical inverse-kinematics library for Python."""
+"""ssik -- pluggable analytical inverse-kinematics library for Python."""
 
 from ssik._version import __version__
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.core.topology import TopologyReport, describe_topology
 
-__all__ = ["__version__"]
+__all__ = [
+    "DEFAULT_TOLERANCE_POLICY",
+    "TolerancePolicy",
+    "TopologyReport",
+    "__version__",
+    "describe_topology",
+]

--- a/src/ssik/core/__init__.py
+++ b/src/ssik/core/__init__.py
@@ -1,0 +1,5 @@
+"""Cross-cutting abstractions: tolerance policy, topology reports, protocols.
+
+This package intentionally keeps no opinions about URDF, solvers, or algorithms
+-- it's the vocabulary every other package uses.
+"""

--- a/src/ssik/core/tolerances.py
+++ b/src/ssik/core/tolerances.py
@@ -1,0 +1,42 @@
+"""Numeric tolerances for kinematic-structure predicates.
+
+Real-world URDFs produce axes and origins that are *nearly* but not exactly
+aligned with canonical kinematic structure -- axes at ``(0, 0, 0.99999998)``
+from Xacro arithmetic rounding, rpy matrices whose orthogonality check differs
+from identity by 1e-12 after accumulation. The predicates that decide "are
+these three axes intersecting?" or "parallel?" need explicit tolerances so
+that behaviour is predictable and so downstream error messages can say "this
+chain is 3e-6 away from three-consecutive-parallel; did you mean to classify
+it that way?"
+
+Every public predicate consumes a :class:`TolerancePolicy`. The default is
+calibrated for metric-scale 6-DOF chains (link lengths < 2m); override for
+millimeter-scale micro-arms or kilometer-scale astronomy mounts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["DEFAULT_TOLERANCE_POLICY", "TolerancePolicy"]
+
+
+@dataclass(frozen=True)
+class TolerancePolicy:
+    """Tolerances for kinematic-structure predicates.
+
+    Attributes:
+        axis_parallel: cross-product magnitude below which two unit-vector
+            axes are considered parallel (or anti-parallel). For unit
+            vectors ``||a x b|| = sin(theta)`` so the default ``1e-8``
+            accepts axes differing by up to ~1 microradian.
+        axis_intersect: perpendicular distance below which two lines in
+            3D are considered to intersect. Default matches the
+            ``axis_parallel`` tolerance in spirit -- metric-scale chains.
+    """
+
+    axis_parallel: float = 1e-8
+    axis_intersect: float = 1e-8
+
+
+DEFAULT_TOLERANCE_POLICY = TolerancePolicy()

--- a/src/ssik/core/topology.py
+++ b/src/ssik/core/topology.py
@@ -1,0 +1,71 @@
+"""Structural description of a kinematic chain.
+
+:class:`TopologyReport` is the output of :func:`describe_topology`; it captures
+which canonical kinematic-family conditions hold on a POE-normalized chain.
+The dispatcher (Phase C) will consume this to pick a closed-form solver;
+in this phase it's also usable as a standalone "what kind of arm is this?"
+diagnostic.
+
+The report is deliberately minimal right now: boolean/location facts about
+the two Pieper-class conditions the dispatcher cares about first (three
+consecutive intersecting axes, three consecutive parallel axes). Near-miss
+diagnostics (distance-to-predicate for each triple, for user-visible
+"your chain is 3e-6 away from three-parallel" error messages) will land
+alongside the dispatcher in Phase C where they have a concrete consumer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.predicates import (
+    three_consecutive_intersecting,
+    three_consecutive_parallel,
+)
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from ssik._kinbody import KinBody
+
+__all__ = ["TopologyReport", "describe_topology"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TopologyReport:
+    """Structural description of a POE-normalized kinematic chain.
+
+    Attributes:
+        dof: number of active joints in the chain.
+        three_consecutive_intersecting: if any triple of consecutive joint
+            axes share a common point, the ``(i, i+1, i+2)`` indices of
+            the first such triple; otherwise ``None``. This is the
+            Pieper spherical-wrist / spherical-shoulder condition.
+        three_consecutive_parallel: if any triple of consecutive joint axes
+            are all pairwise parallel, the ``(i, i+1, i+2)`` indices of the
+            first such triple; otherwise ``None``. This is the three-parallel
+            condition (UR-class arms).
+    """
+
+    dof: int
+    three_consecutive_intersecting: tuple[int, int, int] | None
+    three_consecutive_parallel: tuple[int, int, int] | None
+
+
+def describe_topology(
+    kb: KinBody,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> TopologyReport:
+    """Classify the kinematic structure of a POE-normalized chain.
+
+    :param kb: a :class:`KinBody` returned by
+        :func:`ssik._urdf.load_urdf_kinbody_normalized`. Passing a
+        non-normalized KinBody yields undefined results.
+    :param policy: tolerances for the axis-parallel / axis-intersect
+        predicates. Defaults to :data:`ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+    """
+    return TopologyReport(
+        dof=kb.GetDOF(),
+        three_consecutive_intersecting=three_consecutive_intersecting(kb.joints, policy),
+        three_consecutive_parallel=three_consecutive_parallel(kb.joints, policy),
+    )

--- a/src/ssik/kinematics/__init__.py
+++ b/src/ssik/kinematics/__init__.py
@@ -1,0 +1,24 @@
+"""Kinematic-structure utilities: predicates, POE helpers.
+
+Everything here operates on POE-normalized kinematic chains -- axes in the
+base frame at ``q = 0``, ``T_left`` as pure translation, ``T_right`` as
+identity except on the final joint. Passing a non-normalized KinBody to these
+predicates yields undefined results; use :func:`ssik._urdf.load_urdf_kinbody_normalized`
+first.
+"""
+
+from ssik.kinematics.predicates import (
+    axis_intersect,
+    axis_parallel,
+    joint_origins,
+    three_consecutive_intersecting,
+    three_consecutive_parallel,
+)
+
+__all__ = [
+    "axis_intersect",
+    "axis_parallel",
+    "joint_origins",
+    "three_consecutive_intersecting",
+    "three_consecutive_parallel",
+]

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -1,0 +1,183 @@
+"""Kinematic-structure predicates: axis parallelism, axis intersection,
+three-consecutive-intersecting, three-consecutive-parallel.
+
+These are the primitives the solver dispatcher uses to classify a chain into
+a closed-form kinematic family ("spherical wrist? three parallel? both?").
+Every predicate takes a :class:`~ssik.core.tolerances.TolerancePolicy` so
+behaviour is reproducible and user-tunable.
+
+Preconditions
+-------------
+All functions assume a **POE-normalized** :class:`KinBody` (axes expressed in
+the base frame at ``q = 0``, ``T_left`` as pure translation). Non-normalized
+inputs produce undefined results. See
+:func:`ssik._urdf.load_urdf_kinbody_normalized`.
+
+Axes are assumed to be unit-length up to numerical noise. The URDF loader
+(urchin) normalizes them on load; POE normalization preserves unit length
+because cumulative rpy products stay orthonormal. If a user hand-constructs
+a KinBody with non-unit axes, the parallel/intersect predicates will
+misbehave -- silent failures, not raised errors. A future
+:class:`TolerancePolicy` field can gate this with a runtime check.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from numpy.typing import NDArray
+
+    from ssik._kinbody import Joint
+
+__all__ = [
+    "axis_intersect",
+    "axis_parallel",
+    "joint_origins",
+    "three_consecutive_intersecting",
+    "three_consecutive_parallel",
+]
+
+
+def joint_origins(joints: list[Joint]) -> list[NDArray[np.float64]]:
+    """Return each joint's axis-origin point in the base frame at ``q = 0``.
+
+    On a POE-normalized chain, ``T_left`` for every joint is pure translation,
+    so the cumulative position after joint ``i`` is just the sum of the first
+    ``i + 1`` translations. The result is the point each joint's axis passes
+    through, which the intersection predicates need.
+    """
+    cum = np.zeros(3, dtype=np.float64)
+    origins: list[NDArray[np.float64]] = []
+    for j in joints:
+        cum = cum + j.T_left[:3, 3]
+        origins.append(cum.copy())
+    return origins
+
+
+def axis_parallel(
+    a: NDArray[np.float64],
+    b: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> bool:
+    """Return ``True`` if unit-vector axes ``a`` and ``b`` are parallel or
+    anti-parallel within ``policy.axis_parallel``.
+
+    Implementation: ``||a x b||`` is ``sin(theta)`` for unit vectors, which
+    small-angle approximates to the angular misalignment in radians.
+    """
+    return float(np.linalg.norm(np.cross(a, b))) < policy.axis_parallel
+
+
+def axis_intersect(
+    a: NDArray[np.float64],
+    oa: NDArray[np.float64],
+    b: NDArray[np.float64],
+    ob: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> bool:
+    """Return ``True`` if lines ``(oa + t*a)`` and ``(ob + s*b)`` share a
+    common point within ``policy.axis_intersect``.
+
+    For skew lines the shortest distance is
+    ``|dot(cross(a, b), (ob - oa))| / ||cross(a, b)||``. For parallel lines
+    (``||cross(a, b)|| < policy.axis_parallel``) the two lines are either
+    coincident or disjoint; the distance is then the perpendicular component
+    of ``(ob - oa)`` after projecting out ``a``.
+    """
+    cross = np.cross(a, b)
+    cross_norm = float(np.linalg.norm(cross))
+    delta = ob - oa
+    if cross_norm < policy.axis_parallel:
+        # Parallel case: shortest distance is the perpendicular component
+        # of delta relative to a (equivalently b -- they're parallel).
+        perp = delta - np.dot(delta, a) * a
+        return float(np.linalg.norm(perp)) < policy.axis_intersect
+    distance = abs(float(np.dot(cross, delta))) / cross_norm
+    return distance < policy.axis_intersect
+
+
+def three_consecutive_parallel(
+    joints: list[Joint],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> tuple[int, int, int] | None:
+    """Find the first triple of consecutive joints whose axes are all pairwise
+    parallel within ``policy.axis_parallel``.
+
+    Returns the ``(i, i+1, i+2)`` indices of the first matching triple, or
+    ``None`` if no such triple exists. This is the structural condition for
+    the UR-class (three-inner-parallel) kinematic family.
+    """
+    if len(joints) < 3:
+        return None
+    for i in range(len(joints) - 2):
+        a = joints[i].axis
+        b = joints[i + 1].axis
+        c = joints[i + 2].axis
+        # All three pairwise parallel. Transitivity for unit vectors within
+        # epsilon gives (a || c) from (a || b) and (b || c), but within tol
+        # it can drift; check explicitly.
+        if (
+            axis_parallel(a, b, policy)
+            and axis_parallel(b, c, policy)
+            and axis_parallel(a, c, policy)
+        ):
+            return (i, i + 1, i + 2)
+    return None
+
+
+def three_consecutive_intersecting(
+    joints: list[Joint],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> tuple[int, int, int] | None:
+    """Find the first triple of consecutive joints whose axes share a common
+    point (Pieper's spherical-wrist condition).
+
+    Three lines in 3D that are pairwise intersecting do **not** necessarily
+    share a common point -- they can form a triangle in space. This function
+    requires strict coincidence: computes the intersection point of axes 0
+    and 1, then verifies axis 2 passes through that same point within
+    ``policy.axis_intersect``.
+
+    Parallel-axis triples are rejected (axis_intersect short-circuits on
+    parallel, which is the degenerate case where "intersection" is
+    ill-defined).
+    """
+    if len(joints) < 3:
+        return None
+    origins = joint_origins(joints)
+    for i in range(len(joints) - 2):
+        a, b, c = joints[i].axis, joints[i + 1].axis, joints[i + 2].axis
+        oa, ob, oc = origins[i], origins[i + 1], origins[i + 2]
+
+        # Skip triples where any pair is parallel -- the spherical-wrist
+        # condition requires intersecting non-parallel axes. Parallel
+        # triples are the three_consecutive_parallel family, a separate case.
+        if axis_parallel(a, b, policy) or axis_parallel(b, c, policy):
+            continue
+
+        # All three pairwise intersecting?
+        if not (
+            axis_intersect(a, oa, b, ob, policy)
+            and axis_intersect(b, ob, c, oc, policy)
+            and axis_intersect(a, oa, c, oc, policy)
+        ):
+            continue
+
+        # Common-point check: compute the (a, b) intersection via least-squares
+        # on the 3x2 linear system [a, -b] @ [t, s]^T = (ob - oa), then verify
+        # c passes through that point.
+        M = np.column_stack([a, -b])
+        sol, *_ = np.linalg.lstsq(M, ob - oa, rcond=None)
+        t = float(sol[0])
+        p = oa + t * a
+
+        delta = p - oc
+        perp = delta - np.dot(delta, c) * c
+        if float(np.linalg.norm(perp)) < policy.axis_intersect:
+            return (i, i + 1, i + 2)
+    return None

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,341 @@
+"""Tests for the kinematic-structure predicates.
+
+Coverage split in three:
+
+1. **Low-level primitives** (:func:`axis_parallel`, :func:`axis_intersect`)
+   exercised on hand-built axes with deliberate geometric properties.
+2. **Three-consecutive classifiers** on real-robot fixtures: Puma 560 should
+   classify as spherical-wrist (three-consecutive-intersecting at joints
+   ``(3, 4, 5)``); UR5 should classify as three-consecutive-parallel at
+   joints ``(1, 2, 3)``.
+3. **Tolerance sensitivity** with synthetic chains that live at deliberate
+   near-misses, verifying that ``TolerancePolicy`` behaves correctly at the
+   boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from ssik import DEFAULT_TOLERANCE_POLICY, TolerancePolicy, describe_topology
+from ssik._kinbody import Joint, KinBody, Link
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.kinematics import (
+    axis_intersect,
+    axis_parallel,
+    joint_origins,
+    three_consecutive_intersecting,
+    three_consecutive_parallel,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_chain(
+    positions: list[Any],
+    axes: list[Any],
+) -> KinBody:
+    """Hand-build a POE-normalized KinBody from offsets and axes.
+
+    ``positions[i]`` is the base-frame offset from joint ``i-1`` to joint ``i``
+    (``positions[0]`` is from base to joint 0). ``axes[i]`` is joint ``i``'s
+    axis in the base frame, unit-length. Both lists must have the same length
+    ``N``; the result has ``N`` joints and ``N + 1`` links.
+    """
+    assert len(positions) == len(axes)
+    n = len(positions)
+    link_names = ["base_link", *[f"link_{i}" for i in range(1, n)], "ee_link"]
+    links = [Link(name=name) for name in link_names]
+    joints: list[Joint] = []
+    for i, (p, a) in enumerate(zip(positions, axes, strict=True)):
+        T_left = np.eye(4, dtype=np.float64)
+        T_left[:3, 3] = p
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_left,
+                T_right=np.eye(4, dtype=np.float64),
+                axis=np.asarray(a, dtype=np.float64),
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+def _unit(v: tuple[float, float, float]) -> np.ndarray:
+    arr = np.asarray(v, dtype=np.float64)
+    return arr / float(np.linalg.norm(arr))
+
+
+# --------------------------------------------------------------------------- #
+# axis_parallel
+# --------------------------------------------------------------------------- #
+
+
+def test_axis_parallel_identical_vectors() -> None:
+    a = np.array([1.0, 0.0, 0.0])
+    assert axis_parallel(a, a)
+
+
+def test_axis_parallel_anti_parallel_accepted() -> None:
+    """Anti-parallel unit vectors should count as parallel -- the cross
+    product is zero-magnitude in both the parallel and anti-parallel case,
+    and downstream solvers don't care about sign of rotation axes."""
+    a = np.array([0.0, 0.0, 1.0])
+    b = np.array([0.0, 0.0, -1.0])
+    assert axis_parallel(a, b)
+
+
+def test_axis_parallel_orthogonal_rejected() -> None:
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    assert not axis_parallel(a, b)
+
+
+def test_axis_parallel_near_miss_rejected_by_default() -> None:
+    """Angular misalignment of 1 milliradian is rejected at default 1e-8."""
+    a = np.array([1.0, 0.0, 0.0])
+    b = _unit((np.cos(1e-3), np.sin(1e-3), 0.0))
+    assert not axis_parallel(a, b)
+
+
+def test_axis_parallel_near_miss_accepted_with_loose_tol() -> None:
+    """Same misalignment with a loose policy passes."""
+    a = np.array([1.0, 0.0, 0.0])
+    b = _unit((np.cos(1e-3), np.sin(1e-3), 0.0))
+    assert axis_parallel(a, b, TolerancePolicy(axis_parallel=1e-2))
+
+
+# --------------------------------------------------------------------------- #
+# axis_intersect
+# --------------------------------------------------------------------------- #
+
+
+def test_axis_intersect_two_axes_through_same_point() -> None:
+    """Two orthogonal axes both passing through the origin intersect there."""
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    origin = np.zeros(3)
+    assert axis_intersect(a, origin, b, origin)
+
+
+def test_axis_intersect_two_axes_through_same_non_origin_point() -> None:
+    p = np.array([0.3, -0.5, 1.2])
+    # Pick two non-parallel axes; parameterize lines so they both pass through p.
+    a = np.array([1.0, 0.0, 0.0])
+    b = _unit((0.2, 1.0, 0.3))
+    oa = p - 4.0 * a  # shift along a
+    ob = p + 2.5 * b  # shift along b
+    assert axis_intersect(a, oa, b, ob)
+
+
+def test_axis_intersect_skew_lines_rejected() -> None:
+    """Two non-intersecting skew lines are rejected."""
+    a = np.array([1.0, 0.0, 0.0])  # along +x
+    b = np.array([0.0, 1.0, 0.0])  # along +y, but offset in z
+    oa = np.array([0.0, 0.0, 0.0])
+    ob = np.array([0.0, 0.0, 0.5])  # 0.5 above a's line
+    assert not axis_intersect(a, oa, b, ob)
+
+
+def test_axis_intersect_parallel_coincident_accepted() -> None:
+    """Two coincident parallel lines (same direction, both through origin)
+    satisfy intersection -- their shortest distance is 0."""
+    a = np.array([1.0, 0.0, 0.0])
+    assert axis_intersect(a, np.zeros(3), a, np.zeros(3))
+
+
+def test_axis_intersect_parallel_disjoint_rejected() -> None:
+    """Parallel but non-coincident lines don't intersect."""
+    a = np.array([1.0, 0.0, 0.0])
+    oa = np.zeros(3)
+    ob = np.array([0.0, 1.0, 0.0])
+    assert not axis_intersect(a, oa, a, ob)
+
+
+def test_axis_intersect_near_miss_boundary() -> None:
+    """A 1e-7 offset is rejected at default 1e-8 tol, accepted at 1e-6."""
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    oa = np.zeros(3)
+    ob = np.array([0.0, 0.0, 1e-7])
+    assert not axis_intersect(a, oa, b, ob)
+    assert axis_intersect(a, oa, b, ob, TolerancePolicy(axis_intersect=1e-6))
+
+
+# --------------------------------------------------------------------------- #
+# joint_origins
+# --------------------------------------------------------------------------- #
+
+
+def test_joint_origins_cumulative_translation() -> None:
+    kb = _make_chain(
+        positions=[(1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)],
+        axes=[(0, 0, 1)] * 3,
+    )
+    origs = joint_origins(kb.joints)
+    assert np.allclose(origs[0], [1.0, 0.0, 0.0])
+    assert np.allclose(origs[1], [1.0, 2.0, 0.0])
+    assert np.allclose(origs[2], [1.0, 2.0, 3.0])
+
+
+# --------------------------------------------------------------------------- #
+# three_consecutive_parallel -- UR5 fixture + synthetic
+# --------------------------------------------------------------------------- #
+
+
+def test_three_consecutive_parallel_found_on_synthetic() -> None:
+    kb = _make_chain(
+        positions=[(0, 0, 0.1)] * 4,
+        axes=[(0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0)],
+    )
+    # Joints 1, 2, 3 all share axis (0, 1, 0).
+    assert three_consecutive_parallel(kb.joints) == (1, 2, 3)
+
+
+def test_three_consecutive_parallel_none_when_no_triple() -> None:
+    kb = _make_chain(
+        positions=[(0, 0, 0.1)] * 3,
+        axes=[(1, 0, 0), (0, 1, 0), (0, 0, 1)],
+    )
+    assert three_consecutive_parallel(kb.joints) is None
+
+
+def test_three_consecutive_parallel_finds_anti_parallel() -> None:
+    """Anti-parallel axes should still count -- rotations are symmetric
+    under axis reversal for Pieper-family classification."""
+    kb = _make_chain(
+        positions=[(0, 0, 0.1)] * 3,
+        axes=[(0, 1, 0), (0, -1, 0), (0, 1, 0)],
+    )
+    assert three_consecutive_parallel(kb.joints) == (0, 1, 2)
+
+
+def test_three_consecutive_parallel_ur5() -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "wrist_3_link")
+    # Documented in test_urdf_normalize.py: UR5 joints 1, 2, 3 (and 5) are
+    # all along (0, -1, 0) in base frame. The classifier finds the first
+    # triple, which is (1, 2, 3).
+    assert three_consecutive_parallel(kb.joints) == (1, 2, 3)
+
+
+# --------------------------------------------------------------------------- #
+# three_consecutive_intersecting -- Puma fixture + synthetic
+# --------------------------------------------------------------------------- #
+
+
+def test_three_consecutive_intersecting_found_on_synthetic() -> None:
+    """Three axes through the same point (origin), all non-parallel."""
+    kb = _make_chain(
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0)],
+        axes=[(1, 0, 0), (0, 1, 0), (0, 0, 1)],
+    )
+    assert three_consecutive_intersecting(kb.joints) == (0, 1, 2)
+
+
+def test_three_consecutive_intersecting_rejects_triangle() -> None:
+    """Three axes that pairwise intersect at three *different* points should
+    be rejected -- they form a triangle, not a common-point pencil."""
+    # Axes along +x, +y, +z, originating at three different non-collinear points.
+    # Pair (0,1) intersects at (0,0,0). Pair (1,2) intersects at (1,0,0).
+    # Pair (0,2) does not intersect at (0,0,0) or (1,0,0) because axes are
+    # skew relative to each other in this configuration.
+    kb = _make_chain(
+        positions=[(0, 0, 0), (1, 0, 0), (0, 1, 0)],
+        axes=[(1, 0, 0), (0, 1, 0), (0, 0, 1)],
+    )
+    # Origins: j0 at (0,0,0), j1 at (1,0,0), j2 at (1,1,0).
+    # j0-j1: line x=free,y=0,z=0 vs line x=1,y=free,z=0 -> intersect at (1,0,0).
+    # j1-j2: line x=1,y=free,z=0 vs line x=1,y=1,z=free -> intersect at (1,1,0).
+    # j0-j2: line x=free,y=0,z=0 vs line x=1,y=1,z=free -> skew, no intersection.
+    assert three_consecutive_intersecting(kb.joints) is None
+
+
+def test_three_consecutive_intersecting_rejects_parallel_triple() -> None:
+    """Parallel axes are never classified as intersecting, even if they
+    happen to be coincident (parallel triples go through the
+    three_consecutive_parallel path instead)."""
+    kb = _make_chain(
+        positions=[(0, 0, 0)] * 3,
+        axes=[(0, 0, 1), (0, 0, 1), (0, 0, 1)],
+    )
+    assert three_consecutive_intersecting(kb.joints) is None
+    assert three_consecutive_parallel(kb.joints) == (0, 1, 2)
+
+
+def test_three_consecutive_intersecting_puma560() -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+    # Puma 560 has a classic spherical wrist at joints 3, 4, 5 -- that's the
+    # textbook proof-of-concept for Pieper's decomposition (and what makes
+    # the vendored ikfast's TestIntersectingAxes recognize it, per #36).
+    assert three_consecutive_intersecting(kb.joints) == (3, 4, 5)
+
+
+def test_three_consecutive_intersecting_short_chain_returns_none() -> None:
+    kb = _make_chain(
+        positions=[(0, 0, 0), (0, 0, 0)],
+        axes=[(1, 0, 0), (0, 1, 0)],
+    )
+    assert three_consecutive_intersecting(kb.joints) is None
+
+
+# --------------------------------------------------------------------------- #
+# describe_topology
+# --------------------------------------------------------------------------- #
+
+
+def test_describe_topology_ur5() -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "wrist_3_link")
+    report = describe_topology(kb)
+    assert report.dof == 6
+    assert report.three_consecutive_parallel == (1, 2, 3)
+    # UR5 does not have three consecutive intersecting axes -- that's why
+    # this arm is not Pieper-compatible. But normalized UR5 does have
+    # joints (1, 2, 3) all parallel; report surfaces that.
+    assert report.three_consecutive_intersecting is None
+
+
+def test_describe_topology_puma560() -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+    report = describe_topology(kb)
+    assert report.dof == 6
+    assert report.three_consecutive_intersecting == (3, 4, 5)
+
+
+def test_describe_topology_is_frozen() -> None:
+    """TopologyReport is a frozen dataclass -- callers cannot mutate it."""
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "wrist_3_link")
+    report = describe_topology(kb)
+    with pytest.raises(Exception, match=r"cannot assign|is not writable|FrozenInstance"):
+        report.dof = 7  # type: ignore[misc]
+
+
+def test_describe_topology_honors_policy_loose() -> None:
+    """A chain 1e-5 away from three-parallel: default policy rejects, loose
+    policy accepts."""
+    kb = _make_chain(
+        positions=[(0, 0, 0.1)] * 3,
+        axes=[(0, 1, 0), _unit((1e-5, 1.0, 0.0)), _unit((0, 1.0, 1e-5))],
+    )
+    # Default 1e-8 policy: no three-parallel triple.
+    assert three_consecutive_parallel(kb.joints) is None
+    # Loose policy absorbs the misalignment.
+    loose = TolerancePolicy(axis_parallel=1e-3, axis_intersect=1e-3)
+    assert three_consecutive_parallel(kb.joints, loose) == (0, 1, 2)
+
+
+def test_default_tolerance_policy_is_singleton_like() -> None:
+    """DEFAULT_TOLERANCE_POLICY is a concrete value, not just a type alias."""
+    assert isinstance(DEFAULT_TOLERANCE_POLICY, TolerancePolicy)
+    assert DEFAULT_TOLERANCE_POLICY.axis_parallel > 0
+    assert DEFAULT_TOLERANCE_POLICY.axis_intersect > 0


### PR DESCRIPTION
Part of #37. Fixes #40. Stacked on #42 (which is stacked on #41). GitHub will auto-retarget as the earlier PRs merge.

## Summary

First structural-analysis layer the dispatcher (Phase C) will consume, and the last foundation piece before Phase B writes subproblem solvers.

Given a POE-normalized `KinBody`, classify its kinematic structure: does it have three consecutive intersecting axes (spherical wrist / Pieper condition)? Three consecutive parallel axes (UR-class family)? If neither, the dispatcher will know to route to tier-1 / tier-2 / Husty-Pfurner fallback. If there's a near-miss, users can query with a looser `TolerancePolicy` and get an answer.

## New modules

- `ssik.core.tolerances` — `TolerancePolicy` frozen dataclass (`axis_parallel`, `axis_intersect`, both default 1e-8). Calibrated for metric-scale 6-DOF chains. `DEFAULT_TOLERANCE_POLICY` exported for convenience.
- `ssik.kinematics.predicates` — `axis_parallel`, `axis_intersect`, `joint_origins`, `three_consecutive_parallel`, `three_consecutive_intersecting`. All take a `TolerancePolicy`. All assume POE-normalized input (documented).
- `ssik.core.topology` — `TopologyReport` + `describe_topology`. Minimal right now (dof + the two three-consecutive results); near-miss diagnostics land alongside the dispatcher in Phase C where they have a concrete consumer.

Public surface exported from `ssik` top-level: `TolerancePolicy`, `DEFAULT_TOLERANCE_POLICY`, `TopologyReport`, `describe_topology`.

## Key design decisions

- **Strict common-point coincidence**, not just pairwise intersection. Three 3D lines can pairwise-intersect yet form a triangle rather than a single-point pencil — the test `test_three_consecutive_intersecting_rejects_triangle` guards this.
- **Anti-parallel counts as parallel**. Unit-vector cross product is zero in both cases and downstream solvers don't care about axis sign.
- **Parallel triples are rejected by the intersecting predicate**. Parallel and intersecting are distinct families for dispatcher purposes; coincident parallel axes go through `three_consecutive_parallel`.
- **POE invariant assumed.** Predicates compute joint axis-origins from `T_left` cumulative translation (which is only pure translation in POE form). Documented as a precondition; the API is private enough that we don't need a runtime check in this phase.

## Verified on real fixtures

- **Puma 560** (URDF) → `three_consecutive_intersecting = (3, 4, 5)`. The textbook spherical-wrist Pieper example; matches what the vendored ikfast's `TestIntersectingAxes` finds per #36.
- **UR5** (URDF) → `three_consecutive_parallel = (1, 2, 3)`. The three-inner-parallel UR-class family.

## Test coverage (26 new, 83 total)

- `axis_parallel`: identical, anti-parallel, orthogonal, near-miss at tolerance boundaries.
- `axis_intersect`: common origin, non-origin common point, skew, parallel-coincident, parallel-disjoint, tolerance boundary.
- `joint_origins`: cumulative-translation correctness.
- `three_consecutive_parallel`: synthetic triples, anti-parallel chains, UR5 fixture, no-triple case.
- `three_consecutive_intersecting`: synthetic triples, triangle rejection, parallel-triple rejection, Puma 560 fixture, short-chain edge case.
- `describe_topology`: Puma + UR5 reports, frozen-dataclass immutability, tolerance-policy sensitivity.

## Verification

- [x] `uv run pytest` — 83 passed, 8 deselected.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean (22 source files, up from 16).

## Non-goals

- Solver dispatcher (Phase C).
- Near-miss reporting in `TopologyReport` (Phase C; documented in module docstring).
- POE-normalization extraction from `_urdf.py` into `ssik.kinematics.poe` (plan mentions it as a prerequisite for MJCF support in Phase O; defer until there's an actual second loader).
- Runtime check that the input KinBody is POE-normalized — the loader is the only entry point right now, and it guarantees the invariant. When the public `Manipulator.from_urdf(...)` lands in Phase E it'll be the same story.

## Test plan

- [ ] CI green.
- [ ] #41 + #42 merge; this PR auto-retargets to `main`.