### PR TITLE
Round 2.2: ikgeo.two_parallel (tier-1 univariate-search 6R)

### DIFF
--- a/SUPPORTED_ROBOTS.md
+++ b/SUPPORTED_ROBOTS.md
@@ -36,6 +36,7 @@ alongside each solver PR.
 | (synthetic spherical + intersecting) | 6 | inline in `tests/test_spherical_two_intersecting.py` | `ikgeo.spherical_two_intersecting` | spherical wrist + intersecting shoulder | 📐 |
 | (synthetic generic spherical) | 6 | inline in `tests/test_ikgeo_spherical.py` (two variants) | `ikgeo.spherical` | spherical wrist, shoulder neither parallel nor intersecting | 📐 |
 | (synthetic two-intersecting) | 6 | inline in `tests/test_ikgeo_two_intersecting.py` (two variants) | `ikgeo.two_intersecting` (tier-1) | joints (4, 5) share origin, no spherical wrist | 📐 |
+| (synthetic two-parallel) | 6 | inline in `tests/test_ikgeo_two_parallel.py` (IK-Geo-style random axes with axes[2]=axes[1]) | `ikgeo.two_parallel` (tier-1) | only joints (1, 2) parallel, no spherical wrist or other specialization | 📐 |
 
 ## 6R non-Pieper (tier-1 / tier-2, future)
 

--- a/src/ssik/solvers/__init__.py
+++ b/src/ssik/solvers/__init__.py
@@ -31,6 +31,11 @@ Current contents:
   (``p[5] = 0``). Uses 1D ``search_1d`` over ``theta_3`` with an
   inner SP5 shoulder solve per sample. Rare topology in commercial
   arms; dispatcher fallback when no spherical-wrist sibling matches.
+- :mod:`ssik.solvers.ikgeo.two_parallel` -- tier-1 univariate-search
+  solver for 6R arms where joints ``(1, 2)`` are parallel. Uses 1D
+  ``search_1d`` over ``theta_0`` with an inner SP6 coupling (q4, q6)
+  per sample. Narrower applicability than ``three_parallel`` and
+  fewer returned solutions due to tier-1 search sparsity.
 
 Future: Husty-Pfurner universal fallback, specialist 7R, dispatcher.
 """

--- a/src/ssik/solvers/ikgeo/_univariate.py
+++ b/src/ssik/solvers/ikgeo/_univariate.py
@@ -3,10 +3,18 @@
 Private; shared between ``two_intersecting`` and ``two_parallel`` (Round 2
 of the solver roster in issue #53).
 
-Ported clean-room from the BSD-3 [ik-geo Rust reference][ikgeo]'s
-``auxiliary::search_1d`` (Elias & Wen, arXiv:2211.05737). Retains the
-bracketing + false-position structure so the port is auditable against
-the source.
+- :func:`search_1d` -- clean-room port of IK-Geo Rust's ``search_1d``:
+  samples a vector-valued function on a grid and tracks sign changes
+  per component index via false-position refinement. Works when the
+  branch index is STABLE across samples.
+
+- :func:`search_1d_matched` -- geometric-branch-matched variant:
+  tracks branches by (cos, sin) proximity in branch-parameter space
+  across adjacent samples rather than by index. Handles the case
+  where the inner multi-valued solver returns branches whose order
+  varies with the search variable (e.g. SP6's quartic-root index
+  isn't stable across q1 samples). This gives substantially better
+  completeness for ``two_parallel`` than plain ``search_1d``.
 
 [ikgeo]: https://github.com/rpiRobotics/ik-geo/blob/main/rust/src/inverse_kinematics/auxiliary.rs
 """
@@ -18,7 +26,7 @@ from collections.abc import Callable
 import numpy as np
 from numpy.typing import NDArray
 
-__all__ = ["search_1d"]
+__all__ = ["search_1d", "search_1d_matched"]
 
 _CROSS_THRESHOLD = 0.1
 _FZ_ITERATIONS = 100
@@ -103,3 +111,139 @@ def _find_zero(
     if left <= x_left <= right:
         return x_left
     return None
+
+
+# ---------------------------------------------------------------------------
+# Geometric-branch-matched variant for tier-1 solvers where the inner
+# multi-valued subproblem's branch index isn't stable across samples.
+# ---------------------------------------------------------------------------
+
+_MATCH_ANGLE_TOL = np.pi / 6.0  # 30 degrees -- matches branches across a single
+# grid step without merging geometrically distinct ones.
+
+
+def search_1d_matched(
+    f_branches: Callable[[float], list[tuple[tuple[float, float], float]]],
+    left: float,
+    right: float,
+    initial_samples: int,
+) -> list[tuple[float, tuple[float, float]]]:
+    """Find zeros of a multi-branched 1D function using geometric branch
+    tracking.
+
+    ``f_branches(x)`` returns a list of ``((a1, a2), error)`` tuples: for
+    each branch active at ``x``, its two characteristic angles ``(a1, a2)``
+    and the scalar error at ``x``. The zero-finding tracks branches across
+    adjacent grid samples by matching ``(a1, a2)`` in wrap-to-pi angular
+    distance (threshold ``_MATCH_ANGLE_TOL``) rather than by list index.
+    This handles the case where the underlying multi-valued solver
+    reorders branches as the search variable changes -- which breaks the
+    index-based :func:`search_1d`.
+
+    :returns: list of ``(x_zero, (a1, a2))`` pairs. The ``(a1, a2)`` is
+        the branch parameters at the detected zero (from evaluating
+        ``f_branches`` at the refined ``x``, matched by proximity to the
+        tracked branch). Caller uses these to avoid re-evaluating.
+    """
+    zeros: list[tuple[float, tuple[float, float]]] = []
+    delta = (right - left) / initial_samples
+    last_branches = f_branches(left)
+    x_last = left
+    x = left + delta
+
+    for _ in range(initial_samples):
+        cur_branches = f_branches(x)
+        # For each current branch, find closest last branch; if found, check
+        # for sign change.
+        for cur_params, cur_err in cur_branches:
+            if not np.isfinite(cur_err):
+                continue
+            matched = _closest_branch(cur_params, last_branches)
+            if matched is None:
+                continue
+            _, last_err = matched
+            if not np.isfinite(last_err):
+                continue
+            if (cur_err < 0.0) != (last_err < 0.0) and (
+                abs(cur_err) < _CROSS_THRESHOLD and abs(last_err) < _CROSS_THRESHOLD
+            ):
+                z, z_params = _find_zero_matched(
+                    f_branches, x_last, x, last_err, cur_err, cur_params
+                )
+                if z is not None and z_params is not None:
+                    zeros.append((z, z_params))
+        last_branches = cur_branches
+        x_last = x
+        x += delta
+
+    return zeros
+
+
+def _branch_distance(a: tuple[float, float], b: tuple[float, float]) -> float:
+    """Wrap-to-pi angular distance between two (a1, a2) tuples."""
+
+    def _w(x: float) -> float:
+        return float(((x + np.pi) % (2 * np.pi)) - np.pi)
+
+    d1 = _w(a[0] - b[0])
+    d2 = _w(a[1] - b[1])
+    return float(np.hypot(d1, d2))
+
+
+def _closest_branch(
+    params: tuple[float, float],
+    candidates: list[tuple[tuple[float, float], float]],
+) -> tuple[tuple[float, float], float] | None:
+    """Return the candidate branch (params, err) closest to ``params`` in
+    wrap-to-pi distance, or ``None`` if no candidate is within
+    ``_MATCH_ANGLE_TOL``."""
+    best: tuple[tuple[float, float], float] | None = None
+    best_d = _MATCH_ANGLE_TOL
+    for c_params, c_err in candidates:
+        d = _branch_distance(params, c_params)
+        if d < best_d:
+            best_d = d
+            best = (c_params, c_err)
+    return best
+
+
+def _find_zero_matched(
+    f_branches: Callable[[float], list[tuple[tuple[float, float], float]]],
+    left: float,
+    right: float,
+    y_left: float,
+    y_right: float,
+    branch_params_hint: tuple[float, float],
+) -> tuple[float | None, tuple[float, float] | None]:
+    """False-position refinement on a bracketed zero, tracking the
+    matched geometric branch. At each iteration we re-evaluate
+    ``f_branches`` and pick the branch closest to the previously-tracked
+    ``branch_params``; if no branch is close enough the refinement
+    bails out.
+    """
+    x_left, x_right = left, right
+    tracked = branch_params_hint
+
+    for _ in range(_FZ_ITERATIONS):
+        delta = y_right - y_left
+        if abs(delta) < _FZ_EPSILON:
+            break
+        x_0 = x_left - y_left * (x_right - x_left) / delta
+        branches_0 = f_branches(x_0)
+        match = _closest_branch(tracked, branches_0)
+        if match is None:
+            return None, None
+        p_0, y_0 = match
+        if not np.isfinite(y_0):
+            return None, None
+        tracked = p_0
+        if (y_left < 0.0) != (y_0 < 0.0):
+            x_right = x_0
+            y_right = y_0
+        else:
+            x_left = x_0
+            y_left = y_0
+
+    if left <= x_left <= right:
+        return x_left, tracked
+    return None, None

--- a/src/ssik/solvers/ikgeo/two_parallel.py
+++ b/src/ssik/solvers/ikgeo/two_parallel.py
@@ -1,0 +1,170 @@
+"""Tier-1 univariate-search 6R solver: two parallel shoulder-elbow axes.
+
+Handles any 6R kinematic chain where joints ``(1, 2)`` are parallel
+(``axes[1] || axes[2]``) and no stronger wrist specialization matches.
+Weaker than ``three_parallel`` (which requires three consecutive
+parallel axes).
+
+Algorithm: port of the BSD-3 [ik-geo Rust reference][ikgeo]'s
+``two_parallel`` (Elias & Wen, arXiv:2211.05737). 1D search over
+``theta_0`` with an inner SP6 call per sample.
+
+[ikgeo]: https://github.com/rpiRobotics/ik-geo/blob/main/rust/src/inverse_kinematics/mod.rs
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.predicates import axis_parallel
+from ssik.solvers.ikgeo._univariate import search_1d_matched
+from ssik.subproblems import sp1, sp6
+
+__all__ = ["solve"]
+
+_SEARCH_SAMPLES = 200
+
+
+def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
+    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
+    c = float(np.cos(angle))
+    s = float(np.sin(angle))
+    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _wrap_to_pi(angle: float) -> float:
+    return float(((angle + np.pi) % (2 * np.pi)) - np.pi)
+
+
+def solve(
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> tuple[list[NDArray[np.float64]], bool]:
+    if len(kb.joints) != 6:
+        raise ValueError(f"two_parallel requires a 6-DOF chain; got {len(kb.joints)} joints")
+    if not axis_parallel(kb.joints[1].axis, kb.joints[2].axis, policy):
+        raise ValueError(
+            "two_parallel requires joints (1, 2) to be parallel; "
+            "they are not. Check the chain's topology."
+        )
+
+    axes = [j.axis for j in kb.joints]
+    p = [kb.joints[i].T_left[:3, 3].copy() for i in range(6)]
+    p.append(kb.joints[-1].T_right[:3, 3].copy())
+
+    r_home = kb.joints[-1].T_right[:3, :3]
+    t_target = np.asarray(T_target, dtype=np.float64)
+    r_06 = t_target[:3, :3] @ r_home.T
+    p_0t = t_target[:3, 3]
+
+    p_16 = p_0t - p[0] - r_06 @ p[6]
+
+    p2_norm = float(np.linalg.norm(p[2]))
+
+    def _branches_at(q1: float) -> list[tuple[tuple[float, float], float]]:
+        """At a given q1, return [((q6, q4), alignment_error), ...] for every
+        SP6 branch. Used by `search_1d_matched` to track geometric branches
+        across adjacent q1 samples by (q6, q4)-proximity rather than index.
+        """
+        r_01 = _rot_mat(axes[0], q1)
+        h1 = r_06.T @ r_01 @ axes[1]
+        sp_h = [h1, axes[1], h1, axes[1]]
+        sp_k = [-axes[5], axes[3], -axes[5], axes[3]]
+        sp_p = [p[5], p[4], axes[4], -axes[4]]
+        d1 = float(axes[1] @ (r_01.T @ p_16 - p[1] - p[2] - p[3]))
+        d2 = 0.0
+        sols, _ = sp6.solve(sp_h, sp_k, sp_p, d1, d2, policy)
+        branches: list[tuple[tuple[float, float], float]] = []
+        for q6, q4 in sols:
+            r_34 = _rot_mat(axes[3], q4)
+            r_56 = _rot_mat(axes[5], q6)
+            t23, _ = sp1.solve(
+                axes[1],
+                r_34 @ axes[4],
+                r_01.T @ r_06 @ r_56.T @ axes[4],
+                policy,
+            )
+            r_13 = _rot_mat(axes[1], t23)
+            delta = (
+                r_01.T @ p_16
+                - p[1]
+                - r_13 @ p[3]
+                - r_13 @ r_34 @ p[4]
+                - r_01.T @ r_06 @ r_56.T @ p[5]
+            )
+            err = float(np.linalg.norm(delta)) - p2_norm
+            branches.append(((q6, q4), err))
+        return branches
+
+    q1_and_branch = search_1d_matched(_branches_at, -np.pi, np.pi, _SEARCH_SAMPLES)
+
+    candidates: list[NDArray[np.float64]] = []
+    for q1, (q6, q4) in q1_and_branch:
+        r_01 = _rot_mat(axes[0], q1)
+        r_34 = _rot_mat(axes[3], q4)
+        r_56 = _rot_mat(axes[5], q6)
+
+        t23, _ = sp1.solve(
+            axes[1],
+            r_34 @ axes[4],
+            r_01.T @ r_06 @ r_56.T @ axes[4],
+            policy,
+        )
+        r_13 = _rot_mat(axes[1], t23)
+
+        delta = (
+            r_01.T @ p_16 - p[1] - r_13 @ p[3] - r_13 @ r_34 @ p[4] - r_01.T @ r_06 @ r_56.T @ p[5]
+        )
+        q2, _ = sp1.solve(axes[1], p[2], delta, policy)
+        q5, _ = sp1.solve(
+            -axes[4],
+            r_34.T @ axes[1],
+            r_56 @ r_06.T @ r_01 @ axes[1],
+            policy,
+        )
+        q3 = _wrap_to_pi(t23 - q2)
+        candidates.append(np.array([q1, q2, q3, q4, q5, q6]))
+
+    num_tol = policy.subproblem_numerical
+    dedup_tol = policy.subproblem_dedup
+    verified: list[NDArray[np.float64]] = []
+    for q in candidates:
+        if float(np.linalg.norm(_forward_kinematics(kb, q) - t_target)) < num_tol:
+            verified.append(q)
+
+    solutions: list[NDArray[np.float64]] = []
+    for q in verified:
+        if not any(_q_close(q, existing, dedup_tol) for existing in solutions):
+            solutions.append(q)
+
+    return solutions, len(solutions) == 0
+
+
+def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool:
+    for ai, bi in zip(a, b, strict=True):
+        diff = float(((float(ai) - float(bi) + np.pi) % (2 * np.pi)) - np.pi)
+        if abs(diff) > tol:
+            return False
+    return True
+
+
+def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        rot = np.eye(4)
+        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        T = T @ j.T_left @ rot @ j.T_right
+    return T

--- a/tests/test_ikgeo_two_parallel.py
+++ b/tests/test_ikgeo_two_parallel.py
@@ -1,0 +1,204 @@
+"""End-to-end validation for :mod:`ssik.solvers.ikgeo.two_parallel`.
+
+Tier-1 univariate-search solver for 6R arms with ``axes[1] || axes[2]``
+and no stronger wrist specialization. Same precision / completeness
+caveats as ``two_intersecting`` (see ``project_tier1_search_completeness.md``
+memory): ``search_1d``'s 200-sample grid can miss zero crossings at
+SP6-feasibility boundaries, so the solver may return fewer than the
+generic 8 IK solutions for random poses.
+
+What we do test:
+- every returned q reproduces T_target under FK at 1e-8,
+- topology refusal (wrong DOF, non-parallel joints 1,2).
+
+Fixtures are synthetic, following IK-Geo's own ``TwoParallelSetup``
+pattern (random unit axes with ``axes[2] = axes[1]`` + random offsets).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import two_parallel
+
+
+def _rodrigues(k: np.ndarray, t: float) -> np.ndarray:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: np.ndarray = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _axis_angle_4x4(k: np.ndarray, t: float) -> np.ndarray:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def _fk(kb: KinBody, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _axis_angle_4x4(j.axis, qi) @ j.T_right
+    return T
+
+
+def _build_random_two_parallel_arm(seed: int) -> KinBody:
+    """Follows IK-Geo's own TwoParallelSetup: 6 random unit axes with
+    axes[2] = axes[1] (the 'two parallel' constraint) and 7 random offsets."""
+    rng = np.random.default_rng(seed)
+
+    def _rnorm() -> np.ndarray:
+        v = rng.standard_normal(3)
+        return v / float(np.linalg.norm(v))
+
+    axes = [_rnorm() for _ in range(6)]
+    axes[2] = axes[1].copy()
+    t_lefts = [rng.standard_normal(3) for _ in range(6)]
+    tool_p = rng.standard_normal(3)
+
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        t_right_i = np.eye(4)
+        if i == 5:
+            t_right_i[:3, 3] = tool_p
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=t_right_i,
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+@pytest.fixture(scope="module")
+def synth_a() -> KinBody:
+    return _build_random_two_parallel_arm(seed=7)
+
+
+@pytest.fixture(scope="module")
+def synth_b() -> KinBody:
+    return _build_random_two_parallel_arm(seed=42)
+
+
+# ---------------------------------------------------------------------------
+# Returned-solution correctness: every q that the solver emits must FK-close
+# on T_target. Does not assert completeness (see module docstring).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", list(range(5)))
+def test_random_pose_returned_solutions_fk_match(synth_a: KinBody, seed: int) -> None:
+    """For each of 5 random poses on synth_a, all returned q's FK-match."""
+    rng = np.random.default_rng(seed + 1000)
+    q_star = rng.uniform(-np.pi + 0.3, np.pi - 0.3, 6)
+    T_star = _fk(synth_a, q_star)
+    solutions, is_ls = two_parallel.solve(synth_a, T_star)
+    # Tier-1 sparsity: solver may return 0 solutions on a pose even if a
+    # valid IK exists (search_1d misses crossings at SP6-feasibility
+    # boundaries). Both outcomes are "acceptable" for our correctness
+    # tests; what we verify is that *returned* solutions are correct.
+    if is_ls:
+        return
+    assert len(solutions) >= 1
+    for i, q in enumerate(solutions):
+        T_check = _fk(synth_a, q)
+        assert np.allclose(T_check, T_star, atol=1e-8), (
+            f"solution {i} fails FK: max|diff|={np.max(np.abs(T_check - T_star))}"
+        )
+
+
+@pytest.mark.parametrize("seed", list(range(3)))
+def test_second_synthetic_arm_returned_solutions_fk_match(synth_b: KinBody, seed: int) -> None:
+    """Same correctness check on a differently-seeded synth arm
+    (validates "generic, not geometry-specific")."""
+    rng = np.random.default_rng(seed + 2000)
+    q_star = rng.uniform(-np.pi + 0.3, np.pi - 0.3, 6)
+    T_star = _fk(synth_b, q_star)
+    solutions, is_ls = two_parallel.solve(synth_b, T_star)
+    if is_ls:
+        return
+    assert len(solutions) >= 1
+    for i, q in enumerate(solutions):
+        T_check = _fk(synth_b, q)
+        assert np.allclose(T_check, T_star, atol=1e-8), f"synth_b sol {i} fails FK"
+
+
+def test_solver_finds_at_least_one_solution_over_population(synth_a: KinBody) -> None:
+    """Over 20 random poses, the solver should find at least one valid IK
+    on *some* of them. This is a regression guard -- below the observed
+    baseline indicates the solver has become universally non-functional.
+
+    **Tier-1 sparsity baseline**: measured on this synth with 200
+    search_1d samples, ~15-30% of random non-singular poses yield at
+    least one valid IK. The rest fail because SP6's feasibility window
+    over q1 is narrow AND branch-index tracking across search_1d
+    samples is unstable -- SP6's (q6, q4) branches reorder between
+    adjacent q1 values, so the index-based crossing detection in
+    search_1d misses zeros. Proper geometric-continuity branch
+    tracking (instead of index-based) is a substantial rework tracked
+    separately (post-v0.1). Threshold below is set to catch regressions
+    into zero-completeness; see ``project_tier1_search_completeness.md``.
+    """
+    rng = np.random.default_rng(31415)
+    n_found = 0
+    n_total = 20
+    for _ in range(n_total):
+        q_star = rng.uniform(-np.pi + 0.3, np.pi - 0.3, 6)
+        T_star = _fk(synth_a, q_star)
+        solutions, is_ls = two_parallel.solve(synth_a, T_star)
+        if not is_ls and len(solutions) >= 1:
+            n_found += 1
+    # With geometric branch-matched search_1d (see _univariate.py),
+    # observed is 10-12/20 (~55%) at the time of writing. Floor at
+    # 7/20 (35%) guards against regressions; the remaining misses
+    # are poses where SP6 is infeasible across most of [-pi, pi] and
+    # branch-matching has no pairs to track.
+    assert n_found >= 7, (
+        f"solver found solutions in only {n_found}/{n_total} poses -- "
+        f"tier-1 completeness has regressed below the minimum threshold (7/20)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Topology refusal.
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_dof_raises(synth_a: KinBody) -> None:
+    short_kb = KinBody(links=synth_a.links[:5], joints=synth_a.joints[:4])
+    with pytest.raises(ValueError, match="6-DOF"):
+        two_parallel.solve(short_kb, np.eye(4))
+
+
+def test_wrong_topology_raises_non_parallel_shoulder() -> None:
+    """UR5 has three parallel axes (1,2,3), not just two -- should still
+    pass the two_parallel check because axes[1]||axes[2] holds. Use an
+    arm whose axes[1] is NOT parallel to axes[2]."""
+    from dataclasses import replace
+    from pathlib import Path
+
+    from ssik._urdf import load_urdf_kinbody_normalized
+
+    kb = load_urdf_kinbody_normalized(
+        Path(__file__).parent / "fixtures" / "ur5.urdf", "base_link", "ee_link"
+    )
+    # Break parallelism by setting axes[2] orthogonal to axes[1].
+    new_axis = np.array([1.0, 0.0, 0.0])
+    new_joint = replace(kb.joints[2], axis=new_axis)
+    broken_kb = KinBody(
+        links=kb.links,
+        joints=[new_joint if i == 2 else kb.joints[i] for i in range(6)],
+    )
+    with pytest.raises(ValueError, match="parallel"):
+        two_parallel.solve(broken_kb, np.eye(4))


### PR DESCRIPTION
## Summary

Second tier-1 solver per roster #53. Handles 6R chains with parallel joints (1, 2) and no stronger specialization. Algorithm: IK-Geo's \`two_parallel\` — 1D search over \`theta_0\` with inner SP6 coupling \`(q4, q6)\`.

## Key fix: geometric branch-matched search_1d

The straightforward port of IK-Geo Rust's \`search_1d\` produced **only ~15% completeness** on random poses because SP6's (q6, q4) branches reorder between adjacent q1 samples (quartic-root ordering isn't stable across LAPACK), breaking the index-based zero tracking.

**New \`_univariate.search_1d_matched\`**: tracks branches by wrap-to-π (q6, q4) proximity across samples instead of by index. Matches a current-sample branch to the closest previous-sample branch within a π/6 angular tolerance; only considers sign changes between genuinely-paired branches.

**Result**: completeness rises from ~15% to ~55% on IK-Geo-style random synth arms (10-12 out of 20 random poses yield valid IK).

The original index-based \`search_1d\` stays for \`two_intersecting\` which uses SP5 branches that track stably.

## Validation

- 5 hand-picked random poses + 3 second-arm poses: all returned solutions FK-match at 1e-8
- Population regression guard: 20 random poses must yield ≥7 with valid IK (observed 10-12)
- Topology refusal (wrong DOF, non-parallel joints 1,2)

Tier-1 completeness caveats still apply per \`project_tier1_search_completeness.md\` memory: the 45% of random poses yielding no solutions are those where SP6 is infeasible over nearly all of [-π, π].

## Verification

- [x] \`uv run pytest tests/\` — 246 passed, 4 slow deselected
- [x] \`uv run ruff check\`, \`uv run ruff format --check\`, \`uv run mypy\` — all green

Closes Round 2 of #53.