### PR TITLE
Tutorial rewrite: hands-on tour of ssik (#87)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,30 @@
 # ssik
 
-A pluggable analytical inverse-kinematics library for Python.
+Analytical inverse kinematics for Python, built around the **EAIK gap** — the arms whose IK isn't a one-line call against EAIK or IK-Geo.
 
-This site serves two audiences:
+For Pieper-class arms (UR5, Puma 560, Fanuc, KUKA KR, ABB IRB) ssik bundles tier-0 closed-form solvers ported from IK-Geo and runs them at ~50–200 µs warm-cache, machine-precision FK closure. For non-Pieper arms (Kinova JACO 2, Agilex Piper, Flexiv Rizon 4, custom geometries with no parallel/intersecting axis triples) ssik runs a tier-2 numeric **Raghavan–Roth + Manocha–Canny** pipeline at ~2.25 ms median warm-cache, FK error 3.7e-13, all branches at once. That tier-2 solver is what ssik adds to the ecosystem — analytical IK for the arms nobody else covers analytically.
 
-- **Users** who want a fast, closed-form IK solver in Python — start with the *Tutorial* (forthcoming) or jump to the *Reference*.
-- **Learners** who want to understand how analytic inverse kinematics actually works — the tutorial walks from first principles through the subproblem-decomposition and resultant-elimination algorithms the library uses under the hood.
+## Audience
+
+- **Users** wanting a fast, closed-form IK solver in Python — start with the [Practical guide](tutorial/09_practical_guide.md) or jump to the [Reference](reference/index.md).
+- **Learners** wanting to understand how analytic IK actually works — the [Tutorial](tutorial/index.md) walks from the IK problem through the Pieper class, the EAIK gap, the Raghavan–Roth pipeline, and the four robustness techniques (AE-1/3/4 plus Möbius reparameterization) that make the math survive on real arm geometries.
+- **Robotics implementers** porting analytical IK to a new arm family — Chapter 5 catalogs the conditioning patterns we ran into and how to recognise them in your own derivation.
+
+## What this is
+
+A Python-native analytical IK framework with a pluggable solver registry. Tier-0 subproblem-composition solvers (port of IK-Geo, BSD-3) ship by default. Tier-2 numeric Raghavan–Roth ships by default for the EAIK gap. Tier-1 univariate-search and tier-2 grid-search solvers are also bundled. Husty–Pfurner universal fallback and specialist 7R solvers (GeoFIK, stereographic-SEW) plug in via Python entry points without core patches.
+
+Unlike prior Python projects sharing the legacy `ikfastpy` name (e.g. [andyzeng/ikfastpy](https://github.com/andyzeng/ikfastpy), [yijiangh/ikfast_pybind](https://github.com/yijiangh/ikfast_pybind)), `ssik` is **not** a runtime wrapper around pre-generated C++. The solvers are pure Python + numpy; sympy is used for offline per-arm preprocessing (cached) and isn't on the runtime hot path.
 
 ## Status
 
-Pre-alpha, mid-rebuild. The original `ikfastpy` project (a port of OpenRAVE's IKFast) was renamed to `ssik` and is being rebuilt around the subproblem-decomposition approach. Implementation is tracked in the [GitHub issues](https://github.com/siddhss5/ikfastpy/issues); see the [umbrella rebuild issue](https://github.com/siddhss5/ikfastpy/issues/37) for the current architecture. The docs site you're reading is the framework — chapters land as the implementation lands.
+Pre-alpha, mid-rebuild. The original `ikfastpy` project (a port of OpenRAVE's IKFast) was renamed to `ssik` and is being rebuilt around the subproblem-decomposition + Raghavan–Roth approach. Implementation is tracked in the [GitHub issues](https://github.com/siddhss5/ikfastpy/issues). Recent landings:
 
-## What this is not
-
-Unlike prior Python projects sharing the legacy name (e.g. [andyzeng/ikfastpy](https://github.com/andyzeng/ikfastpy), [yijiangh/ikfast_pybind](https://github.com/yijiangh/ikfast_pybind)), `ssik` is **not** a runtime wrapper around pre-generated C++. It is a Python-native analytical IK framework with a pluggable solver registry: subproblem decomposition as the primary tier, Husty-Pfurner as a universal analytical fallback, and specialist solvers (GeoFIK, stereographic-SEW, and future algorithms) plug in via entry-points without core patches.
+- Real Kinova JACO 2 j2n6s200 fixture transcribed from MJCF (#80).
+- `Solution` dataclass + universal `ssik.refinement` opt-in Newton-polish layer (#74, #75).
+- POE → DH bridge with the `T_pre` fix that broke on JACO 2 (#79).
+- Speed Tier 1/2.x: per-arm `poe_to_dh` cache + drop redundant POE-FK + per-pose pinv cache + vectorised eigenvalue filter (#86 PRs #88, #89, #90). Median JACO 2 IK: 4.5 ms → **2.25 ms**.
 
 ## Acknowledgements
 
-The rebuild draws on the subproblem-decomposition approach of Elias & Wen ([IK-Geo](https://arxiv.org/abs/2211.05737), 2024), Ostermeier ([EAIK](https://arxiv.org/abs/2409.14815), 2024), and Husty & Pfurner (2007). The vendored IKFast tree originates from Rosen Diankov's work at Carnegie Mellon University; see the [Bibliography](bibliography.md) for the primary sources.
+The rebuild draws on the subproblem-decomposition approach of Elias & Wen ([IK-Geo](https://arxiv.org/abs/2211.05737), 2022/2025), Ostermeier ([EAIK](https://arxiv.org/abs/2409.14815), 2024), and Husty & Pfurner (2007), and on the algebraic-elimination pipeline of Raghavan & Roth (1990) + Manocha & Canny (1994). The vendored IKFast tree (slated for removal in [#84](https://github.com/siddhss5/ikfastpy/issues/84)) originates from Rosen Diankov's work at Carnegie Mellon. See the [Bibliography](bibliography.md) for primary sources.

--- a/docs/tutorial/01_ik_problem.md
+++ b/docs/tutorial/01_ik_problem.md
@@ -1,0 +1,58 @@
+# 1. The IK problem
+
+A robot arm has $n$ joints. Each joint has a single scalar angle $q_i \in \mathbb{R}$. The configuration $q = (q_1, \ldots, q_n)$ determines, via a deterministic chain of rigid transforms, the pose of the end effector:
+
+$$
+T = \mathrm{FK}(q) \in \mathrm{SE}(3).
+$$
+
+That is **forward kinematics**: configuration $\to$ pose. It is straightforward, fast, and unique.
+
+The inverse — **inverse kinematics** — asks the dual question. Given a target pose $T^\star$, what configurations $q$ satisfy $\mathrm{FK}(q) = T^\star$?
+
+For a 6-DOF arm reaching a 6-DOF target ($\mathrm{SE}(3)$ has six dimensions: three translation, three rotation), this is generically solvable but typically has **multiple discrete solutions** — up to 16 for a generic 6R chain — corresponding to different elbow / wrist / shoulder branchings. For 7-DOF and higher, there is a continuous redundancy manifold of solutions: every target pose has infinitely many configurations realising it.
+
+## Numeric vs analytic IK
+
+There are two solution strategies, and they differ in what they ask the user to give up.
+
+**Numeric IK** treats $\mathrm{FK}(q) - T^\star$ as a residual to drive to zero with iterative methods — Newton on the spatial Jacobian, damped least squares, gradient descent on a manifold-aware loss. Tools: TRAC-IK, KDL, mink. They handle anything: arbitrary arm topology, joint limits, redundancy. The price is iterative cost (50–200 µs per IK on a tuned implementation; 1–10 ms on Python wrappers), local-minimum risk near singularities, and a single returned solution rather than the full set of branches. They never tell you up front whether the target is reachable.
+
+**Analytic IK** writes the loop-closure equations algebraically and solves them in closed form. Output: every solution at once, with a clear "no real roots ⇒ unreachable" signal. Cost: nanoseconds-to-milliseconds depending on the algorithm. Catch: **the algorithm is arm-specific**. A solver that handles UR5 might not handle JACO 2, and the closed form needs derivation per kinematic family.
+
+This tutorial is about the analytic side. ssik is an analytic IK library.
+
+## The analytical-IK ecosystem
+
+Three families of tools share this corner of the field:
+
+**IKFast** (Diankov 2010, OpenRAVE). Per-robot symbolic codegen. You feed it a kinematic chain, it grinds for hours/days, emits a single C++ file specialised to that arm. Fast at runtime, brittle in derivation: the symbolic pipeline depends on a 2010-vintage sympy and the modern sympy / mpmath stack causes `polyroots NoConvergence` on real arms (UR5, Puma-with-tiny-d, JACO 2). It's not maintained. The vendored copy in this repo's `_legacy/` is an artifact of an earlier resuscitation attempt.
+
+**EAIK** (Ostermeier et al., 2024) and **IK-Geo** (Elias & Wen, 2022). Subproblem-composition closed-form solvers covering Pieper-class arms — those with three consecutive intersecting wrist axes, or three consecutive parallel shoulder axes, or both. Six canonical subproblems (SP1–SP6), each a closed-form circular geometry intersection, compose into per-family analytic IK. Industrial 6R arms — UR3/5/10, Puma 560, Fanuc, KUKA KR, ABB IRB — are all Pieper-class. EAIK and IK-Geo handle them in roughly 0.2 ms with machine-precision closure. **Chapter 2 of this tutorial walks through how this works.**
+
+**Numeric solvers** as above. Strong fallback when no analytic family applies.
+
+ssik bundles tier-0 closed-form solvers ported from IK-Geo (so it covers the same Pieper-class arms EAIK does), and adds a **tier-2 numeric Raghavan–Roth solver** that closes the gap on non-Pieper arms — the EAIK gap. That's the part of the library that didn't already exist.
+
+## What ssik solves that the alternatives don't
+
+The arms whose IK isn't already a one-liner against EAIK or IK-Geo:
+
+- **Kinova JACO 2 (j2n6s200)**: 60° non-orthogonal twists at joints 4–5. No three consecutive intersecting axes. No parallel pair. Subproblem composition's prerequisite geometric specialisations don't apply.
+- **Agilex Piper**: similar gap.
+- **Flexiv Rizon 4**: a 7-DOF non-SRS arm. Joint-locking turns it into a 6R per lock value, but the sub-chain is still non-Pieper.
+- **Custom geometries** that arise from machined-from-scratch arms or kinematic prototyping.
+
+For these, neither closed-form subproblem composition (no specialisation matches) nor IKFast (its symbolic codegen breaks on these chains) gets you analytic IK. Numeric IK works but pays the iterative cost and gives you one solution, not all branches.
+
+ssik's contribution is making the **Raghavan–Roth 1990 / Manocha–Canny 1994** algebraic-elimination pipeline survive on real arms — single-digit-millisecond latency, all branches at once, machine-precision FK closure. Doing this required four independent robustness fixes against ill-conditioning that the textbook algorithm doesn't survive. **Chapter 4** walks the math; **Chapter 5** walks the robustness. Together they describe what's actually shipping.
+
+## What this tutorial assumes
+
+Working knowledge of:
+
+- 4×4 homogeneous transforms and rotation matrices.
+- DH parameters or Product-of-Exponentials (POE) — we use POE as the canonical input format and convert to DH internally; either notation is fine for following along.
+- Eigenvalue / eigenvector basics. Singular value decomposition shows up briefly.
+
+The math here is approachable from a robotics-aware undergraduate background; the harder material lives in the robustness (Chapter 5) and is presented with the runtime intuition rather than a formal numerical-analysis treatment.

--- a/docs/tutorial/02_pieper_subproblems.md
+++ b/docs/tutorial/02_pieper_subproblems.md
@@ -1,0 +1,31 @@
+# 2. The Pieper class and subproblem composition
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in. This chapter covers the analytical-IK ground that EAIK / IK-Geo already handle elegantly — necessary background but not the part of ssik that's novel. See [`src/ssik/subproblems/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/subproblems/) and [`src/ssik/solvers/ikgeo/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/) for the implementation.
+
+## What this chapter covers
+
+- **Pieper's condition (1968):** a 6-DOF arm with three consecutive intersecting axes admits closed-form IK. Decouples wrist orientation from elbow position.
+- **The six canonical subproblems (Paden–Kahan, Elias–Wen):**
+  - **SP1** — `axis k`, vector `p` rotated to align with vector `q`. Single angle `θ`.
+  - **SP2** — two sequential rotations to align `p` with `q`. Two angles, up to 2 solutions.
+  - **SP3** — distance constraint: rotate `p` around `k` to be at distance $d$ from origin. Up to 2 solutions.
+  - **SP4** — projection: $k_2 \cdot \mathrm{Rot}(k_1, \theta) p = h$. Up to 2 solutions.
+  - **SP5** — three sequential rotations placing `p_0 + R_1 p_1 + R_2 p_2 = -p_3`. Quartic, up to 4 solutions.
+  - **SP6** — two pairs of subproblem-4 conditions. Bezout quartic, up to 4 solutions.
+- **Compositions:** how the per-family ssik solvers chain SP1–SP6 to produce 8-solution closed-form IK:
+  - `ikgeo.three_parallel` (UR5, UR10): SP6 + SP1 × 4 + SP3.
+  - `ikgeo.spherical_two_parallel` (Puma 560, Fanuc, KUKA KR): SP4 + SP3 + SP1 + SP4 + SP1 × 2.
+  - `ikgeo.spherical_two_intersecting` (Puma 560 alt., compact arms): SP3 + SP2 + SP4 + SP1 × 2.
+  - `ikgeo.spherical` (generic spherical wrist): SP5 + SP4 + SP1 × 2.
+  - `ikgeo.two_parallel`, `ikgeo.two_intersecting`: tier-1 univariate-search 6R.
+- **Cost note:** these solvers run in 50-200 µs warm-cache (with sub-millisecond first-call cost). Pieper-class arms are basically a closed problem.
+- **Cross-solver agreement on Puma 560:** Puma satisfies *both* `spherical_two_parallel`'s and `spherical_two_intersecting`'s preconditions; the two algebraically-distinct compositions return the same 8-solution set on every pose. This is the strongest correctness guarantee available — see [Chapter 8](08_bulletproof.md).
+- **What Pieper *doesn't* cover:** non-Pieper 6R (no axis triple parallel or intersecting). That's the EAIK gap, addressed in [Chapter 3](03_eaik_gap.md) onward.
+
+## References
+
+- Pieper, D. L. (1968). PhD thesis, Stanford.
+- Paden, B. (1986). PhD thesis, UC Berkeley.
+- Elias, A. & Wen, J. (2022/2025). "IK-Geo: unified robot inverse kinematics using subproblem decomposition." [arXiv:2211.05737](https://arxiv.org/abs/2211.05737).
+- Ostermeier, D. (2024). "EAIK: a Toolbox for Efficient Analytical Inverse Kinematics." [arXiv:2409.14815](https://arxiv.org/abs/2409.14815).

--- a/docs/tutorial/03_eaik_gap.md
+++ b/docs/tutorial/03_eaik_gap.md
@@ -1,0 +1,37 @@
+# 3. The EAIK gap
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in.
+
+## What this chapter covers
+
+The arms whose IK is **not** a one-line call against EAIK or IK-Geo, and why the obvious workarounds don't work.
+
+### Arms outside the Pieper class
+
+- **Kinova JACO 2 (j2n6s200):** 60° non-orthogonal twists at joints 4–5. The quat=(0, 0, 0.5, 0.866) rotation between consecutive wrist links means no two wrist axes intersect, no axis triple is parallel, and the standard subproblem compositions all fail their preconditions. Real fixture in [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py), transcribed from `robot-code/ada_assets/.../jaco2.xml` MJCF (#80).
+- **Agilex Piper:** similar non-Pieper geometry.
+- **Flexiv Rizon 4:** 7-DOF non-SRS arm. Joint-locking turns it into a 6R per lock value, but the resulting sub-chain is non-Pieper at every lock value.
+- **Custom geometries** from machined-from-scratch arms or kinematic prototyping.
+
+### Why the obvious approaches don't work
+
+- **Subproblem composition (EAIK / IK-Geo):** the geometric specialisations (three intersecting wrist axes, three parallel shoulder axes) never apply. SP5's polynomial setup has structural degeneracy on these chains.
+- **IKFast (Diankov 2010):** its symbolic codegen pipeline depends on a 2010-vintage sympy that doesn't exist anymore. Modern sympy + mpmath stack causes `polyroots NoConvergence` at substitution / `solveLiWoernleHiller` time. Verified on real arms — UR5 (797s before failure on cambel URDF), Puma-with-d5=0.01 (617s, NoConvergence), JACO 2. Hours-to-days of derivation on cases where it works at all. The vendored `_legacy/` tree is a museum piece.
+- **Numeric IK (mink, KDL, TRAC-IK):** works but pays the iterative cost, returns one solution rather than the full branch set, and gives no up-front "unreachable" signal. Mink at ~20 ms per call versus ssik's ~2.25 ms median on JACO 2 (post-Tier 2.3 of #86).
+
+### What this means for ssik's design
+
+- **ssik bundles tier-0/1 closed-form solvers** for the Pieper-class arms (covered by EAIK / IK-Geo), so you don't pay the tier-2 cost when you don't need to.
+- **ssik's tier-2 numeric Raghavan–Roth solver** ([Chapter 4](04_raghavan_roth.md)) handles the gap arms.
+- **The dispatcher** picks the right tier per kb at registration time; users call `solve(kb, T)` and don't think about it.
+
+### The strategic frame
+
+EAIK / IK-Geo cover the easy 80% of commercial arms. ssik covers the harder 20% — the EAIK gap. That's where a millisecond-level analytical IK solution didn't exist before. Memory entry [`project_eaik_gap_strategy`](https://github.com/siddhss5/ikfastpy/issues/78) covers the strategic positioning.
+
+## References
+
+- Raghavan, M. & Roth, B. (1990). "Inverse kinematics of the general 6R manipulator and related linkages." *J. Mech. Design*.
+- Manocha, D. & Canny, J. F. (1994). "Efficient inverse kinematics for general 6R manipulators." *IEEE T-RA* 10(5):648–657.
+- Tsai, L.-W. (1999). *Robot Analysis: The Mechanics of Serial and Parallel Manipulators.* Wiley. Appendix C.

--- a/docs/tutorial/04_raghavan_roth.md
+++ b/docs/tutorial/04_raghavan_roth.md
@@ -1,0 +1,208 @@
+# 4. Raghavan–Roth in 8 stages
+
+The tier-2 numeric solver ssik ships for non-Pieper 6R arms is a clean-room port of the **Raghavan–Roth 1990 / 1993** algebraic-elimination pipeline plus the **Manocha–Canny 1994** companion-matrix eigenvalue route. The math is dense but each stage is a well-defined linear-algebra step. This chapter walks through the algorithm one stage at a time, with code pointers into the implementation in [`src/ssik/solvers/ikgeo/_raghavan_roth.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+The next chapter, [Conditioning is the hard part](05_conditioning.md), covers the four robustness fixes (AE-1, AE-3, AE-4, Möbius reparameterization) that are necessary for the textbook algorithm to survive on real ill-conditioned arms like JACO 2. Read this chapter first; it sets up the language those fixes use.
+
+## Setup
+
+A 6R serial chain in standard distal-DH form has six joint transforms
+
+$$
+A_i(\theta_i) = R_z(\theta_i)\, T_z(d_i)\, T_x(a_i)\, R_x(\alpha_i), \qquad i = 1, \ldots, 6,
+$$
+
+where $(\alpha_i, a_i, d_i)$ are the per-link DH parameters and $\theta_i$ is the joint angle for joint $i$. The forward-kinematics map is
+
+$$
+\mathrm{FK}(\theta_1, \ldots, \theta_6) = A_1 A_2 A_3 A_4 A_5 A_6.
+$$
+
+Given a target pose $T \in \mathrm{SE}(3)$, IK asks: find every $(\theta_1, \ldots, \theta_6)$ with $\mathrm{FK} = T$.
+
+Algebraically the equation $A_1 \cdots A_6 = T$ is six trig equations (12 if you count the redundant rotation entries) in six unknowns. The Raghavan–Roth strategy is **rearrange the loop closure so the unknowns split unevenly across the two sides, then eliminate the cluttered side via linear algebra**.
+
+We split as
+
+$$
+A_2 A_3 A_4 = A_1^{-1}\, T\, A_5^{-1} A_6^{-1}.
+$$
+
+The left-hand side depends on $\theta_2, \theta_3, \theta_4$. The right-hand side depends on $\theta_1, \theta_5, \theta_6$. Each side is a $4 \times 4$ matrix; equality gives a system of equations in the six unknowns.
+
+## Stage 1 — The 14-equation $(P, Q)$ system
+
+Take three specific column entries and three specific dot products of the matrix equation and you get **14 polynomial equations** that factor as
+
+$$
+(P_{\sin}\, s_{q_2} + P_{\cos}\, c_{q_2} + P_{\mathrm{one}})\, v_{\mathrm{left}}(q_3, q_4) = Q\, v_{\mathrm{right}}(q_0, q_1).
+$$
+
+where $s_{q_i} = \sin q_i$, $c_{q_i} = \cos q_i$. Here we've renamed so $q_0, \ldots, q_5$ are the joint variables (this is the convention in the code; $\theta_i$ from the setup section maps to $q_{i-1}$). The structure is:
+
+- $P_{\sin}, P_{\cos}, P_{\mathrm{one}}$ are each $14 \times 9$ matrices whose entries are polynomial in the DH parameters and the target pose $T$.
+- $v_{\mathrm{left}}(q_3, q_4)$ is the **bilinear monomial vector** in $(s_3, c_3, s_4, c_4)$:
+
+  $$
+  v_{\mathrm{left}} = (s_3 s_4,\; s_3 c_4,\; c_3 s_4,\; c_3 c_4,\; s_3,\; c_3,\; s_4,\; c_4,\; 1)^T \in \mathbb{R}^9.
+  $$
+
+- $v_{\mathrm{right}}(q_0, q_1) \in \mathbb{R}^8$ is the analogous bilinear-monomial vector in $(s_0, c_0, s_1, c_1)$ but without the constant term.
+- $Q$ is a $14 \times 8$ matrix of DH × target-pose entries. **Constant per pose.**
+
+The reason the equations factor this way is the Raghavan–Roth choice of which scalar combinations of the matrix equation to extract — it is engineered so that $q_0$ and $q_1$ live entirely on the right-hand side, $q_3$ and $q_4$ live entirely on the left, and the two are linked only through $q_2$ (which appears as the linear $s_{q_2}, c_{q_2}$ coefficients) and $q_5$ (which has been eliminated entirely from the columns we extracted — that's the role of the loop split $A_2 A_3 A_4 = A_1^{-1} T A_5^{-1} A_6^{-1}$).
+
+In code: [`build_pq`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) returns $(P_{\sin}, P_{\cos}, P_{\mathrm{one}}, Q, \mathrm{metadata})$. The matrices are derived symbolically once per arm (cached in `_cached_derivation` via `lru_cache` on the DH tuple) and then evaluated at the target pose by lambdified callables — sympy at module-import time, pure numpy at runtime.
+
+## Stage 2 — Eliminate $(q_0, q_1)$ via the left null space of $Q$
+
+$Q$ is $14 \times 8$ with full column rank 8 generically. Its **left null space** has dimension 6: there exist 6 row vectors $n_1, \ldots, n_6 \in \mathbb{R}^{14}$ with $n_i^T Q = 0$.
+
+Multiplying both sides of the (P, Q) system on the left by these null-space rows kills the $Q v_{\mathrm{right}}$ side entirely:
+
+$$
+n_i^T (P_{\sin}\, s_{q_2} + P_{\cos}\, c_{q_2} + P_{\mathrm{one}})\, v_{\mathrm{left}} = 0, \qquad i = 1, \ldots, 6.
+$$
+
+Stacking the six $n_i$ as rows of $N \in \mathbb{R}^{6 \times 14}$, we get an **eliminated 6×9 system** $E$:
+
+$$
+E_{\sin}\, s_{q_2} + E_{\cos}\, c_{q_2} + E_{\mathrm{one}} = N (P_{\sin}\, s + P_{\cos}\, c + P_{\mathrm{one}}),
+$$
+
+with $E_{\bullet} \in \mathbb{R}^{6 \times 9}$, all dependent on $q_2$ alone (in the $s_{q_2}, c_{q_2}$ coefficients) and acting on $v_{\mathrm{left}}(q_3, q_4)$.
+
+The left null space is computed via SVD of $Q$: $Q = U \Sigma V^T$, with $U \in \mathbb{R}^{14 \times 14}$. The left null space rows are the rows of $U^T$ corresponding to the eight zero (or near-zero) singular values. In code: [`eliminate_q0_q1`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) computes this and returns $(E_{\sin}, E_{\cos}, E_{\mathrm{one}})$.
+
+After Stage 2 we have **6 equations in 3 unknowns $(q_2, q_3, q_4)$** — over-determined, exactly what we want.
+
+## Stage 3 — Half-angle (Weierstrass) substitution and basis change
+
+The standard Weierstrass substitution
+
+$$
+x = \tan(q/2), \qquad \sin q = \frac{2x}{1 + x^2}, \qquad \cos q = \frac{1 - x^2}{1 + x^2}
+$$
+
+turns trig polynomials into rational polynomials. Apply it to all three remaining angles, multiply through by the appropriate $(1 + x_i^2)$ to clear denominators, and the system becomes a **polynomial system in $(x_2, x_3, x_4)$**.
+
+We then reorganise the basis of $v_{\mathrm{left}}$. After Weierstrass on $q_3$ and $q_4$, the original 9-monomial $v_{\mathrm{left}}$ basis becomes a 12-monomial basis in $(x_3, x_4)$:
+
+$$
+v_{12} = (x_3^2 x_4^2,\; x_3^2 x_4,\; x_3^2,\; x_3 x_4^2,\; x_3 x_4,\; x_3,\; x_4^2,\; x_4,\; 1,\; x_3 x_4^2,\; x_3 x_4,\; x_3)^T \in \mathbb{R}^{12}.
+$$
+
+(The last three rows duplicate three of the earlier rows multiplied by $x_3$. This redundancy is intentional — it gives the next stage the right shape.)
+
+Apply Weierstrass on $q_2$ also: each row that was $E_{\sin}\, s_2 + E_{\cos}\, c_2 + E_{\mathrm{one}}$ becomes a quadratic in $x_2$ after multiplying by $(1 + x_2^2)$:
+
+$$
+\text{quadratic-in-}x_2\text{ coefficient}\cdot x_2^2 \;+\; \text{linear-in-}x_2\cdot x_2 \;+\; \text{constant}.
+$$
+
+So we now have **6 equations $\times$ 12 monomials, polynomial-in-$x_2$ of degree $\le 2$**. In code: [`weierstrass_eliminate_trig`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+## Stage 4 — Build $M(x_2)$, the $12 \times 12$ polynomial matrix pencil
+
+The elimination so far gives 6 equations in 12 monomials. We need 12 to invert. The trick: stack the system with a **shifted copy** that multiplies the same equations by $x_3$:
+
+$$
+M(x_2) = \begin{bmatrix} E'' & 0 \\ 0 & E'' \cdot x_3 \end{bmatrix}_{12 \times 12} \cdot v_{12} = 0,
+$$
+
+written in matrix form as
+
+$$
+M(x_2)\, v_{12} = (A x_2^2 + B x_2 + C)\, v_{12} = 0,
+$$
+
+with $A, B, C \in \mathbb{R}^{12 \times 12}$ all numeric (the stage-3 outputs $E_{\mathrm{quad}}, E_{\mathrm{lin}}, E_{\mathrm{const}}$ stacked according to the shift construction). This is a **quadratic eigenvalue problem**: find $x_2$ such that $M(x_2)$ is singular and read off the corresponding kernel vector $v_{12}$.
+
+The polynomial $\det M(x_2)$ has degree 24 in $x_2$. Of those 24 roots, 8 are spurious (clustered near $x_2 = \pm i$ from the $(1 + x_2^2)^4$ factor introduced by Weierstrass on $q_2$). The remaining **16 are the candidate $\tan(q_2/2)$ values** — corresponding to the 16 IK branches a generic 6R chain admits.
+
+In code: [`build_m_matrix`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+## Stage 5 — Companion matrix and 24-eigenvalue route
+
+A quadratic eigenvalue problem $(A x^2 + B x + C) v = 0$ linearises into a standard eigenvalue problem on a $24 \times 24$ companion matrix:
+
+$$
+\Sigma = \begin{bmatrix} 0_{12} & I_{12} \\ -A^{-1} C & -A^{-1} B \end{bmatrix}, \qquad
+\Sigma \begin{bmatrix} v \\ x v \end{bmatrix} = x \begin{bmatrix} v \\ x v \end{bmatrix}.
+$$
+
+The 24 eigenvalues of $\Sigma$ are the 24 roots of $\det M(x_2)$. The 24-component eigenvector has block structure $(v;\, x v)$ — the top half is the $v_{12}$ kernel of $M(x_2)$.
+
+We compute $\Sigma$ from $A, B, C$, run `np.linalg.eig`, and filter:
+
+1. Drop eigenvalues clustered near $\pm i$ (spurious from the Weierstrass factor) — controlled by `spurious_tol`.
+2. Drop eigenvalues whose imaginary part exceeds `imag_rel_tol * max(|real|, 1)` — they correspond to complex IK solutions, not physical.
+3. The surviving real eigenvalues are the candidate $x_2 = \tan(q_2/2)$ values; corresponding eigenvectors are the $v_{12}$ kernels.
+
+In code: [`solve_x2_roots`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py). The fallback path [`solve_x2_roots_mobius`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) handles ill-conditioned $A$ via reparameterization (covered in [Chapter 5](05_conditioning.md)).
+
+This is the most expensive single operation in the pipeline (~250 µs of LAPACK `dgeev` time on a 24×24 dense matrix; see #86 for ongoing speed work).
+
+## Stage 6 — Back-substitute: eigenvector to $(q_3, q_4)$ and then to $(q_0, q_1, q_5)$
+
+We have $x_2$ (one root) and $v_{12}$ (its 12-component kernel). We need to extract the remaining angles.
+
+**$(q_3, q_4)$ from $v_{12}$:** the monomial structure tells us each entry of $v_{12}$ is one of $\{x_3, x_4, x_3^2, \ldots\}$ times another. So various pairs of entries have ratio equal to $x_3$ or $x_4$:
+
+$$
+v_{12}[5] / v_{12}[8] = x_3, \quad v_{12}[7] / v_{12}[8] = x_4, \quad v_{12}[2] / v_{12}[5] = x_3, \ldots
+$$
+
+Multiple equivalent ratios exist. Per Manocha–Canny §IV-C, **picking the ratio whose denominator has largest magnitude** is the numerically safe choice — when an eigenvector is unit-normalised, small entries in the denominator amplify error. Implementation: search through a list of redundant ratio pairs, take the one with biggest denominator. From $x_3, x_4$ we recover $q_3 = 2 \arctan x_3$ and $q_4 = 2 \arctan x_4$.
+
+**$(q_0, q_1)$ from $v_{\mathrm{right}}$:** with $q_2, q_3, q_4$ known, the right-hand side $Q v_{\mathrm{right}}$ of the original Stage 1 equation has fully determined left-hand side. Solve
+
+$$
+v_{\mathrm{right}} = Q^+\, (P_{\mathrm{eff}}(q_2)\, v_{\mathrm{left}}(q_3, q_4))
+$$
+
+where $Q^+$ is the pseudo-inverse and $P_{\mathrm{eff}}(q_2) = P_{\sin} s_2 + P_{\cos} c_2 + P_{\mathrm{one}}$. Read $(\sin q_0, \cos q_0)$ and $(\sin q_1, \cos q_1)$ from the appropriate entries of $v_{\mathrm{right}}$ and recover the angles via `atan2`.
+
+(The pinv of $Q$ is **shared across all eigenvalue branches** — it's identical for every branch of the same target pose. ssik computes it once per pose and reuses; this is one of the [Tier 2 speed wins](https://github.com/siddhss5/ikfastpy/pull/89) on #86.)
+
+**$q_5$ (drop joint) from FK closure:** with $q_0, q_1, q_2, q_3, q_4$ known, the only unknown left is $q_5$. Compute the chain before joint 5 and after joint 5; solve
+
+$$
+A_5(q_5) = \mathrm{chain\_before}^{-1}\, T\, \mathrm{chain\_after}^{-1}
+$$
+
+The standard DH form $A_5 = R_z(q_5) T_z(d_5) T_x(a_5) R_x(\alpha_5)$ puts $(c_5, s_5)$ in column 0 rows 0,1 of the result. Read off $q_5 = \mathrm{atan2}(A_5[1,0], A_5[0,0])$.
+
+In code: [`back_substitute`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) (public wrapper) and [`_back_substitute_inner`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) (hot path with precomputed $Q^+$).
+
+## Stage 7 — FK validation and Newton polish (optional)
+
+Each candidate $q$ from Stage 6 is checked against $T$ by FK closure:
+
+$$
+\mathrm{fk\_residual} = \|\mathrm{FK}(q) - T\|_F.
+$$
+
+For a **well-conditioned** arm (say UR5), the algebraic precision is at machine epsilon — typical residual $\sim 10^{-13}$. Candidates pass the `fk_atol` gate (default $10^{-5}$) trivially.
+
+For an **ill-conditioned** arm (JACO 2 with the wrong leftvar choice; see Chapter 5), eigenvalue precision degrades and candidates may have residual $\sim 10^{-3}$. The default policy is to **drop those candidates**: ssik enforces an algebraic-first contract (see [Chapter 6](06_refinement.md)) where pure-algebraic precision is required by default. Users who explicitly opt in via `allow_refinement=True` get a Newton-on-spatial-Jacobian polish ([`lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py)) that converges 1–5 iterations from a near-miss algebraic seed; the resulting `Solution.refinement_used = "lm"` and `refinement_iters = 3` (or whatever) tell the caller exactly what fired.
+
+## Stage 8 — Deduplicate and return
+
+Different eigenvalue branches can map to the same IK solution mod $2\pi$ (especially on degenerate poses). Final deduplication: collapse solutions whose joint vectors agree wrap-to-π within `dedup_atol` (default $10^{-3}$ rad), keeping the lower-`fk_residual` representative.
+
+The public driver [`solve_all_ik`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) returns `tuple[list[Solution], bool]`: a deduplicated list of `Solution` dataclasses (each carrying `q`, `fk_residual`, `refinement_used`, `refinement_iters`, `branch_id`, `solver_name`) and an `is_ls` flag indicating whether at least one candidate survived.
+
+## Why this pipeline works
+
+The algebraic miracle is Stage 1's loop split: the choice $A_2 A_3 A_4 = A_1^{-1} T A_5^{-1} A_6^{-1}$ — combined with the choice of which 14 scalar combinations of the matrix equation to extract — produces a system that's:
+
+- **Linear in the joint variables on each side** (after Weierstrass): each joint contributes a $\sin/\cos$ pair, the bilinears are quadratic, and $q_5$ is eliminated entirely from the columns we keep.
+- **Decoupled** across the two sides: $(q_0, q_1)$ on the right, $(q_3, q_4)$ on the left, $q_2$ as the bridge.
+- **Eliminable** via SVD on $Q$: the right side disappears in a single linear-algebra step.
+
+Manocha–Canny's contribution was recognising that the resulting quadratic eigenvalue problem in $x_2$ linearises cleanly to a 24×24 companion matrix, and the 16 valid roots of $\det M = 0$ are the IK branches.
+
+The whole pipeline is, structurally, a sequence of well-understood linear-algebra primitives: SVD (Stage 2), polynomial substitution (Stage 3), block matrix assembly (Stage 4), companion matrix eigendecomposition (Stage 5), pseudo-inverse and `atan2` (Stage 6). At Python-LAPACK speeds, ssik runs the whole thing in roughly 2.25 ms median per IK on JACO 2 (post-Tier 2.3 of [#86](https://github.com/siddhss5/ikfastpy/issues/86)).
+
+What makes this hard is that several of those primitives become numerically unstable on real arm geometries that produce nearly-singular $A$ in Stage 4. The next chapter covers why, and the four independent attacks ssik ships to handle it.

--- a/docs/tutorial/05_conditioning.md
+++ b/docs/tutorial/05_conditioning.md
@@ -1,0 +1,148 @@
+# 5. Conditioning is the hard part
+
+The Raghavan–Roth pipeline of [Chapter 4](04_raghavan_roth.md) is a sequence of linear-algebra primitives. Run it on a textbook 6R arm with well-separated DH parameters and you get machine-precision IK. Run it on a real arm — Kinova JACO 2 with 60° non-orthogonal twists at joints 4–5 — and the textbook algorithm produces garbage: candidates with FK residual $\sim 10^{0}$ instead of $\sim 10^{-13}$, an algebraic precision floor 12 orders of magnitude looser than expected.
+
+This chapter explains why, and walks through the four independent fixes ssik ships to make the pipeline survive on real arms. The fixes are tagged **AE-1** through **AE-6** in the codebase and issue tracker — analytical-exhaustion measures meant to wring every order of magnitude of conditioning improvement out of the algebraic structure before the algorithm gives up and falls back to numerical refinement.
+
+## The failure mode: a singular pencil
+
+Stage 4 of the pipeline builds the matrix pencil
+
+$$
+M(x_2) = A x_2^2 + B x_2 + C, \qquad A, B, C \in \mathbb{R}^{12 \times 12},
+$$
+
+and Stage 5 linearises to the $24 \times 24$ companion
+
+$$
+\Sigma = \begin{bmatrix} 0 & I \\ -A^{-1} C & -A^{-1} B \end{bmatrix}.
+$$
+
+The construction requires $A$ to be **invertible**. If $A$ is rank-deficient, $A^{-1}$ doesn't exist and the companion construction fails. If $A$ is invertible but **ill-conditioned** (large $\kappa(A) = \sigma_{\max}/\sigma_{\min}$), the inverse exists numerically but amplifies floating-point noise: every digit of $\kappa$ above $10^0$ is roughly a digit of precision lost in $A^{-1} B$ and $A^{-1} C$. With double-precision floats giving us 16 digits of machine epsilon, $\kappa(A) > 10^{16}$ means the construction has zero correct digits.
+
+On JACO 2 with the textbook leftvar choice (linearity = $q_2$, the convention in Manocha–Canny 1994), measured values are:
+
+| metric | textbook (linearity $= q_2$) | what we want |
+|---|---|---|
+| $\kappa(A)$ | $3.75 \times 10^{16}$ | $\le 10^{10}$ |
+| algebraic FK error (median) | $\sim 10^{0}$ | $\sim 10^{-13}$ |
+| pose-level success rate | $\sim 5\%$ | $100\%$ |
+
+The textbook algorithm is unusable on this arm. The cause is a **singular pencil**: the matrices $A, B, C$ for this geometry happen to share a common kernel direction, so the pencil $(A, B, C)$ as a whole is structurally ill-conditioned regardless of how we factor it.
+
+The next four sections describe the four independent attacks ssik ships against this. Each one peels off some of the conditioning damage; together they bring JACO 2 from $\kappa = 10^{16}$ to $\kappa \approx 100$ and FK error from $10^0$ to $10^{-13}$.
+
+## AE-1: Equilibration of the pencil
+
+[Issue #68.](https://github.com/siddhss5/ikfastpy/issues/68) Implementation: [`_equilibrate_pencil`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+**The problem.** Real arms have DH parameters spanning many orders of magnitude — JACO 2 has $a_2 = 0.41$ m alongside $\alpha_4 = 60° = 1.047$ rad. The entries of $A, B, C$ inherit that scale variance: some rows have entries $\sim 10^{-3}$, others $\sim 10^{0}$, and $\kappa(A)$ inflates because LAPACK can't tell row scaling apart from genuine ill-conditioning.
+
+**The fix.** Joint row + column scaling: rescale each row of $(A, B, C)$ jointly so its max-magnitude entry is 1, then rescale each column similarly. The quadratic eigenvalue problem $(A x^2 + B x + C) v = 0$ and the equilibrated $(D_l A D_r) x^2 + (D_l B D_r) x + (D_l C D_r)$ have **the same eigenvalues** $x$; eigenvectors transform as $v = D_r v_{\mathrm{eq}}$. Eigenvalues are scale-invariant, so equilibration costs nothing in correctness.
+
+**The win on JACO 2.** Modest — about $2\times$ reduction in $\kappa(A)$ on most poses. Equilibration is necessary but not sufficient. The structural pencil-singularity needs more than scaling to fix.
+
+IKFast doesn't do this; we put it in because the cost is ~10 µs per pose and the win is consistent.
+
+## AE-3: Leftvar selection — the structural fix
+
+[Issue #70.](https://github.com/siddhss5/ikfastpy/issues/70) Implementation: [`pick_best_leftvar`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py), [`_cached_best_leftvar`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+**The intuition.** The Raghavan–Roth loop split — $A_2 A_3 A_4 = A_1^{-1} T A_5^{-1} A_6^{-1}$ — was a **choice**. We chose joint 2 as the linearity variable (the joint whose $\sin / \cos$ enter as linear coefficients of the $v_{\mathrm{left}}$ basis), with $(q_3, q_4)$ as the bilinear pair on the left side and $(q_0, q_1)$ as the bilinear pair on the right. The cycle $\{q_0, q_5\}$ on the ends is fixed by the standard chain ordering, but the choice of which interior joint is the linearity variable — $q_0$, $q_1$, or $q_2$ — is free. Three choices, three different splits, three different $A, B, C$ matrices, three different conditionings.
+
+**The diagnostic.** On JACO 2, the three options give:
+
+| linearity choice | $v_{\mathrm{left}}$ pair | $v_{\mathrm{right}}$ pair | $\kappa(A)$ |
+|---|---|---|---|
+| $q_0$ (interior, base end) | $(q_1, q_2)$ | $(q_4, q_5)$ | $\sim 10^{14}$ |
+| $q_1$ (interior, middle) | $(q_2, q_3)$ | $(q_0, q_5)$ | **127** |
+| $q_2$ (textbook MC choice) | $(q_3, q_4)$ | $(q_0, q_1)$ | $3.75 \times 10^{16}$ |
+
+Picking $q_1$ as the leftvar drops $\kappa(A)$ by **14 orders of magnitude**. On UR5 (a Pieper arm we don't actually need this solver for, but useful as a baseline) all three choices give similar conditioning around $10^4$.
+
+**Why this works.** The pencil $(A, B, C)$ becomes ill-conditioned when the 60° pathological joints (joints 4 and 5 on JACO 2) sit in the $v_{\mathrm{left}}$ bilinear pair. With linearity = $q_2$, $v_{\mathrm{left}}$ is $(q_3, q_4)$ — joint 4 is in there. With linearity = $q_1$, $v_{\mathrm{left}}$ is $(q_2, q_3)$ — pathological joints 4 and 5 are now on the $v_{\mathrm{right}}$ side, where they get eliminated by the SVD of $Q$ in Stage 2 and never enter the $A, B, C$ construction. **The structural pathology is moved out of the matrix that needs to be invertible.**
+
+Stated as a heuristic: **pick the leftvar that keeps your arm's structurally-bad joints out of the $v_{\mathrm{left}}$ bilinear pair**.
+
+**The selector.** ssik tries all three leftvar choices at module-import time (or first IK call) for a given DH tuple, builds $A, B, C$ for each, computes $\kappa(A)$, and picks the lowest-$\kappa$ option. The choice is cached per arm via [`_cached_best_leftvar`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) — geometry-driven, not pose-driven. After AE-3, the JACO 2 algebraic FK error drops from $\sim 10^{0}$ to $\sim 10^{-13}$ on 96.6% of poses.
+
+This is **the** structural fix. AE-1 (equilibration) softens scale variance; AE-3 chooses a fundamentally better problem to solve.
+
+## AE-4: SO(3) reduction
+
+[Issue #71.](https://github.com/siddhss5/ikfastpy/issues/71)
+
+**The problem.** The 6×9 eliminated system $E$ from Stage 2 contains rows that come from rotation-matrix entries (the $A_2 A_3 A_4$ rotation block has 9 entries), and the $\mathrm{SO}(3)$ orthogonality identities ($R^T R = I$, $\det R = 1$) couple them in ways the algebra doesn't exploit. Some rows of $E$ are nearly-redundant scaled copies of others, inflating $\kappa(A)$.
+
+**The fix.** Apply the $\mathrm{SO}(3)$ identities up front: instead of treating the 9 rotation entries as independent, use the row + column orthogonality to reduce. After this reduction the matrix entries are smaller and less correlated.
+
+**The win on JACO 2.** About $3.4\times$ reduction in $\kappa(A)$ — modest, additive on top of AE-3.
+
+## AE-3 + AE-1 + AE-4 together
+
+On JACO 2 with all three applied:
+
+$$
+\kappa(A) \approx 1.27 \times 10^{2}, \quad \text{vs textbook } 3.75 \times 10^{16}.
+$$
+
+Algebraic FK error median: $2.9 \times 10^{-13}$. Pose-level success: 100%. **No numerical refinement needed.**
+
+## AE-5: Möbius reparameterization (fallback)
+
+For the few arms where AE-1+3+4 don't get $\kappa(A)$ below the cliff threshold ($10^{10}$ in current code), we have a more aggressive fallback: **Möbius reparameterize the eigenvalue variable** to spread roots away from the conditioning cliff.
+
+**The construction.** Substitute
+
+$$
+x_2 = \frac{\alpha\, \tilde{x} + \beta}{\gamma\, \tilde{x} + \delta},
+$$
+
+clear the denominator $(\gamma \tilde{x} + \delta)^2$, and the new pencil $(A_{\mathrm{new}}, B_{\mathrm{new}}, C_{\mathrm{new}})$ in $\tilde{x}$ has the **same** roots, mapped through the inverse transform. Eigenvalues that were near the conditioning cliff at $x_2 \sim 0$ end up at convenient locations in $\tilde{x}$ space.
+
+**The procedure.** Try a few random $(\alpha, \beta, \gamma, \delta)$ Möbius transforms, build $A_{\mathrm{new}}$ for each, take the one with smallest $\kappa(A_{\mathrm{new}})$. If that's still above threshold, fall through to the **generalised eigenvalue route** (Manocha–Canny Theorem 2): solve the matrix pencil $M_1 - x M_2$ via `scipy.linalg.eig` directly, no inversion of $A$ needed. ~2.5–3× slower but always works (singular pencils included).
+
+In code: [`solve_x2_roots_mobius`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+
+## AE-6: Algebraic-first dispatch
+
+[Issue #74.](https://github.com/siddhss5/ikfastpy/issues/74)
+
+After AE-1/3/4/Möbius, the algebraic precision on most arms is at machine epsilon. But on adversarial poses or under exotic DH, the eigenvalue route still produces candidates with FK residual just above `fk_atol` — close enough to converge under Newton refinement, but not below the gate.
+
+The **algebraic-first contract** (covered in [Chapter 6](06_refinement.md)): by default, candidates that miss `fk_atol` algebraically are **dropped**, not polished. Refinement is opt-in (`allow_refinement=True`) and reports back via `Solution.refinement_used`. This keeps the algebraic / iterative line cleanly drawn and surfaces it to callers — they always know whether the result was pure-algebraic or polished.
+
+## What happens when all six measures still aren't enough
+
+A few classes of pose remain hard even after every conditioning measure:
+
+- **Manocha–Canny Table I synthetic arm** (a paper benchmark, not a real robot): the AE-3 leftvar selection improves it but doesn't reach machine precision algebraically. With `allow_refinement=True`, Newton converges in 4–6 iterations from the algebraic seed; without, candidates get dropped and `is_ls=True` fires for some poses. We track this as [#82](https://github.com/siddhss5/ikfastpy/issues/82) — a known **completeness** gap (the solutions returned are correct; we just can't always find the specific seeded $q^\star$ on this fixture).
+- **True kinematic singularities** (wrist-pitch zero, elbow fully extended). Here the $\sin q_4 = 0$ degeneracy collapses two IK branches into one and the eigenvalue route returns two near-equal roots that map to the same configuration. Dedup handles this; reduced-cardinality solution sets are correct, just smaller.
+- **Numerically singular pencils** that survive even Möbius. The generalised-eigenvalue path catches these, costing a few ms.
+
+In every case, the user sees an **honest signal**: `fk_residual` is what it is, `refinement_used` reports what fired, `is_ls=True` fires if no candidate met `fk_atol`. No silent papering over.
+
+## Putting it together
+
+The **AE-1/3/4 + Möbius + algebraic-first** combination is what makes the textbook Raghavan–Roth pipeline survive on JACO 2 specifically and the EAIK gap generally. The summary:
+
+- **AE-1** (equilibration): always-on, ~2× $\kappa$ improvement, free.
+- **AE-3** (leftvar selection): always-on, **structural** fix, up to 14 orders of magnitude on pathological arms, cached per-arm.
+- **AE-4** (SO(3) reduction): optional, ~3× $\kappa$, useful when AE-3 doesn't get all the way home.
+- **AE-5** (Möbius reparameterization): triggered by `cond(A) > 1e10` cliff; always-on as a safety net.
+- **Generalised eigenvalue fallback**: triggered when Möbius can't recondition; rare but bullet-proofs against truly singular pencils.
+- **AE-6** (algebraic-first contract): user-facing — pure algebraic by default, opt-in Newton polish, transparent diagnostics.
+
+The cumulative effect on JACO 2: **median 2.25 ms warm-cache IK, FK error 3.7e-13, 0 failures over 100 random poses.** That's what the next chapters describe how to use.
+
+## A reference for porting RR to a new arm family
+
+If you ever find yourself implementing this pipeline for a new family of arms (or a different parameterisation), the conditioning intuitions transfer:
+
+1. Measure $\kappa(A)$ on a representative pose set with the textbook leftvar choice. If it's below $10^6$, you're done.
+2. If $\kappa$ is high, try alternative leftvars and pick the lowest. The "pathological joints out of $v_{\mathrm{left}}$" heuristic is geometric and applies to any chain.
+3. Equilibrate. Always.
+4. If you still see $\kappa > 10^{10}$, instrument the eigenvector quality with the back-substitution residual and look for which entries of $v_{12}$ are zeroing out — that tells you which monomial is structurally absent and which Möbius transform might decluster the roots.
+5. Always have an opt-in Newton polish with transparent diagnostics. The user needs to know when it fired.
+
+Issue [#81](https://github.com/siddhss5/ikfastpy/issues/81) catalogues the IKFast-era tricks for ill-conditioning that we did **not** port (because they were band-aids over the missing AE-3 leftvar choice, or because they obscure failure modes). Worth reading if you're navigating the same conditioning swamp.

--- a/docs/tutorial/06_refinement.md
+++ b/docs/tutorial/06_refinement.md
@@ -1,0 +1,63 @@
+# 6. Algebraic-first, refinement-second
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in. Implementation: [`src/ssik/refinement/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/) and the `Solution` dataclass at [`src/ssik/core/solution.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/core/solution.py). Design rationale in [#74](https://github.com/siddhss5/ikfastpy/issues/74) and [#75](https://github.com/siddhss5/ikfastpy/issues/75).
+
+## What this chapter covers
+
+The contract every ssik solver follows: **pure algebraic by default, opt-in Newton polish, transparent diagnostics**.
+
+### The contract (#74)
+
+- Default: `solve(kb, T) -> tuple[list[Solution], bool]`. Candidates that don't reach `fk_atol` algebraically are **dropped**, not silently polished.
+- Opt-in: `solve(kb, T, allow_refinement=True)`. Each near-miss candidate goes through one [`lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py) pass — Newton on the SE(3) log residual via the spatial Jacobian.
+- Per-`Solution` reporting: `refinement_used: Literal["none", "lm"]`, `refinement_iters: int`. The caller always knows what fired.
+
+### Why this matters
+
+Numerical refinement hidden inside an "analytical" solver is one of the worst-of-both-worlds anti-patterns. The user thinks they're getting algebraic precision; in fact they're getting whatever Newton converged to in 100 iterations of LM. ssik's contract makes the algebraic / iterative line *explicit* and surfaces it on every returned `Solution`.
+
+### `lm_refine` — the universal polish primitive
+
+Hand-rolled Newton, no scipy:
+
+- Input: seed `q`, FK callable, target pose, optional analytical Jacobian.
+- Inner loop: compute SE(3)-log residual $r = \log(T \cdot \mathrm{FK}(q)^{-1}) \in \mathbb{R}^6$, solve $J_s\, \delta q = r$ via LAPACK, step-clip $\|\delta q\|_\infty \le 0.5$ rad, iterate until $\|r\| < \mathrm{fk\_atol}$ or `max_iters` hit.
+- No divergence-abort heuristic: Newton can be non-monotonic near saddles or under step-clipping; aggressive early termination misses real recoveries.
+- Single LAPACK `solve` per iter; ~50× faster than the scipy LM wrapper on cases where 1–5 iters suffice.
+
+### `Solution` dataclass
+
+```python
+@dataclass(frozen=True)
+class Solution:
+    q: NDArray[np.float64]
+    fk_residual: float
+    refinement_used: Literal["none", "lm"]
+    refinement_iters: int
+    branch_id: int | None = None
+    solver_name: str = ""
+```
+
+Returned by every solver. Frozen — derived data, callers shouldn't mutate.
+
+### `verify_candidates` — the shared back-half
+
+Every solver runs the same pattern after producing raw joint-angle candidates: FK-verify, optionally Newton-polish, dedup. Factored once into [`ssik.refinement.verify_candidates`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py); ten solvers consume it.
+
+### When refinement actually fires
+
+- Tier-0 closed-form solvers (Pieper-class): **never**, by design. Algebraic precision is at machine epsilon.
+- Tier-2 RR solver, well-conditioned arm (JACO 2 post-AE-3): never. 96.6% algebraic_pass at $10^{-13}$ FK error. The refinement plumbing exists but doesn't trigger.
+- Tier-2 RR solver, MC Table I synthetic: ~99% of candidates need polish (the textbook fixture is ill-conditioned by design). With `allow_refinement=True` the median-polish-iteration count is 4. Without, candidates get dropped and `is_ls=True` fires. (#82.)
+
+### What this gives users
+
+- A calling pattern that's identical across all 10 solvers in ssik.
+- A precision contract that's enforceable: "if `refinement_used == 'none'`, this is pure-algebraic at the reported `fk_residual`".
+- A debug surface: when something goes wrong, `Solution.refinement_iters > 5` is a flag that the algebraic path is struggling and you might want to investigate the geometry.
+
+## References
+
+- Memory entry [`feedback_refinement_architecture`](https://github.com/siddhss5/ikfastpy/issues/74).
+- GitHub PR #85 (the migration that landed this contract across all solvers).

--- a/docs/tutorial/07_kinbody_bridge.md
+++ b/docs/tutorial/07_kinbody_bridge.md
@@ -1,0 +1,70 @@
+# 7. The KinBody-input bridge
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in. Implementation: [`src/ssik/kinematics/poe_to_dh.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/kinematics/poe_to_dh.py), [`src/ssik/solvers/ikgeo/general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/general_6r.py). Tracking issue [#79](https://github.com/siddhss5/ikfastpy/issues/79).
+
+## What this chapter covers
+
+How POE-form `KinBody` inputs (the canonical ssik / IK-Geo / EAIK convention) get bridged to the standard distal-DH representation that the Raghavan–Roth solver internally uses.
+
+### POE vs DH
+
+- **POE (Product of Exponentials):** every joint contributes a `T_left @ R_axis(joint.axis, q) @ T_right` factor. Conventional in modern robotics (Murray–Li–Sastry); easy to express directly from URDF or MJCF.
+- **DH (Denavit–Hartenberg):** every joint contributes $A_i = R_z(\theta_i) T_z(d_i) T_x(a_i) R_x(\alpha_i)$. Frame placement is constrained: $z_i$ must be the joint axis, $x_i$ must lie along the common perpendicular to $z_{i-1}$. Conventional in textbook IK derivations (Spong, Tsai).
+
+The Raghavan–Roth solver's algebra ([Chapter 4](04_raghavan_roth.md)) is in DH form. The user's input is in POE form. We need to bridge.
+
+### `poe_to_dh(kb) -> DhWithOffset`
+
+Returns:
+
+```python
+@dataclass
+class DhWithOffset:
+    alpha: NDArray         # length-6, twist angles
+    a: NDArray             # length-6, link lengths
+    d: NDArray             # length-6, link offsets
+    theta_offset: NDArray  # length-6, per-joint angle offset
+    t_pre: NDArray         # 4x4, world to DH frame 0
+    t_post: NDArray        # 4x4, DH frame n to user EE
+```
+
+Such that for every $q$:
+
+$$
+\mathrm{FK_{POE}}(q) = T_{\mathrm{pre}}\, \mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})\, T_{\mathrm{post}}.
+$$
+
+### Algorithm
+
+1. Walk the POE chain at $q = 0$: extract joint axes $z_i$ in world frame, joint origins $p_i$ in world frame, and the home-pose end-effector transform $T_{\mathrm{home}} = \mathrm{FK_{POE}}(0)$.
+2. Place DH frames 0 to $n$ in world coords:
+   - $z_i$ = joint $(i+1)$'s axis in world (i.e., `axes_world[i]` for $i < n$); $z_n$ = $T_{\mathrm{home}}$'s z-axis.
+   - Origin of frame $i$: foot of common perpendicular between $z_{i-1}$ and $z_i$ on $z_i$'s line.
+   - $x_i$ direction: along the common perpendicular, from $z_{i-1}$ toward $z_i$. For parallel axes use the foot-to-foot direction; for intersecting axes use $(z_{i-1} \times z_i)$ normalised.
+3. Read off $(\alpha_i, a_i, d_i, \theta_{\mathrm{offset},i})$ per transition by computing signed angles + projected distances.
+4. Build $T_{\mathrm{pre}}$ from frame 0's $(x_0, y_0, z_0, \mathrm{origin})$ as columns of the rotation block + translation.
+5. Build $T_{\mathrm{post}}$ to absorb any residual rotation between DH frame $n$ at $q = \theta_{\mathrm{offset}}$ and the actual $T_{\mathrm{home}}$.
+
+### The load-bearing bug we fixed
+
+The original implementation hard-coded $z_0 = (0, 0, 1)$ and $T_{\mathrm{pre}} = I$. **This is correct for any arm whose joint-1 axis aligns with world +z** — UR5, Puma 560, most commercial arms. UR5's round-trip test passed for 100 random poses across 3 random seeds at machine precision.
+
+JACO 2 broke it. The MJCF places `link_1` with `quat = (0, 0, 1, 0)` — a 180° rotation about world y, which flips the local +z axis to world −z. So `joints[0].axis` in world frame is $(0, 0, -1)$, not $(0, 0, +1)$. With $z_0 = +z$ hardcoded, the DH chain rotates joint 1 around the wrong axis, the bridge $T_{\mathrm{pre}}^{-1} T\, T_{\mathrm{post}}^{-1}$ doesn't match $\mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})$, and `||bridge_residual||` is 0.81 instead of $10^{-15}$.
+
+### The fix
+
+Set $z_0 = $ `axes_world[0]` (joint 1's actual axis in world frame), $\mathrm{origin}_0 = $ `origins_world[0]` (joint 1's actual origin), $x_0$ chosen as the world-x projection onto the plane perpendicular to $z_0$ (or world-y if $z_0$ is too parallel to x). $T_{\mathrm{pre}}$ then has $(x_0, y_0, z_0, \mathrm{origin}_0)$ as its columns and reduces to identity for commercial-arm conventions while absorbing the rotation/translation discrepancy otherwise. UR5 round-trips still pass; JACO 2 round-trips now pass at machine precision.
+
+### Lesson
+
+UR5 and Puma 560 are *too well-behaved* to be the only test fixture for kinematic-bridge code. They mask convention bugs that real arms with non-trivial base orientations expose immediately. Real-MJCF fixtures matter (#80).
+
+### Caching
+
+`poe_to_dh(kb)` depends only on the chain's geometry, not on any IK target. ssik caches the result on the kb instance (`kb._ssik_dh_with_offset_cache`); subsequent calls are free. ([Tier 1 of #86](https://github.com/siddhss5/ikfastpy/pull/88).)
+
+## References
+
+- Spong, M. W. *Robot Modeling and Control,* §3.2 (DH frame placement).
+- Murray–Li–Sastry, *A Mathematical Introduction to Robotic Manipulation* (POE).

--- a/docs/tutorial/08_bulletproof.md
+++ b/docs/tutorial/08_bulletproof.md
@@ -1,0 +1,69 @@
+# 8. Bulletproof validation
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in.
+
+## What this chapter covers
+
+The validation discipline ssik enforces on every solver PR, why each piece exists, and what failure modes each catches.
+
+### The standard
+
+Memory entry [`feedback_bulletproof_solvers`](https://github.com/siddhss5/ikfastpy/issues/74). Verbatim:
+
+> N-way cross-solver agreement on shared fixtures, 1e-10 FK tolerance, 500+ hypothesis poses; "must be perfect, all the time".
+
+Every solver shipped in ssik passes through five gates before review.
+
+### Gate 1 — Hand-picked generic poses (~5 fixtures × machine-precision FK)
+
+Caught by: typos in the algebraic derivation, wrong indices in branch enumeration, sign flips in atan2, etc. Fast feedback loop in `pytest`.
+
+### Gate 2 — Hand-picked near-singular poses
+
+Wrist-pitch zero ($\sin q_4 = 0$), elbow zero / fully-extended ($\sin q_2 = 0$), shoulder-pan zero ($q_0 = 0$). Caught by: implicit assumptions of nonzero denominators in subproblem decomposition. Solvers must degrade gracefully — return fewer solutions (collapsed branches), all FK-exact, or signal `is_ls=True`.
+
+### Gate 3 — Synthetic alternative-geometry fixture
+
+A second arm with the same topology but different link lengths than the primary fixture. Validates "generic, not geometry-specific". Pieper-class solvers each ship one synthetic alternative; tier-2 solvers ship a randomised alternative.
+
+### Gate 4 — 500-pose hypothesis fuzz with seeded $q^\star$ recovery
+
+[Hypothesis](https://hypothesis.readthedocs.io/) generates 500 random non-singular $q^\star$, the test computes $T = \mathrm{FK}(q^\star)$, calls `solve(kb, T)`, and asserts:
+
+1. `is_ls == False`.
+2. Every returned solution FK-closes within 1e-8 to 1e-10 atol (tier-dependent).
+3. The seeded $q^\star$ is recoverable mod $2\pi$ within 1e-3 to 1e-4 rad.
+
+This catches: rare branch-enumeration bugs that hand-picked tests miss, completeness regressions where the solver loses one of its 8 solutions, and platform variance (hypothesis runs on every CI matrix entry).
+
+### Gate 5 — N-way cross-solver agreement (where applicable)
+
+Puma 560 satisfies the preconditions of *both* `spherical_two_parallel` and `spherical_two_intersecting`. The two compositions are algebraically distinct (SP4+SP3+SP1+SP4+SP1+SP1 vs SP3+SP2+SP4+SP1+SP1) but **must return the same 8-solution set** on every non-singular pose. The `tests/test_puma_cross_validation.py` file asserts exact set agreement at 1e-6 tolerance over 500 hypothesis poses.
+
+This is the strongest correctness guarantee available without an oracle: each solver acts as the other's reference. If both fail in agreement, both have a parallel bug (vanishingly unlikely); if only one fails, the disagreement immediately identifies which one.
+
+### Real-arm fixtures
+
+Synthetic arms are necessary for completeness across topology classes. Real arms are necessary for hidden bugs that hide behind synthetic-fixture conveniences:
+
+- The [JACO 2 j2n6s200 fixture](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) was transcribed from the upstream MJCF (`robot-code/ada_assets/.../jaco2.xml`). It exposed the [`poe_to_dh` `T_pre` bug](07_kinbody_bridge.md) — UR5's joint-1 axis happens to align with world +z, so the original code's `T_pre = I` defaulting accidentally worked. JACO 2's `link_1.quat = (0, 0, 1, 0)` flips the axis and broke the bridge.
+- Tier-2 RR validation runs against the *actual* JACO 2 chain, not a synthetic 60°-twist DH approximation. Slow tests at [`tests/test_jaco2_general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_jaco2_general_6r.py) cover seeded recovery + 4 keyframe round-trips.
+- (#80) tracks adding more real fixtures — Agilex Piper, Flexiv Rizon, KUKA iiwa, Franka Panda — each rebroadcasts the same five gates against a different chain.
+
+### "No papering over"
+
+Memory entry [`feedback_no_papering_over`](https://github.com/siddhss5/ikfastpy/issues/74). When a solver fails a gate, the response is: **investigate the root cause**, fix the underlying bug. Not: clear the hypothesis cache, widen tolerances, mark the test slow and forget it, or scope the workaround without filing the underlying-bug issue.
+
+When the underlying bug is structural and fixing it is out-of-scope for the immediate PR, the failing test gets explicit `xfail(strict=False)` with a reason linking to a tracking issue (e.g. [#82](https://github.com/siddhss5/ikfastpy/issues/82) for the MC Table I coverage gap). The test still **runs** — `xpassed`/`xfailed` counts surface the actual recovery rate per platform — but doesn't block CI on a known cross-platform-flakey case.
+
+### Cumulative test surface
+
+After PR #85, ssik runs:
+
+- ~320 fast-suite tests (single-pose hand-picked + hypothesis fuzz at 500 examples per solver per arm).
+- ~10 slow tests (sympy-preprocessing-dominated tier-2 RR round-trips, JACO 2 keyframes + UR5 generic).
+- 4 CI jobs per PR (macOS / py3.13 + ubuntu / py3.{11,12,13}).
+- Cross-solver Puma agreement (`spherical_two_parallel` ⇿ `spherical_two_intersecting`) at machine precision over 500 random poses.
+
+The discipline is what allows shipping speed work like the Tier 1/2/3 PRs (#88/#89/#90) without precision regressions: every change runs through every gate before merge.

--- a/docs/tutorial/09_practical_guide.md
+++ b/docs/tutorial/09_practical_guide.md
@@ -1,0 +1,115 @@
+# 9. Practical guide
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in.
+
+## What this chapter covers
+
+How to use ssik day-to-day: install, build a `KinBody`, pick a solver, interpret the returned `Solution`, debug failures.
+
+## Install
+
+```
+pip install ssik          # core
+pip install ssik[urdf]    # + URDF loader (urchin)
+```
+
+(Pre-alpha; package name reservation in progress as of writing. See [#83](https://github.com/siddhss5/ikfastpy/issues/83).)
+
+## Build a `KinBody`
+
+From a URDF:
+
+```python
+from ssik._urdf import load_urdf_kinbody_normalized
+
+kb = load_urdf_kinbody_normalized("robots/ur5.urdf", "base_link", "ee_link")
+```
+
+From an MJCF (transcribe joint frames; see [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) for the pattern):
+
+```python
+from ssik._kinbody import build_kinbody
+from fixtures.jaco2 import jaco2_specs  # transcribed once from MJCF
+
+kb = build_kinbody(jaco2_specs())
+```
+
+From scratch: build a list of [`JointSpec`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/_kinbody.py) and pass to [`build_kinbody`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/_kinbody.py).
+
+## Pick a solver
+
+For 6R arms, the dispatcher picks the right tier per kb at registration time:
+
+```python
+from ssik.solvers.ikgeo import general_6r
+
+solutions, is_ls = general_6r.solve(kb, T_target)
+for sol in solutions:
+    print(sol.q, sol.fk_residual, sol.refinement_used)
+```
+
+(The unified `Manipulator.from_urdf(...).ik(T)` API of the rewrite plan is in progress; until it lands, importing the per-tier solver directly is the way.)
+
+For 7R arms with one redundant joint (Franka, KUKA iiwa, Flexiv Rizon):
+
+```python
+from ssik.solvers.jointlock import seven_r
+
+solutions, is_ls = seven_r.solve(kb, T_target, lock_samples=16)
+```
+
+`lock_samples=16` sweeps the chosen redundant joint over 16 lock values; or pass an explicit list `lock_samples=[0.0, 0.5, 1.1, -0.5]` to control which lock values get sampled.
+
+## Read the returned `Solution`
+
+```python
+@dataclass(frozen=True)
+class Solution:
+    q: NDArray[np.float64]
+    fk_residual: float
+    refinement_used: Literal["none", "lm"]
+    refinement_iters: int
+    branch_id: int | None = None
+    solver_name: str = ""
+```
+
+- **`fk_residual`** — `||FK(q) - T_target||_F` at return time. Compare against your application's tolerance; the solver's own `fk_atol` was a *filter*, not a contract on the value.
+- **`refinement_used`** — `"none"` if the solution came directly from algebra; `"lm"` if Newton polished it. Surfaces the algebraic-vs-iterative line.
+- **`refinement_iters`** — how many Newton iterations consumed (0 if `refinement_used == "none"`).
+- **`branch_id`** — IK branch index where applicable (0..15 for the 16-root RR route, 0..7 for spherical+parallel-shoulder, etc.). Stable across calls for the same target pose; useful for branch-tracking across a trajectory.
+- **`solver_name`** — dotted module path. Useful when results pass through a dispatcher that routes across multiple solver candidates.
+
+## Debug `is_ls=True`
+
+`is_ls=True` means **no candidate survived FK validation**. Common causes:
+
+1. **Target unreachable.** The arm physically can't get to `T_target`. Check your target pose against the workspace.
+2. **Singular pose.** The arm *can* reach `T_target` but does so at a singularity (wrist pitch zero, elbow extended). Some branches collapse; the solver may return fewer solutions but they should still be exact. If `is_ls=True` at a singularity, the geometry is on the edge of the singular set.
+3. **Tier-2 RR with `allow_refinement=False`** on an ill-conditioned pose. The algebraic candidates miss `fk_atol` and get dropped. Try `allow_refinement=True` and inspect the returned `refinement_iters` — high iteration counts (>5) suggest the solver is struggling and the pose is genuinely difficult.
+4. **A topology-precondition mismatch.** You called `spherical_two_parallel.solve` on an arm that isn't actually spherical-wrist-with-parallel-shoulder. Tier-0 solvers raise `ValueError` on topology mismatch up front; tier-2 solvers accept any 6R but may struggle if the arm is at a degenerate pose for that algorithm.
+
+## Performance numbers (current at writing)
+
+Real JACO 2 j2n6s200 (60° twists, the hard case), warm cache, 100 random poses:
+
+| metric | value |
+|---|---|
+| min | 0.83 ms |
+| **median** | **2.25 ms** |
+| mean | 3.49 ms |
+| p95 | 10.24 ms |
+| max | 29.61 ms |
+| solutions / pose | median 6, range 1–12 |
+| FK error | median 3.7e-13, max 9.6e-08 |
+| failures (`is_ls=True`) | 0 / 100 |
+
+Cold-cache cost (first IK on a new arm): ~150-300 s of one-time sympy preprocessing for the AE-3 leftvar selection. Cached on disk after that.
+
+For Pieper-class arms (UR5, Puma), the tier-0 solvers run in ~50–200 µs warm-cache, comparable to EAIK.
+
+See [#86](https://github.com/siddhss5/ikfastpy/issues/86) for ongoing speed work; the Phase M codegen / Rust runtime is the next order-of-magnitude lift.
+
+## Reading test output
+
+When a CI job shows xpassed/xfailed counts on test_solve_all_ik_recovers_q_star_and_alternatives, that's the platform-sensitive [#82](https://github.com/siddhss5/ikfastpy/issues/82) coverage gap on MC Table I (a synthetic benchmark). Different LAPACK backends pick different IK branches; the test passes either way (xfail with `strict=False`) but the counts surface the actual recovery rate per platform.

--- a/docs/tutorial/10_whats_next.md
+++ b/docs/tutorial/10_whats_next.md
@@ -1,0 +1,53 @@
+# 10. Roadmap
+
+!!! warning "Scaffolding"
+    Outline below; prose to be filled in.
+
+## What this chapter covers
+
+The next-order lifts that aren't in ssik today, ranked by user impact.
+
+## Husty–Pfurner universal fallback
+
+[Husty & Pfurner 2007](https://doi.org/10.1115/1.2780537) Study-quaternion method gives a degree-16 univariate polynomial covering **any** 6R arm, even when Raghavan–Roth's $A$ pencil is fundamentally singular (rare but real). Lower registry priority than the tier-2 RR solver; auto-selected on fallback. ~10 ms target latency. Clean-room from the published paper, no LGPL dependency.
+
+## Specialist 7R solvers
+
+For 7-DOF arms with full-redundancy IK (sweeping the 1D redundancy manifold rather than locking one joint to a sample):
+
+- **GeoFIK** for Franka Panda. Specialist solver matched to the SRS topology.
+- **Stereographic SEW** (Wenger / NASA 2024) for KUKA iiwa-class arms.
+- **Moz1 NonSRS 7R** for Flexiv Rizon and similar non-SRS chains.
+
+Each plugs in as an independent module via `[project.entry-points."ssik.solvers"]`; no core patches needed.
+
+## Codegen / Rust runtime (Phase M)
+
+Per-arm AOT-compile the Raghavan–Roth pipeline to a `.so` extension:
+
+- Replaces the lambdified-sympy `build_pq` callable with a numpy-only or C-array-only callable.
+- Replaces the Python loop overhead with a Rust hot loop linking `dgeev` + a hand-vectorised back-substitution.
+- Estimated tier-2 latency: ~300–500 µs (vs current 2.25 ms median).
+- Estimated tier-0 latency: ~30–50 µs (matches / beats EAIK on the same algorithm).
+
+See [#86](https://github.com/siddhss5/ikfastpy/issues/86) Tier 3 for the speed roadmap.
+
+## Vendored ikfast retirement (Phase K)
+
+[#84](https://github.com/siddhss5/ikfastpy/issues/84). The `_legacy/` tree contains LGPL-tainted code from the abandoned port-and-patch attempt. Once the new pipeline has full conformance against the cases the vendored solver covered (Puma 560 in tier-0, etc.), the legacy tree gets deleted. No code currently imports from it; the cleanup is purely housekeeping + license hygiene.
+
+## IK modes beyond Transform6D
+
+IKFast supported 16 distinct IK modes (Translation3D, Rotation3D, Direction3D, Ray4D, Lookat3D, ...). ssik currently ships Transform6D only. Each non-trivial mode requires its own loop-closure derivation and back-substitution. The reference table is in [`docs/reference/ik-modes/`](../reference/ik-modes/index.md). Tracking issue: [#18](https://github.com/siddhss5/ikfastpy/issues/18).
+
+## MJCF front-end parallel to URDF
+
+Most modern simulation environments use MuJoCo MJCF rather than URDF. Building a `KinBody` from MJCF directly (rather than transcribing joint frames by hand as JACO 2 does) is a separable concern. Tracking: ada-style MJCF parser, parallel to `ssik._urdf`.
+
+## Extensibility — third-party solvers
+
+The Solver / TopologyClaim / SolverRegistry protocols (`src/ssik/core/`) admit external solvers via Python entry points. The aspiration: someone publishes `ssik-geofik` on PyPI, ssik picks it up at registration time, and the dispatcher routes Franka calls to it without core patches. Real example pending; rebuild-plan covers the protocol.
+
+---
+
+This is also the conclusion of the tutorial. The implementation tracking lives on GitHub issues; the math is done; the bulletproof discipline is shipped; the speed work continues. Open questions live in active issues — start there if you want to contribute.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,16 +1,36 @@
 # Tutorial
 
-A guided introduction to inverse kinematics and to the algorithm IKFast uses internally. The tutorial assumes basic linear algebra; everything else is built up from scratch.
+A guided tour through the algorithms ssik actually ships, focused on the part of the analytical-IK ecosystem that motivated the library: the **EAIK gap**.
 
-!!! note "Under construction"
-    Tutorial chapters land as the underlying implementation lands. Issue [#16](https://github.com/siddhss5/ikfastpy/issues/16) tracks chapters 1–4 (foundational); issue [#17](https://github.com/siddhss5/ikfastpy/issues/17) tracks chapters 5–7 (deep dive into IKFast and EAIK).
+Most analytical IK on commercial 6R arms has been a solved problem for thirty years. Subproblem composition (Paden–Kahan, Pieper, IK-Geo) handles arms with three intersecting axes (spherical wrist) or three consecutive parallel axes; that covers UR5, Puma 560, Fanuc, KUKA KR, ABB IRB, and most industrial manipulators. EAIK ships closed-form solvers for those families in ~0.2 ms.
 
-## Planned chapters
+The arms ssik exists for are the ones that **don't** fit those families: Kinova JACO 2 (60° non-orthogonal twists at joints 4–5), Agilex Piper, Flexiv Rizon 4 (non-SRS 7R), and any custom 6R chain where no axis triple is parallel or intersecting. For those arms ssik runs the **Raghavan–Roth + Manocha–Canny** numeric pipeline — a 14-equation algebraic elimination, a 24×24 companion-matrix eigendecomposition, and a back-substitution — and gets analytical IK at single-digit-millisecond latency with machine-precision FK closure.
 
-1. **The IK Problem** — forward vs inverse kinematics; why closed-form solutions matter for planning.
-2. **Kinematics Primer** — rigid transforms, Denavit–Hartenberg parameters, Product-of-Exponentials.
-3. **Numerical IK** — Jacobian inverse, damped least squares, when these methods fail.
-4. **Classical Closed-Form** — Pieper's three-intersecting-axes condition, Paden–Kahan subproblems.
-5. **Algebraic IK and How IKFast Works** — resultants, elimination, the symbolic decomposition strategy.
-6. **How EAIK Works** — kinematic family detection, comparison to IKFast.
-7. **Practical Guide** — picking a solver, troubleshooting, performance tuning.
+This tutorial walks the math step by step, names every robustness trick we needed to make the pipeline bulletproof on real arms, and shows the actual code paths that implement them.
+
+## Structure
+
+1. [The IK problem](01_ik_problem.md) — forward vs inverse, why analytical when you can, the ecosystem ssik plugs into.
+2. [The Pieper class](02_pieper_subproblems.md) — three-intersecting-axes, subproblem composition, SP1–SP6, what tier-0 solvers look like.
+3. [The EAIK gap](03_eaik_gap.md) — the arms nobody else covers analytically, and why the obvious approaches don't work on them.
+4. [Raghavan–Roth in 8 stages](04_raghavan_roth.md) — the math the tier-2 numeric solver runs, with code pointers at each stage. **Load-bearing technical chapter.**
+5. [Conditioning is the hard part](05_conditioning.md) — why the textbook RR pipeline blows up on JACO 2, and the four independent attacks (AE-1, AE-3, AE-4, Möbius) we shipped to make it survive. **Load-bearing technical chapter.**
+6. [Algebraic-first, refinement-second](06_refinement.md) — the GitHub #74 contract: pure algebraic by default, opt-in Newton polish, transparent diagnostics.
+7. [The KinBody-input bridge](07_kinbody_bridge.md) — POE-normalized chains in, DH-form solver under the hood, and the load-bearing bug that hid until JACO 2 exposed it.
+8. [Bulletproof validation](08_bulletproof.md) — N-way cross-solver agreement, 500-pose hypothesis fuzz, machine-precision FK on real-MJCF fixtures.
+9. [Practical guide](09_practical_guide.md) — installing, picking a solver, reading `Solution.refinement_used`, debugging `is_ls=True`, performance numbers.
+10. [Roadmap](10_whats_next.md) — Husty–Pfurner universal fallback, specialist 7R, codegen / Rust runtime.
+
+## Conventions
+
+- Math uses KaTeX inline ($A x^2 + B x + C = 0$) and block:
+  $$
+  M(x_2) = A x_2^2 + B x_2 + C
+  $$
+- Code references use clickable file links: [`src/ssik/solvers/ikgeo/_raghavan_roth.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py).
+- Cited literature is in the [Bibliography](../bibliography.md).
+- GitHub issue numbers in parens (e.g. **#82**) link to the canonical tracking thread for ongoing work.
+
+## Status
+
+Chapters 1, 4, 5 are complete. Chapters 2, 3, 6–10 are scaffolded outlines being filled in alongside the public-API stabilisation. See [#87](https://github.com/siddhss5/ikfastpy/issues/87) for the rewrite tracking issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,16 @@ nav:
   - Home: index.md
   - Tutorial:
       - tutorial/index.md
+      - 1. The IK problem: tutorial/01_ik_problem.md
+      - 2. The Pieper class: tutorial/02_pieper_subproblems.md
+      - 3. The EAIK gap: tutorial/03_eaik_gap.md
+      - 4. Raghavan–Roth in 8 stages: tutorial/04_raghavan_roth.md
+      - 5. Conditioning is the hard part: tutorial/05_conditioning.md
+      - 6. Algebraic-first refinement: tutorial/06_refinement.md
+      - 7. KinBody-input bridge: tutorial/07_kinbody_bridge.md
+      - 8. Bulletproof validation: tutorial/08_bulletproof.md
+      - 9. Practical guide: tutorial/09_practical_guide.md
+      - 10. Roadmap: tutorial/10_whats_next.md
   - Reference:
       - reference/index.md
       - IK modes:


### PR DESCRIPTION
## Summary

Replaces the placeholder "tour through IKFast and EAIK" framing in `docs/tutorial/` with a ten-chapter walk through what ssik actually ships, focused on the EAIK gap (the non-Pieper 6R arms ssik exists for) and the math + robustness story behind making the Raghavan–Roth pipeline survive on real arms.

## Chapters

| # | Title | Status |
|---|---|---|
| 1 | The IK problem | **full** |
| 2 | The Pieper class and subproblem composition | scaffolded outline |
| 3 | The EAIK gap | scaffolded outline |
| **4** | **Raghavan–Roth in 8 stages** | **full** (load-bearing math chapter) |
| **5** | **Conditioning is the hard part** | **full** (load-bearing robustness chapter) |
| 6 | Algebraic-first, refinement-second | scaffolded outline |
| 7 | The KinBody-input bridge | scaffolded outline |
| 8 | Bulletproof validation | scaffolded outline |
| 9 | Practical guide | scaffolded outline |
| 10 | Roadmap | scaffolded outline |

The three full chapters cover the part of the library that didn't exist in the ecosystem before ssik: the math (Ch 4) and the four robustness fixes (Ch 5: AE-1 equilibration, AE-3 leftvar selection, AE-4 SO(3) reduction, Möbius reparameterization) that make the textbook Raghavan–Roth pipeline survive on JACO 2.

The scaffolded chapters carry detailed section-level outlines + code links — they're reviewable as structure. Prose in follow-up commits as the public-API stabilisation lands. Each carries a `!!! warning "Scaffolding"` admonition so readers know what they're looking at.

## What changed beyond the tutorial files

- `docs/index.md` reframed: leads with the EAIK gap as ssik's strategic positioning; speed numbers updated to current state (median 4.5ms → 2.25ms across PR #88, #89, #90); status section refreshed with recent landings.
- `mkdocs.yml` nav: added all ten chapter files in order. KaTeX + Material theme auto-renders the math.

## Validation

- [x] `mkdocs build --strict`: clean
- [x] All KaTeX expressions render (validated by inspection of the build output)
- [x] All in-tree relative links resolve (chapter-to-chapter cross-references)
- [x] All source-code references use absolute GitHub URLs (`https://github.com/.../blob/main/...`) so they survive mkdocs's static-tree assumptions

## Out of scope (follow-ups)

- Filling in prose for chapters 2, 3, 6, 7, 8, 9, 10. Tracked in #87.
- Per-mode reference pages (`docs/reference/ik-modes/`). Tracked in #18.
- API auto-reference pages via mkdocstrings. Tracked separately.

Closes the planning + load-bearing-chapters portion of #87.