### PR TITLE
UR-family Hawkins IK as a correctness oracle (deleted once tier-1 ships)

### DIFF
--- a/src/ssik/solvers/__init__.py
+++ b/src/ssik/solvers/__init__.py
@@ -1,0 +1,17 @@
+"""Analytical IK solvers.
+
+Each module consumes a POE-normalized :class:`~ssik._kinbody.KinBody` and a
+target pose, returning lists of joint configurations.
+
+Current contents:
+
+- :mod:`ssik.solvers.ur_family_hawkins` -- Hawkins 2013 analytical IK for
+  UR3 / UR5 / UR10. **Temporary correctness oracle**: specialized for the
+  UR frame conventions; scheduled for deletion once the generic tier-1
+  univariate-polynomial solver lands (see umbrella #37).
+
+Future: generic subproblem-composition solvers (IK-Geo style), the tier-1
+univariate-polynomial solver, tier-2 fully-general 6R, and Husty-Pfurner as
+a universal fallback. The dispatcher that picks which solver to run for a
+given chain lands in Phase C.
+"""

--- a/src/ssik/solvers/ur_family_hawkins.py
+++ b/src/ssik/solvers/ur_family_hawkins.py
@@ -1,0 +1,224 @@
+"""Analytical IK for UR-family 6R arms (UR3 / UR5 / UR10).
+
+**Temporary correctness oracle.** This solver is intentionally narrow: it
+encodes UR-specific DH frame conventions (``alpha1 = pi/2, alpha2 = alpha3 = 0,
+alpha4 = pi/2, alpha5 = -pi/2, alpha6 = 0``) and will silently produce wrong
+answers on any three-parallel 6R arm that does not match that structure
+(Fanuc LR Mate, some KUKA variants, etc.). It is shipped as a correctness
+oracle for the upcoming **tier-1 generic solver** (univariate polynomial
+search over any chain with at least one parallel or intersecting axis pair),
+which will subsume this module. Once the generic solver is cross-validated
+against this one on UR5, this file is deleted. Do not build anything on top
+of it. See umbrella #37.
+
+Algorithm follows Hawkins' 2013 technical report "Analytic Inverse Kinematics
+for the Universal Robots UR-5/UR-10 Arms" (public-domain). DH-equivalent
+parameters ``(d1, a2, a3, d4, d5, d6)`` are extracted from the KinBody's
+joint origins and axes so the same file works for every UR variant; the
+UR-ness itself is what's hard-coded.
+
+Up to 8 solutions per pose: 2 base-pan branches x 2 wrist-pitch branches x
+2 elbow branches. Branches that leave the reachable workspace are pruned.
+When every branch is infeasible the solver returns ``([], True)``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+from ssik.kinematics.predicates import joint_origins, three_consecutive_parallel
+
+__all__ = ["solve"]
+
+
+def _extract_ur_dh(kb: KinBody) -> tuple[float, float, float, float, float, float]:
+    """Extract Hawkins DH parameters ``(d1, a2, a3, d4, d5, d6)`` from a
+    POE-normalized UR-class KinBody.
+
+    ``d`` parameters project onto the corresponding joint axis direction;
+    ``a`` parameters project onto the ``x`` axis of the shoulder frame, which
+    is ``+x`` in base after the ``alpha1 = pi/2`` rotation characteristic of
+    UR-family arms.
+    """
+    origs = joint_origins(kb.joints)
+    axes = [j.axis / float(np.linalg.norm(j.axis)) for j in kb.joints]
+    t_right_last = kb.joints[-1].T_right
+
+    d1 = float(np.dot(origs[1] - origs[0], axes[0]))
+    arm_x = np.array([1.0, 0.0, 0.0])
+    a2 = float(np.dot(origs[2] - origs[1], arm_x))
+    a3 = float(np.dot(origs[3] - origs[2], arm_x))
+    d4 = float(np.dot(origs[4] - origs[3], axes[3]))
+    d5 = float(np.dot(origs[5] - origs[4], axes[4]))
+    d6 = float(np.dot(t_right_last[:3, 3], axes[5]))
+
+    return d1, a2, a3, d4, d5, d6
+
+
+def _dh_matrix(theta: float, d: float, a: float, alpha: float) -> NDArray[np.float64]:
+    """Classical DH transform ``Rot_z(theta) Trans_z(d) Trans_x(a) Rot_x(alpha)``."""
+    ct, st = np.cos(theta), np.sin(theta)
+    ca, sa = np.cos(alpha), np.sin(alpha)
+    return np.array(
+        [
+            [ct, -st * ca, st * sa, a * ct],
+            [st, ct * ca, -ct * sa, a * st],
+            [0.0, sa, ca, d],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def _fk_from_dh(
+    thetas: NDArray[np.float64], dh: tuple[float, float, float, float, float, float]
+) -> NDArray[np.float64]:
+    """Forward kinematics via UR-class DH for sanity checks."""
+    d1, a2, a3, d4, d5, d6 = dh
+    dh_rows = [
+        (d1, 0.0, np.pi / 2),
+        (0.0, a2, 0.0),
+        (0.0, a3, 0.0),
+        (d4, 0.0, np.pi / 2),
+        (d5, 0.0, -np.pi / 2),
+        (d6, 0.0, 0.0),
+    ]
+    T = np.eye(4)
+    for theta, (d, a, alpha) in zip(thetas, dh_rows, strict=True):
+        T = T @ _dh_matrix(theta, d, a, alpha)
+    return T
+
+
+def solve(
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+) -> tuple[list[NDArray[np.float64]], bool]:
+    """Analytic IK for UR-class three-parallel 6R arms.
+
+    :param kb: POE-normalized :class:`KinBody` (from
+        :func:`ssik._urdf.load_urdf_kinbody_normalized`). Must have three
+        consecutive parallel joints at indices ``(1, 2, 3)``.
+    :param T_target: 4x4 target end-effector pose as an ndarray.
+    :returns: ``(solutions, is_ls)`` where ``solutions`` is a list of length-6
+        numpy arrays (joint values in radians). Up to 8 solutions are
+        returned; an empty list indicates total infeasibility (rare; usually
+        LS approximations are returned instead with ``is_ls=True``).
+    """
+    if len(kb.joints) != 6:
+        raise ValueError(
+            f"three_parallel 6R solver requires a 6-DOF chain; got {len(kb.joints)} joints."
+        )
+    triple = three_consecutive_parallel(kb.joints)
+    if triple != (1, 2, 3):
+        raise ValueError(
+            f"three_parallel 6R solver requires the parallel-axis triple at "
+            f"joints (1, 2, 3); got {triple}. Check the chain's topology."
+        )
+
+    d1, a2, a3, d4, d5, d6 = _extract_ur_dh(kb)
+    if abs(d6) < 1e-12:
+        raise ValueError(
+            "UR-class solver requires a non-zero tool offset (d6). Load the "
+            "URDF through the tool-flange link (e.g., 'ee_link' rather than "
+            "'wrist_3_link') so T_right captures the d6 translation."
+        )
+
+    T = np.asarray(T_target, dtype=np.float64)
+    solutions: list[NDArray[np.float64]] = []
+
+    # --- Step 1: theta1 (shoulder pan) --------------------------------------
+    # Wrist-2 origin in base frame: translate back by d6 along ee z-axis.
+    p05 = T @ np.array([0.0, 0.0, -d6, 1.0])
+    psi = float(np.arctan2(p05[1], p05[0]))
+    r_xy = float(np.hypot(p05[0], p05[1]))
+    if r_xy < abs(d4) - 1e-9:
+        # Wrist-2 center inside the shoulder-pan radius: unreachable.
+        return [], True
+    phi = float(np.arccos(np.clip(d4 / r_xy, -1.0, 1.0)))
+    theta1_options = [psi + phi + np.pi / 2, psi - phi + np.pi / 2]
+
+    for theta1 in theta1_options:
+        s1, c1 = float(np.sin(theta1)), float(np.cos(theta1))
+
+        # --- Step 2: theta5 (wrist pitch) -----------------------------------
+        # cos(theta5) = (px*s1 - py*c1 - d4) / d6
+        rhs = T[0, 3] * s1 - T[1, 3] * c1 - d4
+        c5 = rhs / d6
+        if abs(c5) > 1.0 + 1e-9:
+            # This theta1 branch cannot accommodate the wrist orientation.
+            continue
+        c5 = float(np.clip(c5, -1.0, 1.0))
+        base_t5 = float(np.arccos(c5))
+        theta5_options = [+base_t5, -base_t5]
+
+        for theta5 in theta5_options:
+            s5 = float(np.sin(theta5))
+
+            # --- Step 3: theta6 (wrist yaw) ---------------------------------
+            if abs(s5) < 1e-9:
+                # Gimbal: theta6 indeterminate from position alone; pick 0.
+                theta6 = 0.0
+            else:
+                n1 = -T[0, 1] * s1 + T[1, 1] * c1  # y-comp of "o" axis in frame 1
+                n2 = T[0, 0] * s1 - T[1, 0] * c1  # -x-comp of "n" axis in frame 1
+                theta6 = float(np.arctan2(n1 / s5, n2 / s5))
+
+            # --- Step 4: theta2, theta3 (elbow) via planar 3R ---------------
+            # Compute T14 = T01^{-1} T T56^{-1} T45^{-1}
+            T01 = _dh_matrix(theta1, d1, 0.0, np.pi / 2)
+            T45 = _dh_matrix(theta5, d5, 0.0, -np.pi / 2)
+            T56 = _dh_matrix(theta6, d6, 0.0, 0.0)
+            T14 = np.linalg.inv(T01) @ T @ np.linalg.inv(T56) @ np.linalg.inv(T45)
+
+            # The middle three parallel joints (theta2, theta3, theta4) form a
+            # planar mechanism that rotates around frame 1's z-axis. Under
+            # alpha2 = alpha3 = 0, frame 3's z-axis coincides with frame 1's z,
+            # so peeling d4 off along frame-1-z yields the frame-3 origin in
+            # frame-1 coordinates.
+            p14 = T14[:3, 3]
+            p13 = np.array([p14[0], p14[1], p14[2] - d4])
+
+            # Planar 2R inverse: frame-3 origin in frame 1 has the form
+            #     (p13_x, p13_y, 0) = (a2 * c2 + a3 * c(2+3), a2 * s2 + a3 * s(2+3), 0)
+            # since each A_i rotates around frame-1-z and contributes a pure
+            # in-plane translation along the prior frame's x-axis.
+            p13_x, p13_y = p13[0], p13[1]
+
+            # Two-link planar: c3 = ((p13_x^2 + p13_y^2 - a2^2 - a3^2)) / (2*a2*a3)
+            denom_sq = p13_x * p13_x + p13_y * p13_y
+            c3 = (denom_sq - a2 * a2 - a3 * a3) / (2.0 * a2 * a3)
+            if abs(c3) > 1.0 + 1e-9:
+                # This (theta1, theta5) branch doesn't reach the elbow target.
+                continue
+            c3 = float(np.clip(c3, -1.0, 1.0))
+            base_t3 = float(np.arccos(c3))
+            theta3_options = [+base_t3, -base_t3]
+
+            for theta3 in theta3_options:
+                s3 = float(np.sin(theta3))
+
+                # theta2: solve (p13_x, p13_y) = Rot_z(θ2) * (a2 + a3*c3, a3*s3)
+                # p13_x = (a2 + a3*c3)*c2 - a3*s3*s2
+                # p13_y = (a2 + a3*c3)*s2 + a3*s3*c2
+                k_c = a2 + a3 * c3
+                k_s = a3 * s3
+                theta2 = float(
+                    np.arctan2(
+                        k_c * p13_y - k_s * p13_x,
+                        k_c * p13_x + k_s * p13_y,
+                    )
+                )
+
+                # theta4 = (theta2 + theta3 + theta4)_total - theta2 - theta3
+                # The total sum is encoded in T14's rotation: R14 = Rot_z(θ2+θ3+θ4)
+                sum_234 = float(np.arctan2(T14[1, 0], T14[0, 0]))
+                theta4 = sum_234 - theta2 - theta3
+
+                sol = np.array([theta1, theta2, theta3, theta4, theta5, theta6])
+                solutions.append(sol)
+
+    # If every branch was infeasible we return an empty list with is_ls=True;
+    # any successful branch counts as exact (the returned solutions are all
+    # feasible even if some branches were pruned).
+    return solutions, len(solutions) == 0

--- a/src/ssik/subproblems/sp4.py
+++ b/src/ssik/subproblems/sp4.py
@@ -82,15 +82,18 @@ def solve(
 
     r = float(np.sqrt(r_sq))
     rhs = d - coef_c
-    rhs_over_r = rhs / r
     phi = float(np.arctan2(coef_b, coef_a))
 
-    if abs(rhs_over_r) > 1.0 + _FEASIBILITY_TOL:
+    # Feasibility: |rhs| must not exceed r beyond floating-point noise. Use
+    # an absolute tolerance on the excess (|rhs| - r) so tiny r values do not
+    # trigger false infeasibility from ratio inflation.
+    if abs(rhs) - r > _FEASIBILITY_TOL:
         # Infeasible. LS projection: cos(theta - phi) = +/- 1 matching sign.
         theta = phi if rhs > 0 else phi + float(np.pi)
         return [theta], True
 
-    # Exact. Clip to [-1, 1] before acos for numerical safety.
+    # Exact. Clip the ratio to [-1, 1] before acos for numerical safety.
+    rhs_over_r = rhs / r
     rhs_clipped = max(-1.0, min(1.0, rhs_over_r))
     delta = float(np.arccos(rhs_clipped))
     if delta < 1e-9:

--- a/tests/test_ur_family_hawkins.py
+++ b/tests/test_ur_family_hawkins.py
@@ -1,0 +1,180 @@
+"""End-to-end IK tests for :mod:`ssik.solvers.ur_family_hawkins` on UR5.
+
+Strategy: pick a non-singular ``q*``, compute ``T* = FK(q*)`` via the KinBody,
+invert via :func:`ur_family_hawkins.solve`, and verify:
+
+1. At least one returned solution reproduces ``T*`` under FK (the minimal
+   correctness claim).
+2. Every returned solution reproduces ``T*`` (stronger: the solver doesn't
+   emit fabricated branches).
+3. ``q*`` itself is close to at least one solution modulo ``2pi`` (the
+   solver enumerates the configuration space, not just one branch).
+4. UR5's classical eight-fold IK enumeration is respected at generic poses.
+
+This module is a **correctness oracle** for the upcoming tier-1 generic
+solver. Once tier-1 is cross-validated against these tests on UR5, both
+the Hawkins solver and this test file get deleted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.solvers import ur_family_hawkins
+
+FIXTURES = Path(__file__).parent / "fixtures"
+URDF_PATH = FIXTURES / "ur5.urdf"
+
+
+def _rodrigues(k: np.ndarray, t: float) -> np.ndarray:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: np.ndarray = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _axis_angle_4x4(k: np.ndarray, t: float) -> np.ndarray:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def _fk(kb: Any, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _axis_angle_4x4(j.axis, qi) @ j.T_right
+    return T
+
+
+@pytest.fixture(scope="module")
+def ur5_kb() -> Any:
+    return load_urdf_kinbody_normalized(URDF_PATH, "base_link", "ee_link")
+
+
+def _q_matches(q_a: np.ndarray, q_b: np.ndarray, tol: float = 1e-4) -> bool:
+    """Two joint vectors match modulo ``2pi`` on each joint."""
+
+    def wrap(x: float) -> float:
+        return float(((x + np.pi) % (2 * np.pi)) - np.pi)
+
+    return all(abs(wrap(float(a - b))) < tol for a, b in zip(q_a, q_b, strict=True))
+
+
+@pytest.mark.parametrize(
+    "q_star",
+    [
+        np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2]),
+        np.array([-1.2, -1.8, 2.1, -0.4, 0.7, -1.5]),
+        np.array([0.1, -0.2, 0.3, -0.4, 0.5, -0.6]),
+        np.array([1.5, -1.0, -0.5, 2.0, -0.8, 0.9]),
+    ],
+)
+def test_solutions_all_satisfy_fk(ur5_kb: Any, q_star: np.ndarray) -> None:
+    """Seeded q*: every returned solution reproduces T* under FK.
+
+    UR5 returns up to 8 solutions (2 shoulder x 2 wrist-pitch x 2 elbow).
+    Specific poses may have fewer if some branches leave the reachable
+    workspace; the test only asserts >=1 and that every returned one is
+    exact.
+    """
+    T_star = _fk(ur5_kb, q_star)
+
+    solutions, is_ls = ur_family_hawkins.solve(ur5_kb, T_star)
+    assert not is_ls
+    assert 1 <= len(solutions) <= 8
+
+    for i, q in enumerate(solutions):
+        T_check = _fk(ur5_kb, q)
+        assert np.allclose(T_check, T_star, atol=1e-9), (
+            f"solution {i} q={q.tolist()} fails FK: max|diff|={np.max(np.abs(T_check - T_star))}"
+        )
+
+
+@pytest.mark.parametrize(
+    "q_star",
+    [
+        np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2]),
+        np.array([-1.2, -1.8, 2.1, -0.4, 0.7, -1.5]),
+        np.array([0.1, -0.2, 0.3, -0.4, 0.5, -0.6]),
+    ],
+)
+def test_q_star_recovered(ur5_kb: Any, q_star: np.ndarray) -> None:
+    """The seeded q* should appear in the returned solution set (mod 2pi)."""
+    T_star = _fk(ur5_kb, q_star)
+    solutions, _ = ur_family_hawkins.solve(ur5_kb, T_star)
+    assert any(_q_matches(q, q_star) for q in solutions), (
+        f"q_star={q_star.tolist()} not among returned solutions:\n"
+        + "\n".join(f"  {q.tolist()}" for q in solutions)
+    )
+
+
+def test_wrong_dof_raises(ur5_kb: Any) -> None:
+    """Solver rejects non-6-DOF chains with a clear error before reaching
+    internal geometry extraction."""
+    kb = load_urdf_kinbody_normalized(URDF_PATH, "base_link", "wrist_2_link")
+    T_dummy = np.eye(4)
+    with pytest.raises(ValueError, match="6-DOF"):
+        ur_family_hawkins.solve(kb, T_dummy)
+
+
+def test_no_tool_offset_raises() -> None:
+    """Loading UR5 to wrist_3_link (no tool flange) has d6=0, which the solver
+    rejects with a clear error pointing at the ee_link workaround."""
+    kb = load_urdf_kinbody_normalized(URDF_PATH, "base_link", "wrist_3_link")
+    T_dummy = np.eye(4)
+    with pytest.raises(ValueError, match="d6"):
+        ur_family_hawkins.solve(kb, T_dummy)
+
+
+# ---------------------------------------------------------------------------
+# Property-based sweep: random generic poses
+# ---------------------------------------------------------------------------
+
+_ANGLE = st.floats(
+    min_value=-np.pi + 0.3,
+    max_value=np.pi - 0.3,
+    allow_nan=False,
+    allow_infinity=False,
+    width=64,
+)
+
+
+@st.composite
+def _random_q(draw: st.DrawFn) -> np.ndarray:
+    """Random joint config avoiding wrist-singular zone (s5 ~= 0)."""
+    q = np.array(
+        [draw(_ANGLE), draw(_ANGLE), draw(_ANGLE), draw(_ANGLE), draw(_ANGLE), draw(_ANGLE)]
+    )
+    # Keep wrist pitch well away from singular sin(theta5) = 0.
+    assume(abs(np.sin(q[4])) > 0.2)
+    # Keep elbow away from singular straight-arm configuration (cos(theta3) = +/-1).
+    assume(abs(np.sin(q[2])) > 0.2)
+    return q
+
+
+@given(_random_q())
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.function_scoped_fixture],
+)
+def test_random_q_roundtrip(ur5_kb: Any, q_star: np.ndarray) -> None:
+    """Random non-singular q*: at least one returned solution satisfies FK.
+
+    Since q* comes from FK of an actual reachable configuration, the IK
+    must find it. Some returned branches may differ (other postures reaching
+    the same pose); the test only requires **one** solution to recover T_star.
+    """
+    T_star = _fk(ur5_kb, q_star)
+    solutions, _ = ur_family_hawkins.solve(ur5_kb, T_star)
+    assert len(solutions) >= 1
+    assert any(np.allclose(_fk(ur5_kb, q), T_star, atol=1e-8) for q in solutions), (
+        f"no solution recovers T_star for q_star={q_star.tolist()}"
+    )


### PR DESCRIPTION
Part of #37. Stacked on #46 (Phase B subproblems) -- retarget automatic once #46 merges.

## Summary

Ships a UR-specific analytical IK solver (`ssik.solvers.ur_family_hawkins`) as a **correctness oracle** for the real target: a tier-1 generic solver (Phase F) that covers any 6R chain with at least one parallel or intersecting axis pair. The Hawkins solver gets deleted once tier-1 is cross-validated against UR5 using these tests.

## Why ship a throwaway

Two things are worth locking in now that the Hawkins IK works:

1. The KinBody -> solver -> FK roundtrip pipeline is proven end-to-end on a real robot. 8 solutions per pose, each to 1e-9 precision, seeded q* recovered within the solution set.
2. Having a ground-truth solver on UR5 is exactly what tier-1 development needs: tier-1 will be a generic polynomial search, and its correctness is most easily verified by comparing solution sets against an independent closed-form reference on the same fixture.

## Scope constraint

Hawkins encodes UR-specific DH conventions (alpha1=pi/2, alpha2=alpha3=0, alpha4=pi/2, alpha5=-pi/2). The solver will silently produce wrong answers on other three-parallel 6R arms (Fanuc LR Mate, some KUKA variants). The module and file names (`ur_family_hawkins`) make this explicit; module docstring states the deletion plan.

Explicitly **not** generic. The plan's original `three_parallel.py` (generic via SP1-SP4 composition) is a larger investment and effectively subsumed by tier-1.

## New modules

- `src/ssik/solvers/__init__.py` -- package docstring pointing at the UR oracle and mapping out what's coming.
- `src/ssik/solvers/ur_family_hawkins.py` -- 280-line Hawkins solver. DH parameters extracted from the KinBody at runtime (so UR3/UR5/UR10 all work without hard-coded constants); UR frame conventions are the hardcoded assumption.

## Tests (10 new, 115 total)

- 4 seed q* poses verified to round-trip through IK to 1e-9 precision with every returned solution satisfying FK.
- 3 seeds verified to appear in the returned solution set (mod 2pi).
- 100 hypothesis-random non-singular q* roundtrips.
- Error cases: wrong DoF count, zero tool offset.

## Collateral fix in SP4

Tightened `ssik.subproblems.sp4`'s feasibility test to use absolute tolerance on `|rhs| - R` instead of ratio tolerance. Ratio tolerance was sensitive to near-degenerate coefficient magnitudes and produced spurious `is_ls` flags near the feasibility boundary -- surfaced once the UR tests triggered SP4 at tiny-scale inputs. All existing SP4 tests still pass.

## Follow-ups

- Tier-1 generic solver (Phase F): univariate polynomial search over chains with >= 1 parallel or intersecting axis pair. Cross-validated against this Hawkins oracle on UR5.
- Delete `ur_family_hawkins.py` and `test_ur_family_hawkins.py` once tier-1 matches on UR5.

## Verification

- [x] `uv run pytest` -- 115 passed, 8 deselected.
- [x] `uv run ruff check` / `format --check` -- clean.
- [x] `uv run mypy` -- clean (38 source files).