### PR TITLE
Tutorial: fill scaffolded chapters 2, 3, 6, 7, 8, 9, 10 (#87)

### DIFF
--- a/docs/tutorial/02_pieper_subproblems.md
+++ b/docs/tutorial/02_pieper_subproblems.md
@@ -1,31 +1,117 @@
 # 2. The Pieper class and subproblem composition
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in. This chapter covers the analytical-IK ground that EAIK / IK-Geo already handle elegantly — necessary background but not the part of ssik that's novel. See [`src/ssik/subproblems/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/subproblems/) and [`src/ssik/solvers/ikgeo/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/) for the implementation.
+Most commercial 6-DOF arms admit closed-form analytical IK because their kinematic structure has a **special geometric property** — three consecutive intersecting axes (a spherical wrist) or three consecutive parallel axes (a parallel-shoulder configuration). Pieper proved in 1968 that the first of these conditions makes IK a closed-form problem; subsequent work extended the result to other geometric specialisations. This chapter walks through that body of theory — the *Pieper class* — and the modern computational reformulation in terms of six canonical *subproblems* that compose into per-family solvers.
 
-## What this chapter covers
+This is necessary background, not novel material. EAIK and IK-Geo already ship excellent implementations of the algorithms in this chapter. ssik bundles the same algorithms (ported from the BSD-3 IK-Geo Rust reference) so that Pieper-class arms — UR5, UR10, Puma 560, most Fanuc / KUKA / ABB industrial arms — solve in 50–200 µs warm-cache without any of the tier-2 numeric machinery from [Chapter 4](04_raghavan_roth.md). The non-Pieper arms — the EAIK gap that motivates ssik's existence — are covered in [Chapter 3](03_eaik_gap.md).
 
-- **Pieper's condition (1968):** a 6-DOF arm with three consecutive intersecting axes admits closed-form IK. Decouples wrist orientation from elbow position.
-- **The six canonical subproblems (Paden–Kahan, Elias–Wen):**
-  - **SP1** — `axis k`, vector `p` rotated to align with vector `q`. Single angle `θ`.
-  - **SP2** — two sequential rotations to align `p` with `q`. Two angles, up to 2 solutions.
-  - **SP3** — distance constraint: rotate `p` around `k` to be at distance $d$ from origin. Up to 2 solutions.
-  - **SP4** — projection: $k_2 \cdot \mathrm{Rot}(k_1, \theta) p = h$. Up to 2 solutions.
-  - **SP5** — three sequential rotations placing `p_0 + R_1 p_1 + R_2 p_2 = -p_3`. Quartic, up to 4 solutions.
-  - **SP6** — two pairs of subproblem-4 conditions. Bezout quartic, up to 4 solutions.
-- **Compositions:** how the per-family ssik solvers chain SP1–SP6 to produce 8-solution closed-form IK:
-  - `ikgeo.three_parallel` (UR5, UR10): SP6 + SP1 × 4 + SP3.
-  - `ikgeo.spherical_two_parallel` (Puma 560, Fanuc, KUKA KR): SP4 + SP3 + SP1 + SP4 + SP1 × 2.
-  - `ikgeo.spherical_two_intersecting` (Puma 560 alt., compact arms): SP3 + SP2 + SP4 + SP1 × 2.
-  - `ikgeo.spherical` (generic spherical wrist): SP5 + SP4 + SP1 × 2.
-  - `ikgeo.two_parallel`, `ikgeo.two_intersecting`: tier-1 univariate-search 6R.
-- **Cost note:** these solvers run in 50-200 µs warm-cache (with sub-millisecond first-call cost). Pieper-class arms are basically a closed problem.
-- **Cross-solver agreement on Puma 560:** Puma satisfies *both* `spherical_two_parallel`'s and `spherical_two_intersecting`'s preconditions; the two algebraically-distinct compositions return the same 8-solution set on every pose. This is the strongest correctness guarantee available — see [Chapter 8](08_bulletproof.md).
-- **What Pieper *doesn't* cover:** non-Pieper 6R (no axis triple parallel or intersecting). That's the EAIK gap, addressed in [Chapter 3](03_eaik_gap.md) onward.
+## Pieper's condition
+
+A 6-DOF serial manipulator with three consecutive *intersecting* joint axes admits closed-form IK.
+
+The argument is geometric. If joints 4, 5, 6 share a common point of intersection (a "spherical wrist"), the position of the wrist center is determined by the first three joint angles alone — joints 4, 5, 6 only rotate the EE around the fixed wrist center. So the IK decomposes into:
+
+1. **Inverse position** for $(q_1, q_2, q_3)$: place the wrist center at the target-pose-implied location.
+2. **Inverse orientation** for $(q_4, q_5, q_6)$: rotate the EE around the wrist center to match the target rotation.
+
+Each subproblem is a 3-equation 3-unknown closed-form system. The wrist-center position equation reduces to a quartic; the orientation equation reduces to a $\sin$/$\cos$ pair via Euler-angle extraction.
+
+The same decomposition works (with minor adjustments to which subproblem solves which equations) for arms with three *parallel* axes — three-parallel arms like the UR family decouple via projection onto the shared axis.
+
+Pieper's theorem covers virtually every 6-DOF industrial robot built before 2015: anthropomorphic arms with spherical wrists (Puma, Fanuc, KUKA KR, ABB IRB, Stäubli), collaborative arms with three-parallel shoulders (UR3/5/10, Kassow), and most lab manipulators. Modern arms designed for compactness (Kinova JACO 2, Agilex Piper) deliberately *break* the Pieper condition for mechanical-design reasons (compact wrist housings, non-orthogonal twists for cable routing) — those are the EAIK gap.
+
+## The six canonical subproblems
+
+The Paden–Kahan formulation (1986) and its modern Elias–Wen extension (IK-Geo, 2022/2025) decompose Pieper-class IK into six canonical *subproblems*. Each subproblem is a closed-form geometric primitive — circle/sphere/plane intersection — and each per-family solver chains a specific sequence of subproblems to produce 8 IK solutions per pose.
+
+The subproblems, in order of complexity:
+
+**SP1 — single-axis rotation alignment.** Given an axis $\hat{k}$ and two vectors $\mathbf{p}, \mathbf{q}$, find $\theta$ with $R(\hat{k}, \theta) \mathbf{p} = \mathbf{q}$. Closed form: $\theta = \mathrm{atan2}(\hat{k} \cdot (\mathbf{p} \times \mathbf{q}),\ \mathbf{p} \cdot \mathbf{q} - (\hat{k} \cdot \mathbf{p})(\hat{k} \cdot \mathbf{q}))$. Single-valued (or LS-optimal if input is infeasible). Used for "rotate around joint axis to align two vectors."
+
+**SP2 — two sequential rotations.** Given two axes $\hat{k}_1, \hat{k}_2$ and vectors $\mathbf{p}, \mathbf{q}$, find $(\theta_1, \theta_2)$ with $R(\hat{k}_1, \theta_1) R(\hat{k}_2, \theta_2) \mathbf{p} = \mathbf{q}$. Reduces to two SP1 calls plus a magnitude check. Up to 2 solutions. Used for "rotate around two consecutive joints to align two vectors."
+
+**SP3 — distance constraint on a circle.** Given an axis $\hat{k}$, vectors $\mathbf{p}, \mathbf{q}$, and a target distance $d$, find $\theta$ with $\|R(\hat{k}, \theta) \mathbf{p} - \mathbf{q}\| = d$. Reduces to a quadratic in $\sin\theta$ (or $\cos\theta$). Up to 2 solutions. Used for "elbow distance" — given the wrist center is at a known distance from the shoulder, what's the elbow angle?
+
+**SP4 — projection onto an axis.** Given axes $\hat{h}, \hat{k}$, a vector $\mathbf{p}$, and a target $d$, find $\theta$ with $\hat{h} \cdot R(\hat{k}, \theta) \mathbf{p} = d$. Reduces to a linear-in-$\sin$/$\cos$ equation. Up to 2 solutions. Used for "shoulder pan" — project onto the parallel-trio axis to isolate the base joint.
+
+**SP5 — three sequential rotations placing a position.** Given three axes $\hat{k}_1, \hat{k}_2, \hat{k}_3$ and vectors $\mathbf{p}_0, \ldots, \mathbf{p}_3$, find $(\theta_1, \theta_2, \theta_3)$ with $\mathbf{p}_0 + R(\hat{k}_1, \theta_1) (\mathbf{p}_1 + R(\hat{k}_2, \theta_2) (\mathbf{p}_2 + R(\hat{k}_3, \theta_3) \mathbf{p}_3)) = \mathbf{0}$. Reduces to a quartic in $\tan(\theta_3/2)$. Up to 4 triple solutions. Used for "shoulder-elbow-wrist position chain" when no specialisation is available — the heaviest tier-0 subproblem.
+
+**SP6 — Bezout quartic on two SP4 conditions.** Given paired axes $\{(\hat{h}_i, \hat{k}_i, \mathbf{p}_i)\}_{i=1..4}$ and target scalars $d_1, d_2$, find $(\theta_1, \theta_2)$ such that two SP4 conditions hold simultaneously. Reduces to a Bezout resultant — a quartic in $\tan(\theta_2/2)$. Up to 4 pair solutions. Used for "three-parallel base rotation + wrist roll" in the UR family.
+
+ssik's implementations live in [`src/ssik/subproblems/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/subproblems/) — one module per subproblem (`sp1`, `sp2`, ..., `sp6`), pure-numpy clean-room from the Elias–Wen paper, with hand-computed test vectors for every entry-point case.
+
+## How per-family solvers compose subproblems
+
+For each Pieper-class kinematic family, ssik ships a solver module under [`src/ssik/solvers/ikgeo/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/) that chains the right sequence of subproblems for that family's geometry.
+
+**`ikgeo.spherical_two_parallel`** — three-intersecting-axes wrist + parallel shoulder-elbow (joints 1, 2). Targets: Puma 560, Fanuc LR, KUKA KR series, ABB IRB. Composition:
+
+1. SP4 on the shoulder projection: project the base-to-wrist vector onto the parallel axis to isolate $q_1$. Up to 2 solutions for $q_1$.
+2. For each $q_1$: SP3 on the elbow triangle for $q_3$. Up to 2 solutions.
+3. For each $(q_1, q_3)$: SP1 for $q_2$ from the shoulder plane.
+4. For each $(q_1, q_2, q_3)$: SP4 for the wrist pitch $q_5$.
+5. For each $(q_1, q_2, q_3, q_5)$: SP1 × 2 for $q_4$ and $q_6$.
+
+Total: $2 \times 2 \times 1 \times 2 \times 1 \times 1 = 8$ IK solutions per generic pose.
+
+**`ikgeo.three_parallel`** — three consecutive parallel axes (joints 1, 2, 3). Targets: UR3, UR5, UR10, any other three-parallel-shoulder arm. Composition:
+
+1. SP6 on the parallel-trio + wrist axes for $(q_1, q_5)$ jointly. Up to 4 pair solutions.
+2. For each $(q_1, q_5)$: SP1 for $q_3$ + SP1 × 2 for the dependent $\theta_{14} = q_2 + q_3 + q_4$ and $q_6$.
+3. SP3 for the elbow.
+4. SP1 for $q_2$.
+5. $q_4 = \mathrm{wrap\_to\_pi}(\theta_{14} - q_2 - q_3)$.
+
+Total: 8 IK solutions.
+
+**`ikgeo.spherical_two_intersecting`** — three-intersecting-axes wrist + joints 0,1 sharing an origin ($p_1 = 0$). Alternate composition for Puma 560, ABB IRB smaller variants, compact arms. Composition:
+
+1. SP3 on the elbow distance constraint (since $p_1 = 0$ simplifies the wrist-center position equation).
+2. For each $q_3$: SP2 on the shoulder for $(q_1, q_2)$. Up to 2 pair solutions per $q_3$.
+3. SP4 + SP1 × 2 for the wrist orientation.
+
+Total: 8 IK solutions.
+
+Note Puma 560 satisfies the preconditions of *both* `spherical_two_parallel` and `spherical_two_intersecting` simultaneously. This redundancy is the cross-validation gate from [Chapter 8](08_bulletproof.md): the two algebraically-distinct compositions must return the same 8-solution set on every pose, and they do — over 500 hypothesis poses at 1e-6 wrap-to-π agreement.
+
+**`ikgeo.spherical`** — generic three-intersecting-axes wrist with no additional shoulder specialisation. Falls back to SP5 for the joint shoulder-to-wrist position equation. Up to 8 solutions but slower (~150 µs vs ~50 µs for the specialisations) because SP5's quartic is heavier than SP3 + SP1.
+
+**`ikgeo.two_parallel`** and **`ikgeo.two_intersecting`** — tier-1 univariate-search 6R for arms with two parallel axes (joints 1, 2) but not three, or two intersecting axes at the wrist (joints 4, 5) but not three. SP6 inside a 1D bisection loop over the remaining unconstrained joint. Slower (~1 ms) and partially complete (the 1D search can miss zero crossings); rarely matches commercial arms, but useful for custom geometries.
+
+The dispatcher (in progress; see Chapter 9 for the public API) inspects the kb's topology at registration time and routes to the highest-tier solver that matches.
+
+## Why subproblem composition is so fast
+
+The whole pipeline for `spherical_two_parallel` on Puma 560 involves:
+
+- 1 × SP4 (one 14-element scalar dot product + one quadratic root): ~5 µs.
+- 2 × SP3 (each: one quadratic + an `atan2`): ~5 µs each.
+- 4 × SP1 (each: one `atan2` + one cross product): ~3 µs each.
+- 1 × SP4 (wrist alignment): ~5 µs.
+- 4 × FK forward-kinematics validation: ~10 µs each.
+
+Total: ~80 µs warm-cache, allocations included. Sub-millisecond by an order of magnitude. The arithmetic is dominated by `atan2` calls and small dot products; numpy dispatch overhead is the bottleneck, not LAPACK.
+
+By comparison, the tier-2 RR pipeline on a non-Pieper arm involves a 14×8 SVD, an SVD elimination of 14 rows to 6, a 12×12 matrix assembly, a 24×24 eigendecomposition, and 4–16 back-substitution branches each requiring a 14×8 pseudo-inverse multiplication. ~2.25 ms warm-cache (post the [#86](https://github.com/siddhss5/ikfastpy/issues/86) Tier 1/2 work). 30× slower than tier-0, *and* requiring the entire conditioning-fix machinery from [Chapter 5](05_conditioning.md) to be correct in the first place.
+
+The takeaway: **if your arm is Pieper-class, you get 30× speedup and bulletproof precision for free.** The tier-2 RR machinery exists for arms where Pieper doesn't apply.
+
+## Subproblem robustness — cluster roots
+
+The trickiest subproblem in practice is SP5. Its inner quartic has a **cluster-root pathology** ([#55](https://github.com/siddhss5/ikfastpy/issues/55)): for specific geometric configurations, the four roots split into pairs of nearly-equal values, and `numpy.roots` (which uses companion-matrix eigendecomposition) returns slightly-drifted clusters where two of the four reported roots are off the true roots by ~1e-3 to 1e-4.
+
+Symptom: tests that expect 8 IK solutions get 7 or 9; the spurious solution has FK error ~1e-3 instead of ~1e-12. Fix:
+
+1. Extract candidate roots from the quartic.
+2. Apply Gauss–Newton refinement to each root against the original SP5 polynomial.
+3. Filter imaginary roots with a scale-aware `|imag| < tol * max(|real|, 1)` test.
+
+After SP5's GN polish, cluster-root cases pass at machine precision. The fix lives in `ssik.subproblems.sp5`; the cross-solver Puma agreement gate ([Chapter 8](08_bulletproof.md)) was the test that surfaced the bug. The same pattern applies to SP6's Bezout quartic, with a slightly different invariant (memory entry [`reference_ikfast_analytical_tricks`](https://github.com/siddhss5/ikfastpy/issues/81) covers the lineage).
+
+This is the kind of stability work that doesn't show up in user-facing API documentation but matters enormously for "must be perfect, all the time" — a 1% cluster-root failure rate on SP5 would invalidate every Pieper-class solver in the library.
 
 ## References
 
-- Pieper, D. L. (1968). PhD thesis, Stanford.
-- Paden, B. (1986). PhD thesis, UC Berkeley.
-- Elias, A. & Wen, J. (2022/2025). "IK-Geo: unified robot inverse kinematics using subproblem decomposition." [arXiv:2211.05737](https://arxiv.org/abs/2211.05737).
-- Ostermeier, D. (2024). "EAIK: a Toolbox for Efficient Analytical Inverse Kinematics." [arXiv:2409.14815](https://arxiv.org/abs/2409.14815).
+- **Pieper, D. L.** (1968). *The Kinematics of Manipulators Under Computer Control.* PhD thesis, Stanford. — The original solvability-via-three-intersecting-axes theorem.
+- **Paden, B.** (1986). *Kinematics and Control of Robot Manipulators.* PhD thesis, UC Berkeley. — Subproblem decomposition (SP1–SP3 in modern terminology).
+- **Elias, A. & Wen, J.** (2022/2025). "IK-Geo: unified robot inverse kinematics using subproblem decomposition." [arXiv:2211.05737](https://arxiv.org/abs/2211.05737). — Modern unified treatment of SP1–SP6 with the per-family compositions ssik ports.
+- **Ostermeier, D.** (2024). "EAIK: a Toolbox for Efficient Analytical Inverse Kinematics." [arXiv:2409.14815](https://arxiv.org/abs/2409.14815). — Family-detection-driven dispatch over the same subproblem library.

--- a/docs/tutorial/03_eaik_gap.md
+++ b/docs/tutorial/03_eaik_gap.md
@@ -1,37 +1,77 @@
 # 3. The EAIK gap
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in.
+[Chapter 2](02_pieper_subproblems.md) covered Pieper-class arms — those with three consecutive intersecting wrist axes or three consecutive parallel shoulder axes. EAIK and IK-Geo solve those families in 50–200 µs warm-cache, machine-precision FK closure, all 8 branches at once. For the dominant share of commercial 6R arms (UR3/5/10, Puma 560, Fanuc, KUKA KR, ABB IRB) those tools are excellent and ssik bundles their algorithms via the BSD-3 IK-Geo port.
 
-## What this chapter covers
+The arms whose IK is **not** a one-line call against EAIK or IK-Geo — the ones whose geometry deliberately violates Pieper's condition for mechanical-design reasons — are the EAIK gap. ssik exists for them. This chapter catalogues the gap, walks through why the obvious workarounds don't work, and frames the strategic positioning of the library.
 
-The arms whose IK is **not** a one-line call against EAIK or IK-Geo, and why the obvious workarounds don't work.
+## Arms outside the Pieper class
 
-### Arms outside the Pieper class
+**Kinova JACO 2 (j2n6s200).** Six revolute joints. Joints 1–3 form a conventional shoulder-elbow-elbow configuration. The wrist (joints 4, 5, 6) is **non-orthogonal**: the consecutive twists between joints 4 and 5, and between joints 5 and 6, are 60° rather than the 90° that would put the axes on standard orthogonal planes.
 
-- **Kinova JACO 2 (j2n6s200):** 60° non-orthogonal twists at joints 4–5. The quat=(0, 0, 0.5, 0.866) rotation between consecutive wrist links means no two wrist axes intersect, no axis triple is parallel, and the standard subproblem compositions all fail their preconditions. Real fixture in [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py), transcribed from `robot-code/ada_assets/.../jaco2.xml` MJCF (#80).
-- **Agilex Piper:** similar non-Pieper geometry.
-- **Flexiv Rizon 4:** 7-DOF non-SRS arm. Joint-locking turns it into a 6R per lock value, but the resulting sub-chain is non-Pieper at every lock value.
-- **Custom geometries** from machined-from-scratch arms or kinematic prototyping.
+Concretely, the MJCF places `link_5` and `link_6` with `quat = (0, 0, 0.5, 0.866025)` — a 60° rotation around the local z-axis. As a result, no two wrist axes are parallel, no two intersect, and the wrist isn't spherical. Joints 4-5-6 form a **non-Pieper** sub-chain, and the standard subproblem compositions can't apply: SP4 (used for spherical-wrist alignment) requires the three wrist axes to share a common point; SP5 (used for the generic shoulder-elbow-wrist position chain) develops degenerate cluster roots near these geometries. Real fixture in [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py), transcribed from `robot-code/ada_assets/.../jaco2.xml`.
 
-### Why the obvious approaches don't work
+The 60° twists are intentional — they let Kinova package the wrist's three motors into a more compact volume than an orthogonal wrist would allow, at the cost of giving up Pieper's analytical IK. Modern compact arms make this trade-off frequently: motor packaging volume traded against IK closed-form solvability.
 
-- **Subproblem composition (EAIK / IK-Geo):** the geometric specialisations (three intersecting wrist axes, three parallel shoulder axes) never apply. SP5's polynomial setup has structural degeneracy on these chains.
-- **IKFast (Diankov 2010):** its symbolic codegen pipeline depends on a 2010-vintage sympy that doesn't exist anymore. Modern sympy + mpmath stack causes `polyroots NoConvergence` at substitution / `solveLiWoernleHiller` time. Verified on real arms — UR5 (797s before failure on cambel URDF), Puma-with-d5=0.01 (617s, NoConvergence), JACO 2. Hours-to-days of derivation on cases where it works at all. The vendored `_legacy/` tree is a museum piece.
-- **Numeric IK (mink, KDL, TRAC-IK):** works but pays the iterative cost, returns one solution rather than the full branch set, and gives no up-front "unreachable" signal. Mink at ~20 ms per call versus ssik's ~2.25 ms median on JACO 2 (post-Tier 2.3 of #86).
+**Agilex Piper.** A 6R arm with similar non-Pieper geometry: the wrist twists aren't orthogonal, and no axis triple is parallel. (Less commercially deployed than JACO 2 but follows the same compactness-driven design philosophy.)
 
-### What this means for ssik's design
+**Flexiv Rizon 4.** A 7-DOF arm. The 7-DOF case is more general than the 6-DOF case — IK on a 7R has a continuous **redundancy manifold** of solutions for any given target pose — but a common reduction is **joint-locking**: fix one joint at a sample value, solve the remaining 6R. ssik's `jointlock.seven_r` does this generically (sweep one configurable joint over N samples; dispatch each lock value to the best-matching 6R inner solver). For Rizon 4 the locked sub-chains are non-Pieper at every lock value because the wrist geometry is non-orthogonal — same gap as JACO 2.
 
-- **ssik bundles tier-0/1 closed-form solvers** for the Pieper-class arms (covered by EAIK / IK-Geo), so you don't pay the tier-2 cost when you don't need to.
-- **ssik's tier-2 numeric Raghavan–Roth solver** ([Chapter 4](04_raghavan_roth.md)) handles the gap arms.
-- **The dispatcher** picks the right tier per kb at registration time; users call `solve(kb, T)` and don't think about it.
+**Custom geometries.** Lab manipulators, prototype arms from kinematic-design exercises, "what if my wrist twist were 47 degrees" experiments. These often deliberately break Pieper because the designer doesn't care about closed-form IK or wants to test the general case. They're the arms ssik users running their own kinematic prototyping bring.
 
-### The strategic frame
+## Why the obvious approaches don't work
 
-EAIK / IK-Geo cover the easy 80% of commercial arms. ssik covers the harder 20% — the EAIK gap. That's where a millisecond-level analytical IK solution didn't exist before. Memory entry [`project_eaik_gap_strategy`](https://github.com/siddhss5/ikfastpy/issues/78) covers the strategic positioning.
+**Subproblem composition (EAIK / IK-Geo).** The geometric specialisations don't apply: there's no spherical wrist for SP4 to project onto, no parallel-axis trio for SP6's Bezout setup. The `ikgeo.spherical` solver falls back to SP5 for the shoulder-elbow-wrist position chain when no specialisation matches, but SP5 itself develops structural degeneracy on these chains — its quartic has near-triple roots when the wrist twist isn't orthogonal, which break the cluster-root recovery from [Chapter 2](02_pieper_subproblems.md).
+
+In practice, calling `ikgeo.spherical.solve(jaco2_kb, T_target)` raises `ValueError` at the topology gate: the predicate `three_consecutive_intersecting(joints, policy)` returns `(-1, -1, -1)` instead of `(3, 4, 5)` — the wrist axes don't intersect at any single point.
+
+**IKFast (Diankov 2010, OpenRAVE).** The original IKFast pipeline — symbolic codegen via sympy — was supposed to handle anything. Modern reality:
+
+- The codegen depends on a 2010-vintage `sympy.polys` API that has been substantially rewritten since. Module-level imports fail on `sympy >= 1.5`.
+- The `solveLiWoernleHiller` numerical step calls `mpmath.polyroots` on a degree-16 univariate polynomial. On modern `mpmath`, this raises `NoConvergence` after `maxsteps=5000` iterations on real-arm parameter sets. Verified on UR5 (797 s before failure on the cambel URDF), Puma-with-d5=0.01 (617 s, NoConvergence), POE-normalized UR5, and JACO 2.
+- Even when the symbolic derivation does complete, it takes hours-to-days per arm. The output is a single C++ file specialised to that one robot's DH parameters — change one number and you re-derive from scratch.
+- The vendored copy in this repo's `_legacy/` (slated for deletion in [#84](https://github.com/siddhss5/ikfastpy/issues/84)) is a museum piece. It works on the few specific 2010-era examples that still pass through modern sympy; it doesn't work on JACO 2 or Piper or any of the post-2015 arms ssik users actually need to solve.
+
+The polynomial-coefficient cliff that breaks IKFast on JACO 2 is the *same* conditioning failure that we covered in [Chapter 5](05_conditioning.md) — a singular pencil that the textbook algorithm can't survive. IKFast's response was "wait longer for `mpmath.polyroots`" (i.e. keep iterating with higher precision); ssik's response is the AE-1/3/4 conditioning suite that makes the algebraic problem well-conditioned to begin with.
+
+**Numeric IK (mink, KDL, TRAC-IK, Pinocchio, drake).** These work — every modern numerical IK library handles non-Pieper 6R fine — but pay the iterative cost. On real benchmarks:
+
+| solver | JACO 2 IK time | what it returns |
+|---|---|---|
+| mink (Python wrapper, JIT-warmed) | ~20 ms | one solution |
+| KDL (C++ via ROS) | ~1-5 ms | one solution |
+| ssik tier-2 RR (current, post-#86 Tier 2.3) | ~2.25 ms median | all 4-16 branches |
+
+mink and KDL give you one solution. ssik gives you all of them — in a single call, with stable `branch_id` indices that let you track which physical configuration is which across a trajectory. Numeric solvers also have no up-front "unreachable" signal: if the target is unreachable, mink returns the closest reachable approximation rather than telling you it failed. ssik's `is_ls=True` explicitly distinguishes "no candidate met `fk_atol`" (could be unreachable, could be ill-conditioned) from "found N solutions".
+
+## What this means for ssik's design
+
+Three architectural decisions follow from the gap analysis:
+
+**1. ssik bundles tier-0/1 closed-form solvers** (port of IK-Geo) for Pieper-class arms. We don't make the user pay the tier-2 cost when their arm has the Pieper specialisation — they get the same 50-200 µs latency EAIK gives them, with the same `Solution` shape and refinement contract from [Chapter 6](06_refinement.md).
+
+**2. ssik's tier-2 numeric Raghavan–Roth solver** ([Chapter 4](04_raghavan_roth.md)) handles the gap arms. The math has been around since 1990 (Raghavan–Roth) and 1994 (Manocha–Canny); what's new is the **conditioning robustness** ([Chapter 5](05_conditioning.md)) that makes the algebraic pipeline survive on real ill-conditioned arm geometries. Without AE-3 leftvar selection, the textbook RR pipeline fails on JACO 2 — same failure mode as IKFast.
+
+**3. The dispatcher** picks the right tier per kb at registration time (work in progress; see [Chapter 9](09_practical_guide.md)). Users call `solve(kb, T)` and don't think about tiers; the library routes to `ikgeo.three_parallel` for UR5, `ikgeo.spherical_two_parallel` for Puma, and `ikgeo.general_6r` (the tier-2 RR) for JACO 2 — all returning the same `tuple[list[Solution], bool]` shape.
+
+## The strategic frame
+
+EAIK and IK-Geo cover the easy 80% of commercial 6R arms. ssik covers the harder 20% — the EAIK gap. That's where a millisecond-level analytical IK solution didn't exist before.
+
+Memory entry [`project_eaik_gap_strategy`](https://github.com/siddhss5/ikfastpy/issues/78) frames the positioning:
+
+> Non-Pieper 6R (JACO 2, Piper) + non-SRS 7R (Rizon 4) is the wedge. Duplicating EAIK's Pieper/SRS coverage adds nothing.
+
+The library's value isn't in being a faster EAIK — it isn't, on Pieper-class arms (we run IK-Geo's algorithm; can't beat it without codegen). The value is in covering the arms EAIK and IK-Geo *don't* cover, with the same precision contract and the same `Solution` API the rest of the library uses. A user with a fleet of mixed UR5s and JACO 2s shouldn't have to write two different solver paths; ssik gives them one API.
+
+## What the rest of the tutorial covers
+
+Chapters 4 and 5 are the load-bearing technical chapters: the Raghavan–Roth math and the conditioning fixes that make it survive on real arms. Chapters 6, 7, 8 cover the architectural pieces — the `Solution` / `lm_refine` contract, the POE → DH bridge with the JACO 2 `T_pre` bug fix, and the bulletproof validation discipline. Chapters 9 and 10 are practical-guide and roadmap.
+
+If you're here because you have a JACO 2 / Piper / Rizon-style arm and need analytical IK, [Chapter 9](09_practical_guide.md) is the practical entry point and [Chapter 4](04_raghavan_roth.md) is the technical backstop. If you're here because you're porting analytical IK to a new arm family, [Chapter 5](05_conditioning.md) is essential reading: the conditioning intuitions transfer to any algebraic-elimination IK pipeline.
 
 ## References
 
-- Raghavan, M. & Roth, B. (1990). "Inverse kinematics of the general 6R manipulator and related linkages." *J. Mech. Design*.
-- Manocha, D. & Canny, J. F. (1994). "Efficient inverse kinematics for general 6R manipulators." *IEEE T-RA* 10(5):648–657.
-- Tsai, L.-W. (1999). *Robot Analysis: The Mechanics of Serial and Parallel Manipulators.* Wiley. Appendix C.
+- **Raghavan, M. & Roth, B.** (1990). "Inverse kinematics of the general 6R manipulator and related linkages." *Journal of Mechanical Design*. — The 14-equation algebraic-elimination foundation of the tier-2 pipeline.
+- **Manocha, D. & Canny, J. F.** (1994). "Efficient inverse kinematics for general 6R manipulators." *IEEE Transactions on Robotics and Automation* 10(5):648–657. — The companion-matrix eigenvalue route + Möbius reparameterization fallback.
+- **Tsai, L.-W.** (1999). *Robot Analysis: The Mechanics of Serial and Parallel Manipulators.* Wiley. Appendix C. — Pedagogical treatment of the RR derivation that ssik's clean-room implementation follows.
+- **Ostermeier, D.** (2024). [EAIK](https://github.com/OstermD/EAIK). — Where the gap analysis pivots: EAIK explicitly doesn't cover the cases ssik does.

--- a/docs/tutorial/06_refinement.md
+++ b/docs/tutorial/06_refinement.md
@@ -1,63 +1,135 @@
 # 6. Algebraic-first, refinement-second
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in. Implementation: [`src/ssik/refinement/`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/) and the `Solution` dataclass at [`src/ssik/core/solution.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/core/solution.py). Design rationale in [#74](https://github.com/siddhss5/ikfastpy/issues/74) and [#75](https://github.com/siddhss5/ikfastpy/issues/75).
+The Raghavan–Roth pipeline of [Chapter 4](04_raghavan_roth.md) and the conditioning fixes of [Chapter 5](05_conditioning.md) get you to algebraic candidate solutions. For well-conditioned arms with the right leftvar choice, those candidates are at machine precision and you're done. For ill-conditioned poses or adversarial geometries, the candidates are *near misses* — close enough that one Newton step on the FK residual would converge them, but not close enough to call themselves "the answer".
 
-## What this chapter covers
+Every analytical-IK library has to decide what to do with near-miss candidates. The choice is more than a tuning decision; it's a **contract with the user** about what "analytical IK" actually means. ssik's contract is: **pure algebraic by default, opt-in Newton polish, transparent diagnostics**.
 
-The contract every ssik solver follows: **pure algebraic by default, opt-in Newton polish, transparent diagnostics**.
+This chapter walks through that contract, the `Solution` dataclass that surfaces it, and the `lm_refine` primitive that implements the opt-in polish.
 
-### The contract (#74)
+## The contract
 
-- Default: `solve(kb, T) -> tuple[list[Solution], bool]`. Candidates that don't reach `fk_atol` algebraically are **dropped**, not silently polished.
-- Opt-in: `solve(kb, T, allow_refinement=True)`. Each near-miss candidate goes through one [`lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py) pass — Newton on the SE(3) log residual via the spatial Jacobian.
-- Per-`Solution` reporting: `refinement_used: Literal["none", "lm"]`, `refinement_iters: int`. The caller always knows what fired.
+The shape every solver in ssik exposes:
 
-### Why this matters
+```python
+def solve(
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    *,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+) -> tuple[list[Solution], bool]:
+    ...
+```
 
-Numerical refinement hidden inside an "analytical" solver is one of the worst-of-both-worlds anti-patterns. The user thinks they're getting algebraic precision; in fact they're getting whatever Newton converged to in 100 iterations of LM. ssik's contract makes the algebraic / iterative line *explicit* and surfaces it on every returned `Solution`.
+The contract is in three lines:
 
-### `lm_refine` — the universal polish primitive
+- **Default** (`allow_refinement=False`): candidates that miss `policy.subproblem_numerical` algebraically are **dropped**, not silently polished. The solver returns only solutions that the algebraic pipeline produced at the requested tolerance.
+- **Opt-in** (`allow_refinement=True`): each near-miss candidate gets one [`lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py) pass — Newton on the SE(3) log residual via the spatial Jacobian. If it converges within `refinement_max_iters`, the polished `q` is included; if not, dropped.
+- **Per-Solution reporting**: the returned `Solution` dataclass carries `refinement_used: Literal["none", "lm"]` and `refinement_iters: int`. The caller always knows what fired on every solution.
 
-Hand-rolled Newton, no scipy:
+This is GitHub issue [#74](https://github.com/siddhss5/ikfastpy/issues/74)'s design spec. The corresponding dataclass is [#75](https://github.com/siddhss5/ikfastpy/issues/75).
 
-- Input: seed `q`, FK callable, target pose, optional analytical Jacobian.
-- Inner loop: compute SE(3)-log residual $r = \log(T \cdot \mathrm{FK}(q)^{-1}) \in \mathbb{R}^6$, solve $J_s\, \delta q = r$ via LAPACK, step-clip $\|\delta q\|_\infty \le 0.5$ rad, iterate until $\|r\| < \mathrm{fk\_atol}$ or `max_iters` hit.
-- No divergence-abort heuristic: Newton can be non-monotonic near saddles or under step-clipping; aggressive early termination misses real recoveries.
-- Single LAPACK `solve` per iter; ~50× faster than the scipy LM wrapper on cases where 1–5 iters suffice.
+## Why this contract specifically
 
-### `Solution` dataclass
+The obvious alternative — always run Newton inside the solver, hide it from the user — is the worst-of-both-worlds anti-pattern. The user thinks they're getting *analytical* IK; in fact they're getting whatever Newton converged to in 100 iterations of Levenberg–Marquardt. The reported "FK error" is post-LM-polish, which can hide structural problems with the algebraic pipeline (e.g. a leftvar choice that makes most candidates fail by orders of magnitude — the user wouldn't notice because LM cleans it up before they see it).
+
+The Day-4 prototype of ssik's tier-2 RR solver did exactly that: scipy LM was embedded in the candidate-validation loop, up to 100 iterations per branch. It worked — JACO 2 reached FK error 5.7e-9 — but the architecture was wrong:
+
+- Users couldn't tell whether their IK call was deterministic or iterative.
+- Iteration counts ballooned (100 LM iters for cases Manocha–Canny §V-E specifies handle in 1–2 Newton steps).
+- FK tolerance became a hidden default rather than a user-facing contract.
+
+The user's verbatim direction at the time:
+
+> we can't just paper over LS randomly. it's a last resort and we need to assert exactly when and where we need it. We also need to be super transparent to the user why we're using LS and what the tolerance is and also if they want to do it at all on their robot or just skip it and reject solutions if they don't meet tolerance.
+
+The contract is the codification of that direction.
+
+## The `Solution` dataclass
+
+Every solver in ssik returns `tuple[list[Solution], bool]` where `Solution` is:
 
 ```python
 @dataclass(frozen=True)
 class Solution:
-    q: NDArray[np.float64]
-    fk_residual: float
-    refinement_used: Literal["none", "lm"]
-    refinement_iters: int
-    branch_id: int | None = None
-    solver_name: str = ""
+    q: NDArray[np.float64]                       # joint vector
+    fk_residual: float                            # ||FK(q) - T_target||_F at return time
+    refinement_used: Literal["none", "lm"]        # whether polish fired
+    refinement_iters: int                         # iteration count if it did (0 otherwise)
+    branch_id: int | None = None                  # IK branch index (0..15 for 6R RR)
+    solver_name: str = ""                         # e.g. "ikgeo.general_6r"
 ```
 
-Returned by every solver. Frozen — derived data, callers shouldn't mutate.
+Frozen — derived data, callers shouldn't mutate. The dataclass lives at [`src/ssik/core/solution.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/core/solution.py).
 
-### `verify_candidates` — the shared back-half
+The fields encode the exact provenance and precision of each solution. `fk_residual` is what you'd measure if you computed `np.linalg.norm(FK(q) - T_target)` yourself; the solver's `fk_atol` was a *filter*, not a contract on the value reported here. `refinement_used` is the algebraic-vs-iterative flag — `"none"` means pure algebraic, `"lm"` means Newton-polished. `refinement_iters` says how many iterations consumed (0 if none). `branch_id` is the IK branch index (the back-substitution route assigns a stable index 0..15 per pose for the 16-root RR solver). `solver_name` is useful when results pass through a dispatcher.
 
-Every solver runs the same pattern after producing raw joint-angle candidates: FK-verify, optionally Newton-polish, dedup. Factored once into [`ssik.refinement.verify_candidates`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py); ten solvers consume it.
+This shape has carried through every solver migration in [PR #85](https://github.com/siddhss5/ikfastpy/pull/85): the ten public solvers (six tier-0 closed-form, two tier-1 univariate-search, one tier-2 grid, one tier-2 RR, one jointlock 7R wrapper) all return the same shape with the same semantic guarantees.
 
-### When refinement actually fires
+## `lm_refine` — the universal polish primitive
 
-- Tier-0 closed-form solvers (Pieper-class): **never**, by design. Algebraic precision is at machine epsilon.
-- Tier-2 RR solver, well-conditioned arm (JACO 2 post-AE-3): never. 96.6% algebraic_pass at $10^{-13}$ FK error. The refinement plumbing exists but doesn't trigger.
-- Tier-2 RR solver, MC Table I synthetic: ~99% of candidates need polish (the textbook fixture is ill-conditioned by design). With `allow_refinement=True` the median-polish-iteration count is 4. Without, candidates get dropped and `is_ls=True` fires. (#82.)
+The opt-in polish is a hand-rolled Newton method on the SE(3) log residual. Implementation: [`ssik.refinement.lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py). The signature:
 
-### What this gives users
+```python
+def lm_refine(
+    q_seed: NDArray[np.float64],
+    fk_fn: Callable[[NDArray[np.float64]], NDArray[np.float64]],
+    t_target: NDArray[np.float64],
+    *,
+    fk_atol: float = 1e-9,
+    max_iters: int = 15,
+    jacobian_fn: Callable[[NDArray[np.float64]], NDArray[np.float64]] | None = None,
+    step_clip: float = 0.5,
+) -> tuple[NDArray[np.float64], float, int] | None:
+    ...
+```
 
-- A calling pattern that's identical across all 10 solvers in ssik.
-- A precision contract that's enforceable: "if `refinement_used == 'none'`, this is pure-algebraic at the reported `fk_residual`".
-- A debug surface: when something goes wrong, `Solution.refinement_iters > 5` is a flag that the algebraic path is struggling and you might want to investigate the geometry.
+The inner loop in pseudocode:
 
-## References
+1. Compute `T_q = fk_fn(q)`.
+2. Compute residual $r = \log(T_{\mathrm{target}}\, T_q^{-1}) \in \mathbb{R}^6$ (translation + axis-angle rotation).
+3. If $\|r\| < \mathrm{fk\_atol}$, return $(q, \|r\|, \mathrm{iter})$.
+4. Compute spatial Jacobian $J_s$ (analytical if `jacobian_fn` given; central differences otherwise — slow).
+5. Solve $J_s\, \delta q = r$ via LAPACK `np.linalg.solve` (with Tikhonov-damped fallback on singular Jacobian).
+6. Step-clip $\|\delta q\|_\infty \le \mathrm{step\_clip}$ rad to keep the trajectory inside the linearisation regime.
+7. $q \leftarrow q + \delta q$, repeat.
+8. After `max_iters` if still above tolerance, return `None`.
 
-- Memory entry [`feedback_refinement_architecture`](https://github.com/siddhss5/ikfastpy/issues/74).
-- GitHub PR #85 (the migration that landed this contract across all solvers).
+There is **no divergence-abort heuristic**. Newton can be non-monotonic near saddles or under step-clipping; aggressive early termination misses real recoveries. We trust the `max_iters` cap and a final residual check.
+
+Single LAPACK `solve` per iter, no scipy. Roughly 50× faster than the original scipy-LM wrapper on cases where 1–5 iters suffice (which is virtually all reasonable seeds when the spatial Jacobian is exact).
+
+## `verify_candidates` — the shared back-half
+
+The pattern after producing raw joint-angle candidates — FK-verify, optionally Newton-polish, dedup — is identical across every solver in ssik. It's factored once into [`ssik.refinement.verify_candidates`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py); ten solvers consume it. That's how the contract gets enforced uniformly: the dedup-by-fk-residual rule, the wrap-to-π comparison, the `Solution` wrapping with the right `refinement_used` flag — all live in one place.
+
+The helper takes the raw candidates plus an `fk_fn`, optional `jacobian_fn`, target pose, tolerance policy, and the `allow_refinement` flag, and returns a deduplicated `list[Solution]`. Solvers boil down to: produce raw `q` candidates from the algebraic algorithm, hand them to `verify_candidates`, return the result.
+
+## When refinement actually fires
+
+In practice the refinement plumbing rarely triggers because the algebraic pipeline plus the AE-1/3/4 conditioning fixes get most arms to machine precision:
+
+- **Tier-0 closed-form solvers** (Pieper-class — `spherical_two_parallel`, `three_parallel`, etc.): never. Algebraic precision is at machine epsilon by construction. The `verify_candidates` plumbing exists for uniformity but the lm_refine path doesn't enter.
+- **Tier-2 RR solver, well-conditioned arm**: never on real arms with the right leftvar. Real JACO 2 j2n6s200 with AE-3-selected leftvar = q₁ runs at 96.6% algebraic_pass with median FK error 3.7e-13 across 100 random poses (post-Tier 2.3 of [#86](https://github.com/siddhss5/ikfastpy/pull/90)). Refinement off, `is_ls=False`, all branches recovered.
+- **Tier-2 RR solver, MC Table I synthetic** (textbook benchmark from Manocha–Canny 1994, deliberately ill-conditioned): ~99% of candidates need polish. With `allow_refinement=True` median Newton iteration count is 4. Without, candidates get dropped and `is_ls=True` fires for some poses. Tracked as [#82](https://github.com/siddhss5/ikfastpy/issues/82) — a known *completeness* gap on a synthetic fixture.
+
+## What this gives users
+
+1. **A uniform calling pattern.** Every solver in ssik takes `(kb, T_target, policy, *, allow_refinement, refinement_max_iters)` and returns `tuple[list[Solution], bool]`. Switching from one solver to another is a one-line import change.
+
+2. **A precision contract that's enforceable.** If `Solution.refinement_used == "none"`, the value is pure-algebraic at the reported `fk_residual`. The user gets to choose whether iterative polish was acceptable for their use case.
+
+3. **A debug surface.** `Solution.refinement_iters > 5` is a flag that the algebraic path is struggling on this specific pose — worth investigating if you see it consistently (it usually means the arm is at or near a singularity, or the leftvar choice isn't ideal).
+
+4. **A mental model**: ssik draws the algebraic / iterative line *explicitly*. There is no "mostly analytical" middle ground — solutions are either reported pure-algebraic (with `refinement_used="none"`) or pure-Newton-polished from a near-miss algebraic seed (with `refinement_used="lm"` and an iteration count).
+
+## The architectural rule
+
+When something is structurally a separate concern, the user-facing API should make it look like a separate concern. Numerical refinement is structurally separate from algebraic IK — it's a different algorithm operating on a different correctness contract — and ssik's API treats it that way. The solver / refinement separation is the same architectural move that distinguishes optional features (`allow_refinement` flag) from the core path (algebraic-only by default).
+
+The corresponding [memory entry](https://github.com/siddhss5/ikfastpy/issues/74) reads, verbatim:
+
+> Numerical refinement is a separate, opt-in, transparent layer. Solvers produce algebraic candidates; LS/Newton lives in `ssik.refinement`, off by default, FK-tolerance-driven, surfaces what fired.
+
+That's what's shipping.

--- a/docs/tutorial/07_kinbody_bridge.md
+++ b/docs/tutorial/07_kinbody_bridge.md
@@ -1,22 +1,46 @@
 # 7. The KinBody-input bridge
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in. Implementation: [`src/ssik/kinematics/poe_to_dh.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/kinematics/poe_to_dh.py), [`src/ssik/solvers/ikgeo/general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/general_6r.py). Tracking issue [#79](https://github.com/siddhss5/ikfastpy/issues/79).
+The Raghavan–Roth solver of [Chapter 4](04_raghavan_roth.md) speaks **standard distal-DH** — a kinematic representation where each joint contributes $A_i = R_z(\theta_i) T_z(d_i) T_x(a_i) R_x(\alpha_i)$ and frames must be placed with $z_i$ along the joint axis and $x_i$ along the common perpendicular to $z_{i-1}$. Users speak **POE** (Product of Exponentials) — the modern convention where each joint contributes a `T_left @ R_axis(joint.axis, q) @ T_right` factor and frame placement is whatever the URDF or MJCF says it is.
 
-## What this chapter covers
+These two representations encode the same kinematic chain, but the algebra in DH form is incompatible with POE form. Asking the user to convert is a footgun (DH parameterisation has six different conventions in use; nobody agrees which is "standard"). The library converts internally.
 
-How POE-form `KinBody` inputs (the canonical ssik / IK-Geo / EAIK convention) get bridged to the standard distal-DH representation that the Raghavan–Roth solver internally uses.
+This chapter walks through the conversion, the bridging transforms `T_pre` and `T_post`, and the load-bearing bug that hid behind UR5's accidental world-z alignment for months until JACO 2 broke it. Implementation: [`src/ssik/kinematics/poe_to_dh.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/kinematics/poe_to_dh.py); the public solver wrapper that uses it: [`src/ssik/solvers/ikgeo/general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/general_6r.py). Tracking issue [#79](https://github.com/siddhss5/ikfastpy/issues/79).
 
-### POE vs DH
+## POE versus DH
 
-- **POE (Product of Exponentials):** every joint contributes a `T_left @ R_axis(joint.axis, q) @ T_right` factor. Conventional in modern robotics (Murray–Li–Sastry); easy to express directly from URDF or MJCF.
-- **DH (Denavit–Hartenberg):** every joint contributes $A_i = R_z(\theta_i) T_z(d_i) T_x(a_i) R_x(\alpha_i)$. Frame placement is constrained: $z_i$ must be the joint axis, $x_i$ must lie along the common perpendicular to $z_{i-1}$. Conventional in textbook IK derivations (Spong, Tsai).
+**Product of Exponentials** is the convention from Murray–Li–Sastry. Each joint $i$ contributes a transform
 
-The Raghavan–Roth solver's algebra ([Chapter 4](04_raghavan_roth.md)) is in DH form. The user's input is in POE form. We need to bridge.
+$$
+J_i(q) = T_{\mathrm{left},i} \cdot R_{\mathrm{axis}}(\hat{a}_i, q_i) \cdot T_{\mathrm{right},i}
+$$
 
-### `poe_to_dh(kb) -> DhWithOffset`
+where $T_{\mathrm{left},i}, T_{\mathrm{right},i} \in \mathrm{SE}(3)$ are arbitrary rigid transforms and $\hat{a}_i$ is the joint axis in the joint's local frame. The forward kinematics is
 
-Returns:
+$$
+\mathrm{FK_{POE}}(q) = \prod_{i=1}^{n} J_i(q_i).
+$$
+
+POE is convenient because $T_{\mathrm{left}}$ and $T_{\mathrm{right}}$ can be read directly from URDF `<origin>` tags or MJCF `<body pos quat>` attributes. There's no constraint on frame placement; you describe the chain however the upstream model author described it.
+
+**Standard distal-DH** (Spong) is more constrained. The forward kinematics is
+
+$$
+\mathrm{FK_{DH}}(\theta_1, \ldots, \theta_n) = \prod_{i=1}^{n} A_i(\theta_i), \qquad A_i = R_z(\theta_i)\, T_z(d_i)\, T_x(a_i)\, R_x(\alpha_i),
+$$
+
+with frame placement constraints:
+
+- $z_i$ along joint $(i+1)$'s axis (so $z_0$ along joint 1's axis).
+- Origin of frame $i$ at the foot of the common perpendicular between $z_{i-1}$ and $z_i$, on $z_i$'s line.
+- $x_i$ along the common perpendicular, from $z_{i-1}$ to $z_i$.
+
+DH is convenient because the algebra closes elegantly — the $A_i$ structure is tight enough that Raghavan–Roth's loop-closure split works. The constraints are the price.
+
+The conversion `poe_to_dh(kb)` walks the POE chain, computes joint axes and origins in world coordinates, and places DH frames satisfying the constraints.
+
+## The `DhWithOffset` shape
+
+The conversion returns a [`DhWithOffset`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/kinematics/poe_to_dh.py) carrying:
 
 ```python
 @dataclass
@@ -25,46 +49,75 @@ class DhWithOffset:
     a: NDArray             # length-6, link lengths
     d: NDArray             # length-6, link offsets
     theta_offset: NDArray  # length-6, per-joint angle offset
-    t_pre: NDArray         # 4x4, world to DH frame 0
-    t_post: NDArray        # 4x4, DH frame n to user EE
+    t_pre: NDArray         # 4x4, world frame -> DH frame 0
+    t_post: NDArray        # 4x4, DH frame n -> user EE
 ```
 
-Such that for every $q$:
+with the contract
 
 $$
-\mathrm{FK_{POE}}(q) = T_{\mathrm{pre}}\, \mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})\, T_{\mathrm{post}}.
+\mathrm{FK_{POE}}(q) = T_{\mathrm{pre}}\, \mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})\, T_{\mathrm{post}}
 $$
 
-### Algorithm
+for every $q$. The `(alpha, a, d)` triple is what the Raghavan–Roth pipeline consumes; `theta_offset` accounts for the user's joint zero positions not aligning with DH's zero positions; and `T_pre`, `T_post` are the bridging rotations that translate between the user's world frame, DH frame 0, DH frame n, and the user's end-effector frame.
 
-1. Walk the POE chain at $q = 0$: extract joint axes $z_i$ in world frame, joint origins $p_i$ in world frame, and the home-pose end-effector transform $T_{\mathrm{home}} = \mathrm{FK_{POE}}(0)$.
-2. Place DH frames 0 to $n$ in world coords:
-   - $z_i$ = joint $(i+1)$'s axis in world (i.e., `axes_world[i]` for $i < n$); $z_n$ = $T_{\mathrm{home}}$'s z-axis.
-   - Origin of frame $i$: foot of common perpendicular between $z_{i-1}$ and $z_i$ on $z_i$'s line.
-   - $x_i$ direction: along the common perpendicular, from $z_{i-1}$ toward $z_i$. For parallel axes use the foot-to-foot direction; for intersecting axes use $(z_{i-1} \times z_i)$ normalised.
-3. Read off $(\alpha_i, a_i, d_i, \theta_{\mathrm{offset},i})$ per transition by computing signed angles + projected distances.
-4. Build $T_{\mathrm{pre}}$ from frame 0's $(x_0, y_0, z_0, \mathrm{origin})$ as columns of the rotation block + translation.
-5. Build $T_{\mathrm{post}}$ to absorb any residual rotation between DH frame $n$ at $q = \theta_{\mathrm{offset}}$ and the actual $T_{\mathrm{home}}$.
+For commercial arms with conventional URDF base orientation (joint 1 axis = world +z, base at world origin), `T_pre = I` and `theta_offset` is small. For arms with non-trivial base orientations (JACO 2's `link_1.quat = (0, 0, 1, 0)` rotates joint 1's local +z to world −z), `T_pre` absorbs the rotation/translation discrepancy.
 
-### The load-bearing bug we fixed
+## The conversion algorithm
 
-The original implementation hard-coded $z_0 = (0, 0, 1)$ and $T_{\mathrm{pre}} = I$. **This is correct for any arm whose joint-1 axis aligns with world +z** — UR5, Puma 560, most commercial arms. UR5's round-trip test passed for 100 random poses across 3 random seeds at machine precision.
+`poe_to_dh(kb)` does the following:
 
-JACO 2 broke it. The MJCF places `link_1` with `quat = (0, 0, 1, 0)` — a 180° rotation about world y, which flips the local +z axis to world −z. So `joints[0].axis` in world frame is $(0, 0, -1)$, not $(0, 0, +1)$. With $z_0 = +z$ hardcoded, the DH chain rotates joint 1 around the wrong axis, the bridge $T_{\mathrm{pre}}^{-1} T\, T_{\mathrm{post}}^{-1}$ doesn't match $\mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})$, and `||bridge_residual||` is 0.81 instead of $10^{-15}$.
+1. **Walk the POE chain at $q = 0$**: extract joint axes $\hat{a}_i^w$ in world frame (rotated by the cumulative `T_left` chain), joint origins $p_i^w$ in world frame, and the home-pose end-effector transform $T_{\mathrm{home}} = \mathrm{FK_{POE}}(0)$.
+2. **Place DH frames 0 to $n$** in world coordinates:
+   - Frame 0: $z_0 = \hat{a}_0^w$ (joint 1's axis in world). Origin = $p_0^w$ (joint 1's origin in world). $x_0$ = world-x projected onto the plane perpendicular to $z_0$ (or world-y if too parallel).
+   - Frame $i$ for $1 \le i \le n - 1$: $z_i = \hat{a}_i^w$. Origin = foot of common perpendicular between $z_{i-1}$ and $z_i$ on $z_i$'s line. $x_i$ direction along the common perpendicular, oriented from frame $i-1$ to frame $i$. For parallel axes use the foot-to-foot direction; for intersecting axes use $(z_{i-1} \times z_i)$ normalised.
+   - Frame $n$: $z_n$ = $T_{\mathrm{home}}$'s z-axis. Origin = $T_{\mathrm{home}}$'s translation. $x_n$ = projection of $x_{n-1}$ onto the plane perpendicular to $z_n$.
+3. **Read off $(\alpha_i, a_i, d_i, \theta_{\mathrm{offset},i})$** for each transition $i \to i+1$ via signed-angle and projected-distance computations against the placed frames.
+4. **Compute $T_{\mathrm{pre}}$** from frame 0's $(x_0, y_0, z_0, \mathrm{origin})$ assembled as a $4 \times 4$ rigid transform.
+5. **Compute $T_{\mathrm{post}}$** as $\mathrm{frame}_n^{-1} \cdot T_{\mathrm{home}}$ — absorbs any residual rotation between DH frame $n$ at $q = \theta_{\mathrm{offset}}$ and the actual user-facing EE pose.
 
-### The fix
+The output is cached on the `KinBody` instance as `kb._ssik_dh_with_offset_cache` (the conversion depends only on the chain, not on any IK target) — see the speed work in [PR #88](https://github.com/siddhss5/ikfastpy/pull/88).
 
-Set $z_0 = $ `axes_world[0]` (joint 1's actual axis in world frame), $\mathrm{origin}_0 = $ `origins_world[0]` (joint 1's actual origin), $x_0$ chosen as the world-x projection onto the plane perpendicular to $z_0$ (or world-y if $z_0$ is too parallel to x). $T_{\mathrm{pre}}$ then has $(x_0, y_0, z_0, \mathrm{origin}_0)$ as its columns and reduces to identity for commercial-arm conventions while absorbing the rotation/translation discrepancy otherwise. UR5 round-trips still pass; JACO 2 round-trips now pass at machine precision.
+## The load-bearing bug
 
-### Lesson
+The original implementation hard-coded $z_0 = (0, 0, 1)$ and $T_{\mathrm{pre}} = I$. **This is correct for any arm whose joint-1 axis aligns with world +z and whose joint-1 origin is at the world origin** — UR5, Puma 560, most commercial 6R arms with conventional base orientation. UR5's round-trip test passed for 100 random poses across 3 random seeds at machine precision, so the function looked correct.
 
-UR5 and Puma 560 are *too well-behaved* to be the only test fixture for kinematic-bridge code. They mask convention bugs that real arms with non-trivial base orientations expose immediately. Real-MJCF fixtures matter (#80).
+JACO 2 broke it.
 
-### Caching
+The MJCF places `link_1` with `pos = (0, 0, 0.15675)` and **`quat = (0, 0, 1, 0)`** — a 180° rotation about world y. Applied to the local +z joint-1 axis, this gives a world-frame axis of $(0, 0, -1)$. Joint 1 rotates around world −z, not world +z.
 
-`poe_to_dh(kb)` depends only on the chain's geometry, not on any IK target. ssik caches the result on the kb instance (`kb._ssik_dh_with_offset_cache`); subsequent calls are free. ([Tier 1 of #86](https://github.com/siddhss5/ikfastpy/pull/88).)
+With $z_0 = +z$ hardcoded, the DH chain's $A_1$ rotates the chain around the wrong axis. The bridge $T_{\mathrm{pre}}^{-1} \cdot T \cdot T_{\mathrm{post}}^{-1}$ doesn't equal $\mathrm{FK_{DH}}(q + \theta_{\mathrm{offset}})$, which means the IK solver receives a target pose in the wrong frame. The Frobenius residual `||bridge - DH(q*+offset)||` measured 0.81 instead of 1e-15. Every IK call on JACO 2 returned solutions that were wildly wrong on the user's POE chain even though they were correct in the (wrong) DH frame.
 
-## References
+Worse: this didn't show up as a numerical instability or a flagged failure. The solver returned candidates with low FK residual *against the wrong target*, so `is_ls=False` and the candidates looked valid. They just didn't reproduce the user's target pose. We caught it only by running the full `KinBody → poe_to_dh → solve_all_ik → POE-FK` round-trip and finding `||FK_POE(q) - T*||` = 0.6 on every solution.
 
-- Spong, M. W. *Robot Modeling and Control,* §3.2 (DH frame placement).
-- Murray–Li–Sastry, *A Mathematical Introduction to Robotic Manipulation* (POE).
+## The fix
+
+Replace the hardcoded $z_0$ with the actual world-frame axis of joint 1:
+
+```python
+z_0 = axes_world[0] / np.linalg.norm(axes_world[0])
+```
+
+Pick a sensible perpendicular as $x_0$ (project world-x onto the plane perpendicular to $z_0$; fall back to world-y if too parallel). Compute origin $\mathrm{origin}_0 = $ `origins_world[0]`. Build $T_{\mathrm{pre}}$ from those vectors as columns of the rotation block + the translation.
+
+For UR5 (joint-1 axis = world +z, joint-1 origin at world origin) this gives $z_0 = (0, 0, 1)$, $x_0 = (1, 0, 0)$, $\mathrm{origin}_0 = (0, 0, 0)$, and $T_{\mathrm{pre}} = I$. The original UR5 round-trip tests still pass at machine precision.
+
+For JACO 2 ($z_0 = (0, 0, -1)$, $\mathrm{origin}_0 = (0, 0, 0.15675)$, $x_0 = $ projection of $(1, 0, 0)$), $T_{\mathrm{pre}}$ becomes a non-trivial rigid transform. The bridge equation now closes at machine precision: `||bridge - DH(q* + offset)||` measures 1.6e-15 instead of 0.81. JACO 2 IK works.
+
+Verifying: the [`tests/test_poe_to_dh.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_poe_to_dh.py) round-trip test passes on UR5 over 300 random poses (3 seeds × 100 poses) at 1e-10 atol. The [`tests/test_jaco2_general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_jaco2_general_6r.py) round-trip passes on JACO 2 over the seed pose plus 4 keyframes at 1e-5 atol (the looser tolerance reflects the tier-2 RR algebraic floor, not the bridge — the bridge alone is at machine precision).
+
+## What this lesson is
+
+UR5 and Puma 560 are *too well-behaved* to be the only test fixtures for kinematic-bridge code. Both have base orientations that align with world axes. Both have joint 1 at the world origin. Both have right-handed chains where every quaternion in the chain happens to have its w-component positive. The conventions are so uniform that any of half a dozen subtly-different bridge implementations would pass UR5's round-trip — including the wrong one.
+
+JACO 2's MJCF carries a deliberate 180° rotation in `link_1` because the upstream Kinova URDF defines its base frame that way (the arm's data-sheet "joint 1" is conventionally rotation around its mounting flange's normal, which on the j2n6s200 points downward when the arm is mounted on a workbench). It was the first fixture in our suite where any of the conventions UR5 takes for granted were violated. And it broke immediately.
+
+This is the case for **real-arm fixtures, not synthetic-arm fixtures**. Synthetic fixtures share the convenience-of-construction biases that make testing easy. Real fixtures break those biases, in different ways for different arms, and they break them on day one. ssik tracks adding more real fixtures (Agilex Piper, Flexiv Rizon, KUKA iiwa, Franka Panda) under [#80](https://github.com/siddhss5/ikfastpy/issues/80) — each one will probably surface another similar convention bug.
+
+The right test isn't "did UR5 round-trip pass?" — it's "did UR5 round-trip pass *and* did the round-trip pass on an arm whose base orientation is deliberately not world-aligned?" That's what the JACO 2 fixture is for. That's what real fixtures are for in general.
+
+## Caching
+
+The conversion is geometrically determined — it depends only on the chain's structure, not on any IK target. The expensive parts (foot-of-perpendicular calculations, signed-angle computations) recompute every call against the same input. ssik stores the result on the kb instance as `kb._ssik_dh_with_offset_cache`; subsequent calls return the cached result. Garbage-collected with the kb. Saves ~1.6 ms median per IK call on JACO 2 (the previous-largest single hot-spot in the warm-cache profile; see [PR #88](https://github.com/siddhss5/ikfastpy/pull/88)).
+
+For users who rebuild the `KinBody` per IK call (e.g. URDF-loader inside the loop), the cache misses every time and you pay the conversion cost. The recommended pattern is **build kb once outside the IK loop**, reuse it.

--- a/docs/tutorial/08_bulletproof.md
+++ b/docs/tutorial/08_bulletproof.md
@@ -1,69 +1,114 @@
 # 8. Bulletproof validation
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in.
+Algorithms that work on hand-picked test poses are easy. Algorithms that work on **every** target pose, on **every** arm topology, with **machine-precision FK closure**, on **every** LAPACK backend, with **0 failures across 500 random samples** are hard. The discipline ssik enforces on every solver PR is what closes the gap.
 
-## What this chapter covers
+This chapter walks through the five gates every solver passes through before review, why each gate exists, and what failure modes each catches. The shorthand we use for the standard is "bulletproof" — short for *must be perfect, all the time, on every reachable pose*.
 
-The validation discipline ssik enforces on every solver PR, why each piece exists, and what failure modes each catches.
+## The standard
 
-### The standard
-
-Memory entry [`feedback_bulletproof_solvers`](https://github.com/siddhss5/ikfastpy/issues/74). Verbatim:
+The verbatim direction from memory entry [`feedback_bulletproof_solvers`](https://github.com/siddhss5/ikfastpy/issues/74):
 
 > N-way cross-solver agreement on shared fixtures, 1e-10 FK tolerance, 500+ hypothesis poses; "must be perfect, all the time".
 
-Every solver shipped in ssik passes through five gates before review.
+The intent is not perfection-as-aspiration but perfection-as-default. A solver that passes 99% of poses is not bulletproof — the 1% is a debugging black hole, full of cases where your IK silently fails on production data. Better to find and fix the 1% before merge than ship the 99% and fight it later.
 
-### Gate 1 — Hand-picked generic poses (~5 fixtures × machine-precision FK)
+ssik passes through five gates, in order of cost.
 
-Caught by: typos in the algebraic derivation, wrong indices in branch enumeration, sign flips in atan2, etc. Fast feedback loop in `pytest`.
+## Gate 1 — Hand-picked generic poses
 
-### Gate 2 — Hand-picked near-singular poses
+**What it is.** A handful of generic non-singular `q*` values (often four or five), each FK-encoded to `T*`, fed into `solve(kb, T*)`. Assertions:
 
-Wrist-pitch zero ($\sin q_4 = 0$), elbow zero / fully-extended ($\sin q_2 = 0$), shoulder-pan zero ($q_0 = 0$). Caught by: implicit assumptions of nonzero denominators in subproblem decomposition. Solvers must degrade gracefully — return fewer solutions (collapsed branches), all FK-exact, or signal `is_ls=True`.
+- `is_ls == False`.
+- The number of returned solutions matches the algorithm's expected branch count (often 8 for tier-0 closed-form, up to 16 for tier-2 RR).
+- Every returned `q` reproduces `T*` under FK at machine precision (1e-10 atol).
 
-### Gate 3 — Synthetic alternative-geometry fixture
+**What it catches.** Typos in the algebraic derivation. Wrong indices in branch enumeration (`v_12[5]` vs `v_12[6]`). Sign flips in `atan2` that `±` solutions can't tell apart. Wrong `T_left` / `T_right` interpretation. Off-by-one in the DH parameter order.
 
-A second arm with the same topology but different link lengths than the primary fixture. Validates "generic, not geometry-specific". Pieper-class solvers each ship one synthetic alternative; tier-2 solvers ship a randomised alternative.
+**Cost.** Milliseconds per pose. Runs in fast pytest cycles.
 
-### Gate 4 — 500-pose hypothesis fuzz with seeded $q^\star$ recovery
+## Gate 2 — Hand-picked near-singular poses
 
-[Hypothesis](https://hypothesis.readthedocs.io/) generates 500 random non-singular $q^\star$, the test computes $T = \mathrm{FK}(q^\star)$, calls `solve(kb, T)`, and asserts:
+Singularities are the failure mode that hides best. The IK pipeline assumes nonzero denominators all over: `atan2(s, c)` doesn't care about magnitude but the SP3 ellipse intersection breaks if the elbow distance is zero, SP4's projection breaks if the projected vector is zero, SP5's quartic develops cluster roots near specific geometries (#55).
+
+ssik's near-singular fixture set covers the classical ones:
+
+- **Wrist-pitch zero**: `sin(q_4) = 0` aligns joints 3 and 5 (wrist roll + tool roll degenerate to a single rotation around a shared axis). Tier-0 spherical-wrist solvers must collapse two wrist branches into one and return the survivors at 1e-6 atol.
+- **Wrist-pitch π**: the same degeneracy but at the alternate branch.
+- **Elbow zero / fully-extended**: `sin(q_2) = 0` collapses the two shoulder branches. SP3's elbow distance constraint becomes linear instead of quadratic; the solver returns half the usual solutions but they remain exact.
+- **Shoulder-pan zero**: `q_0 = 0` doesn't degenerate the algorithm itself but tests that the hand-picked rotation matrices are right.
+
+What we assert: the solver returns at least one solution, no `nan` / `inf` leaks through, every returned `q` is exact under FK at 1e-6 atol. We don't assert solution counts because branch collapse changes them.
+
+## Gate 3 — Synthetic alternative-geometry fixture
+
+Bugs that depend on link-length specific values pass the hand-picked tests by accident. The third gate validates "generic, not geometry-specific" by running the same five gates against a *second* arm with the same topology but deliberately different DH parameters from the first.
+
+For tier-0 solvers, each module ships a synthetic arm with hand-chosen alternative dimensions. For example, [`tests/test_three_parallel.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_three_parallel.py) tests against UR5 (the canonical fixture) and against `synthetic_three_parallel_kb` (different `d1, a2, a3, d4, d5, d6`, same `axes` pattern). The fixture builder is in the test file; deliberately not in `tests/fixtures/` to discourage cross-pollination.
+
+For tier-2 solvers, the synthetic alternative is randomised — IK-Geo's `GeneralSetup` pattern: 6 random unit axes + 7 random offsets, no parallel or intersecting constraints. Drawn fresh per test.
+
+What this catches: assumptions hardcoded against UR5's specific 0-radius wrist offset; SP6 cluster-root pathology that triggers only for specific Bezout configurations; numerical underflow when DH parameters span many orders of magnitude.
+
+## Gate 4 — 500-pose hypothesis fuzz
+
+The hand-picked fixtures cover known failure modes. The fuzz catches the *unknown* failure modes.
+
+[Hypothesis](https://hypothesis.readthedocs.io/) draws 500 random non-singular `q*` per test, computes `T*` via FK, calls `solve(kb, T*)`, and asserts:
 
 1. `is_ls == False`.
 2. Every returned solution FK-closes within 1e-8 to 1e-10 atol (tier-dependent).
-3. The seeded $q^\star$ is recoverable mod $2\pi$ within 1e-3 to 1e-4 rad.
+3. The seeded `q*` is recoverable mod $2\pi$ within 1e-3 to 1e-4 rad.
 
-This catches: rare branch-enumeration bugs that hand-picked tests miss, completeness regressions where the solver loses one of its 8 solutions, and platform variance (hypothesis runs on every CI matrix entry).
+The third assertion is the load-bearing one. It catches **completeness regressions** — cases where the solver finds *some* IK solutions but not the specific seeded one. A solver that finds 7 of 8 IK branches will pass tests 1 and 2 (every solution it returns FK-closes; `is_ls` is False) but fail test 3 if the seeded `q*` was the 8th branch. Real bugs we caught this way: branch tracking errors in tier-1 univariate-search where the (q6, q4) tuples reorder between adjacent samples (memory entry [`project_tier1_search_completeness`](https://github.com/siddhss5/ikfastpy/issues/74)).
 
-### Gate 5 — N-way cross-solver agreement (where applicable)
+The 500-sample size is calibrated against the rare-event frequency. Most regression bugs hit ~5% of poses; 500 samples flags them with high confidence. Some bugs hit 1% of poses; 500 samples still flag those. Bugs at the 0.1% level need more samples — those tend to be near-singularities that the hand-picked Gate 2 catches.
 
-Puma 560 satisfies the preconditions of *both* `spherical_two_parallel` and `spherical_two_intersecting`. The two compositions are algebraically distinct (SP4+SP3+SP1+SP4+SP1+SP1 vs SP3+SP2+SP4+SP1+SP1) but **must return the same 8-solution set** on every non-singular pose. The `tests/test_puma_cross_validation.py` file asserts exact set agreement at 1e-6 tolerance over 500 hypothesis poses.
+Hypothesis runs on every CI matrix entry (macOS / py3.13 + ubuntu / py3.{11, 12, 13}), so platform variance shows up immediately. The MC Table I `xfail(strict=False)` from PR #89 was a direct consequence: the same 500-pose fuzz produces different recovery rates on different LAPACK backends, and we surface that via the `xpassed` / `xfailed` counts rather than papering over.
 
-This is the strongest correctness guarantee available without an oracle: each solver acts as the other's reference. If both fail in agreement, both have a parallel bug (vanishingly unlikely); if only one fails, the disagreement immediately identifies which one.
+## Gate 5 — N-way cross-solver agreement
 
-### Real-arm fixtures
+When two algebraically-distinct solvers cover the same arm family, they become each other's reference. ssik's strongest correctness guarantee is the **Puma 560 cross-validation** in [`tests/test_puma_cross_validation.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_puma_cross_validation.py).
 
-Synthetic arms are necessary for completeness across topology classes. Real arms are necessary for hidden bugs that hide behind synthetic-fixture conveniences:
+Puma 560 satisfies the preconditions of *both*:
 
-- The [JACO 2 j2n6s200 fixture](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) was transcribed from the upstream MJCF (`robot-code/ada_assets/.../jaco2.xml`). It exposed the [`poe_to_dh` `T_pre` bug](07_kinbody_bridge.md) — UR5's joint-1 axis happens to align with world +z, so the original code's `T_pre = I` defaulting accidentally worked. JACO 2's `link_1.quat = (0, 0, 1, 0)` flips the axis and broke the bridge.
-- Tier-2 RR validation runs against the *actual* JACO 2 chain, not a synthetic 60°-twist DH approximation. Slow tests at [`tests/test_jaco2_general_6r.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_jaco2_general_6r.py) cover seeded recovery + 4 keyframe round-trips.
-- (#80) tracks adding more real fixtures — Agilex Piper, Flexiv Rizon, KUKA iiwa, Franka Panda — each rebroadcasts the same five gates against a different chain.
+- **`spherical_two_parallel`** — three-intersecting-axes wrist + parallel shoulder-elbow (joints 1, 2). Composition: SP4 (projection on shared axis) + SP3 (elbow) + SP1 (shoulder plane) + SP4 (wrist alignment) + SP1 × 2 (wrist roll + tool roll).
+- **`spherical_two_intersecting`** — three-intersecting-axes wrist + joints 0, 1 sharing an origin (`p[1] = 0`). Composition: SP3 (elbow distance from wrist center) + SP2 (shoulder) + SP4 + SP1 × 2.
 
-### "No papering over"
+The two compositions chain different subproblems in different orders. They share no algebraic substructure beyond "the answer is some IK solution to the same chain". And yet — by the uniqueness of IK on Puma 560 at non-singular poses — they *must* return the same 8-solution set on every pose.
 
-Memory entry [`feedback_no_papering_over`](https://github.com/siddhss5/ikfastpy/issues/74). When a solver fails a gate, the response is: **investigate the root cause**, fix the underlying bug. Not: clear the hypothesis cache, widen tolerances, mark the test slow and forget it, or scope the workaround without filing the underlying-bug issue.
+The cross-validation asserts exact set agreement (every solution from one solver matches some solution from the other within 1e-6 wrap-to-π) over 500 hypothesis poses. If both solvers fail in agreement, both have a parallel bug — vanishingly unlikely given the algebraic distinctness. If only one fails, the disagreement immediately identifies which one.
 
-When the underlying bug is structural and fixing it is out-of-scope for the immediate PR, the failing test gets explicit `xfail(strict=False)` with a reason linking to a tracking issue (e.g. [#82](https://github.com/siddhss5/ikfastpy/issues/82) for the MC Table I coverage gap). The test still **runs** — `xpassed`/`xfailed` counts surface the actual recovery rate per platform — but doesn't block CI on a known cross-platform-flakey case.
+This was the gate that retired the legacy "Hawkins oracle" cross-check (an external numerical reference): we no longer needed an external oracle once we had two algebraically-distinct in-tree solvers acting as each other's. Memory entry [`reference_ikfast_analytical_tricks`](https://github.com/siddhss5/ikfastpy/issues/81) covers the lineage.
 
-### Cumulative test surface
+## Real-arm fixtures
 
-After PR #85, ssik runs:
+Synthetic arms cover topology classes; real arms catch convention bugs.
 
-- ~320 fast-suite tests (single-pose hand-picked + hypothesis fuzz at 500 examples per solver per arm).
-- ~10 slow tests (sympy-preprocessing-dominated tier-2 RR round-trips, JACO 2 keyframes + UR5 generic).
-- 4 CI jobs per PR (macOS / py3.13 + ubuntu / py3.{11,12,13}).
-- Cross-solver Puma agreement (`spherical_two_parallel` ⇿ `spherical_two_intersecting`) at machine precision over 500 random poses.
+The **JACO 2 j2n6s200** fixture in [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) was transcribed by hand from the upstream MJCF (`robot-code/ada_assets/.../jaco2.xml`). It exposed the [`poe_to_dh` `T_pre` bug from Chapter 7](07_kinbody_bridge.md) — UR5's joint-1 axis happens to align with world +z, so the original code's `T_pre = I` defaulting accidentally worked. JACO 2's `link_1.quat = (0, 0, 1, 0)` flips the local +z axis to world −z and broke the bridge. Synthetic JACO-2-like fixtures (with hand-chosen DH parameters) couldn't have caught this because they would have shared UR5's convenient base-frame alignment.
 
-The discipline is what allows shipping speed work like the Tier 1/2/3 PRs (#88/#89/#90) without precision regressions: every change runs through every gate before merge.
+The real-fixture work is tracked in [#80](https://github.com/siddhss5/ikfastpy/issues/80). Adding more real fixtures — Agilex Piper, Flexiv Rizon, KUKA iiwa, Franka Panda — is on the roadmap. Each one rebroadcasts the same five gates against a different chain.
+
+## "No papering over"
+
+The bulletproof discipline depends on root-cause analysis. When a gate fails, the response is **investigate the underlying bug**, not work around it. Memory entry [`feedback_no_papering_over`](https://github.com/siddhss5/ikfastpy/issues/74) lists the antipatterns:
+
+- Clearing the hypothesis cache to rerandomise away from a failure (the failure tells you something; rerandomising buries it).
+- Widening tolerances to make the failure pass (now the test passes but the bug is unfixed).
+- Marking the test slow and forgetting it (now it never runs).
+- Scoping the workaround without filing the underlying-bug issue (now the bug isn't tracked).
+
+When the underlying bug is *known but structurally out-of-scope* for the immediate PR, the failing case gets explicit `xfail(strict=False)` with a `reason=...` linking to a tracking issue. The MC Table I coverage gap is the canonical example: [#82](https://github.com/siddhss5/ikfastpy/issues/82) is the tracking issue, the four MC Table I seeds are marked `xfail(strict=False)` in [`tests/test_raghavan_roth_pq.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/test_raghavan_roth_pq.py), and the test still runs on every CI run — the `xpassed` / `xfailed` counts surface the actual recovery rate per platform, so when #82 is fixed we'll know to drop the marks.
+
+## Cumulative test surface
+
+After PR #85, ssik's test surface is roughly:
+
+- **~320 fast-suite tests** (single-pose hand-picked + hypothesis fuzz at 500 examples per solver per arm).
+- **~10 slow tests** (sympy-preprocessing-dominated tier-2 RR round-trips on JACO 2 keyframes + UR5 generic).
+- **4 CI jobs per PR** (macOS / py3.13 + ubuntu / py3.{11, 12, 13}).
+- **Cross-solver Puma agreement** at machine precision over 500 random poses.
+- **Per-PR slow round-trips** on JACO 2 (real MJCF fixture), UR5 (URDF fixture), Puma 560 (URDF fixture).
+
+The discipline scales with the codebase: every new solver carries its own test file with the same five gates, every new fixture broadens the cross-arm coverage, every new optimisation runs through the same suite before merge. That's how the Tier 1/2/3 speedup PRs (#88, #89, #90) shipped without precision regressions: each one passed the same gates as the original solver. The 32% / 26% / median speed wins came with FK error unchanged at 3.7e-13 and 0 failures across 100 random poses on every PR.
+
+The discipline is the reason the speed work could ship aggressively. Bulletproof gates aren't a slowdown; they're the safety net that lets you sprint.

--- a/docs/tutorial/09_practical_guide.md
+++ b/docs/tutorial/09_practical_guide.md
@@ -1,24 +1,32 @@
 # 9. Practical guide
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in.
-
-## What this chapter covers
-
-How to use ssik day-to-day: install, build a `KinBody`, pick a solver, interpret the returned `Solution`, debug failures.
+This chapter is the user-facing entry point. It covers installation, building a `KinBody`, picking a solver, interpreting the returned `Solution`, debugging failures, and the performance numbers you should actually expect on the hardware in front of you.
 
 ## Install
 
+ssik is pre-alpha; package-name reservation in progress as of writing (see [#83](https://github.com/siddhss5/ikfastpy/issues/83)). Until the PyPI release lands:
+
 ```
-pip install ssik          # core
-pip install ssik[urdf]    # + URDF loader (urchin)
+pip install git+https://github.com/siddhss5/ikfastpy.git
 ```
 
-(Pre-alpha; package name reservation in progress as of writing. See [#83](https://github.com/siddhss5/ikfastpy/issues/83).)
+For URDF loading you also need the `urdf` extra:
+
+```
+pip install "git+https://github.com/siddhss5/ikfastpy.git#egg=ssik[urdf]"
+```
+
+This pulls in [urchin](https://github.com/fishbotics/urchin) for URDF parsing. Without the extra, the `ssik._urdf` module raises `ImportError`; the rest of the library works fine.
+
+Runtime dependencies are kept narrow: numpy ≥ 2.0 and sympy ≥ 1.10 (sympy is used at module-import time for offline per-arm symbolic preprocessing; not on the hot IK path). scipy is *not* required — the few places that benefit from `scipy.linalg.eig` lazy-import it inside an `except ImportError` branch and degrade gracefully.
 
 ## Build a `KinBody`
 
-From a URDF:
+ssik's canonical input is a POE-normalized `KinBody`. There are three ways to get one.
+
+### From a URDF
+
+Most users start here. URDF is the dominant interchange format in ROS / MoveIt / mink ecosystems.
 
 ```python
 from ssik._urdf import load_urdf_kinbody_normalized
@@ -26,7 +34,11 @@ from ssik._urdf import load_urdf_kinbody_normalized
 kb = load_urdf_kinbody_normalized("robots/ur5.urdf", "base_link", "ee_link")
 ```
 
-From an MJCF (transcribe joint frames; see [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) for the pattern):
+`load_urdf_kinbody_normalized` reads the URDF, walks the chain from `base_link` to `ee_link`, normalizes per-joint origins into POE form (`T_left @ R_axis(joint.axis, q) @ T_right` per joint), and returns the assembled `KinBody`. The function handles non-orthogonal RPY in URDF `<origin>` tags, mid-chain fixed joints (their offsets fold into the next non-fixed joint), and continuous joints (treated as revolute without limits).
+
+### From an MJCF
+
+MuJoCo MJCF is increasingly common in modern simulation environments (`isaac-sim`, `mujoco`, `geodude`). ssik doesn't currently parse MJCF directly (tracked as a follow-up); the recommended pattern is to **transcribe the joint frames once by hand** into a `JointSpec` list. See [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) for the canonical example — six `<body pos quat>` extractions, one tool offset, one `JointSpec` per joint:
 
 ```python
 from ssik._kinbody import build_kinbody
@@ -35,23 +47,73 @@ from fixtures.jaco2 import jaco2_specs  # transcribed once from MJCF
 kb = build_kinbody(jaco2_specs())
 ```
 
-From scratch: build a list of [`JointSpec`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/_kinbody.py) and pass to [`build_kinbody`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/_kinbody.py).
+The transcription is one-time per arm. Once written, the fixture is a Python module that imports cheaply. Real-fixture transcription was the last thing that needed to happen before ssik could close the JACO 2 loop end-to-end (see [Chapter 7](07_kinbody_bridge.md) for the convention bug it surfaced).
+
+### From scratch
+
+For prototyping kinematics or testing the solver against a synthetic arm, build a list of [`JointSpec`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/_kinbody.py) directly:
+
+```python
+from ssik._kinbody import JointSpec, build_kinbody
+import numpy as np
+
+specs = [
+    JointSpec(
+        parent_link_T=np.eye(4),
+        axis=np.array([0., 0., 1.]),
+        joint_type="revolute",
+        child_link_T=np.eye(4),
+        name="joint_0",
+    ),
+    # ... five more JointSpec entries
+]
+kb = build_kinbody(specs)
+```
+
+Each `JointSpec` carries the per-joint `T_left` (parent frame to joint frame), the joint axis in the joint frame, the joint type (`"revolute"` or `"prismatic"` — though prismatic is currently out-of-scope, see Chapter 10 roadmap), and an optional `T_right` (joint frame to child link frame; defaults to identity).
 
 ## Pick a solver
 
-For 6R arms, the dispatcher picks the right tier per kb at registration time:
+ssik ships ten solver modules. The dispatcher (in progress; see Chapter 10) will pick the right one for your kb at registration time. Until that lands, the recommended pattern is to import the per-tier solver directly.
+
+### 6R arms
+
+For most arms, start with the tier-2 numeric Raghavan–Roth solver. It works on every 6R chain — Pieper-class or non-Pieper — at machine precision. It's slower than the tier-0 specialisations but it never refuses a topology.
 
 ```python
 from ssik.solvers.ikgeo import general_6r
 
 solutions, is_ls = general_6r.solve(kb, T_target)
 for sol in solutions:
-    print(sol.q, sol.fk_residual, sol.refinement_used)
+    print(f"q = {sol.q}, fk_residual = {sol.fk_residual:.2e}, "
+          f"refinement = {sol.refinement_used}")
 ```
 
-(The unified `Manipulator.from_urdf(...).ik(T)` API of the rewrite plan is in progress; until it lands, importing the per-tier solver directly is the way.)
+If your arm is Pieper-class — three intersecting wrist axes or three parallel shoulder axes — the tier-0 solvers are 30× faster:
 
-For 7R arms with one redundant joint (Franka, KUKA iiwa, Flexiv Rizon):
+```python
+# Three-parallel arms (UR5, UR10):
+from ssik.solvers.ikgeo import three_parallel
+solutions, is_ls = three_parallel.solve(kb, T_target)
+
+# Spherical wrist + parallel shoulder (Puma 560, Fanuc, KUKA KR):
+from ssik.solvers.ikgeo import spherical_two_parallel
+solutions, is_ls = spherical_two_parallel.solve(kb, T_target)
+
+# Spherical wrist + intersecting shoulder (Puma 560 alternate, compact arms):
+from ssik.solvers.ikgeo import spherical_two_intersecting
+solutions, is_ls = spherical_two_intersecting.solve(kb, T_target)
+
+# Generic spherical wrist with no shoulder specialisation:
+from ssik.solvers.ikgeo import spherical
+solutions, is_ls = spherical.solve(kb, T_target)
+```
+
+These tier-0 solvers raise `ValueError` at the topology gate if your kb doesn't match their preconditions. That's the right signal — try a different solver.
+
+### 7R arms with one redundant joint
+
+For Franka Panda, KUKA iiwa, Flexiv Rizon — anything with one redundant degree of freedom — the joint-locking wrapper is the generic solution:
 
 ```python
 from ssik.solvers.jointlock import seven_r
@@ -59,39 +121,59 @@ from ssik.solvers.jointlock import seven_r
 solutions, is_ls = seven_r.solve(kb, T_target, lock_samples=16)
 ```
 
-`lock_samples=16` sweeps the chosen redundant joint over 16 lock values; or pass an explicit list `lock_samples=[0.0, 0.5, 1.1, -0.5]` to control which lock values get sampled.
+The `lock_samples=16` parameter sweeps the auto-selected redundant joint over 16 evenly-spaced lock values; for each, the wrapper dispatches the resulting 6R sub-chain to the best-matching `ikgeo.*` solver. You can also pass an explicit list of lock values:
+
+```python
+solutions, is_ls = seven_r.solve(kb, T_target, lock_samples=[0.0, 0.5, 1.1, -0.5])
+```
+
+This is useful when you want to track a specific configuration's redundancy slice (e.g. "lock joint 3 at zero, find every IK there"). The joint-locking convention picks one slice of the 2D redundancy manifold rather than parametrising it; if you need exact redundancy parametrisation you'll want to wait for the specialist 7R solvers (`specialist.geofik` for Franka, `specialist.stereo_sew` for iiwa-class arms) on the roadmap.
 
 ## Read the returned `Solution`
+
+Every solver returns `tuple[list[Solution], bool]`. The `Solution` dataclass:
 
 ```python
 @dataclass(frozen=True)
 class Solution:
-    q: NDArray[np.float64]
-    fk_residual: float
-    refinement_used: Literal["none", "lm"]
-    refinement_iters: int
-    branch_id: int | None = None
-    solver_name: str = ""
+    q: NDArray[np.float64]                       # joint vector
+    fk_residual: float                            # ||FK(q) - T_target||_F
+    refinement_used: Literal["none", "lm"]        # "none" or "lm"
+    refinement_iters: int                         # iter count if "lm" fired
+    branch_id: int | None = None                  # IK branch index
+    solver_name: str = ""                         # e.g. "ikgeo.general_6r"
 ```
 
-- **`fk_residual`** — `||FK(q) - T_target||_F` at return time. Compare against your application's tolerance; the solver's own `fk_atol` was a *filter*, not a contract on the value.
-- **`refinement_used`** — `"none"` if the solution came directly from algebra; `"lm"` if Newton polished it. Surfaces the algebraic-vs-iterative line.
-- **`refinement_iters`** — how many Newton iterations consumed (0 if `refinement_used == "none"`).
-- **`branch_id`** — IK branch index where applicable (0..15 for the 16-root RR route, 0..7 for spherical+parallel-shoulder, etc.). Stable across calls for the same target pose; useful for branch-tracking across a trajectory.
-- **`solver_name`** — dotted module path. Useful when results pass through a dispatcher that routes across multiple solver candidates.
+The semantic guarantees:
+
+- **`q`**: the joint vector. Always in the user's POE frame (matches `FK_POE(q)`, not `FK_DH(theta)`); the bridge from [Chapter 7](07_kinbody_bridge.md) is applied internally.
+- **`fk_residual`**: what `np.linalg.norm(FK(q) - T_target)` would measure. Compare against your application's tolerance; the solver's own `policy.subproblem_numerical` was a *filter*, not a contract on this value.
+- **`refinement_used`**: `"none"` if the solution came directly from algebra; `"lm"` if [`lm_refine`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/refinement/__init__.py) polished it. Surfaces the algebraic-vs-iterative line — see [Chapter 6](06_refinement.md).
+- **`refinement_iters`**: number of Newton iterations consumed (0 if `refinement_used == "none"`). Values >5 suggest the algebraic path is struggling on this pose.
+- **`branch_id`**: stable IK-branch index (0..15 for the 16-root RR route, 0..7 for spherical-wrist + parallel-shoulder, etc.). Useful for branch-tracking across a trajectory — pick a `q` from `solutions[i].q` where `solutions[i].branch_id` is consistent across calls.
+- **`solver_name`**: dotted module path (`"ikgeo.general_6r"`, `"ikgeo.spherical_two_parallel"`, ...). Useful when results pass through a dispatcher that routes across multiple solver candidates.
 
 ## Debug `is_ls=True`
 
-`is_ls=True` means **no candidate survived FK validation**. Common causes:
+`is_ls=True` means **no candidate survived FK validation** — the returned solution list is empty. Common causes:
 
-1. **Target unreachable.** The arm physically can't get to `T_target`. Check your target pose against the workspace.
-2. **Singular pose.** The arm *can* reach `T_target` but does so at a singularity (wrist pitch zero, elbow extended). Some branches collapse; the solver may return fewer solutions but they should still be exact. If `is_ls=True` at a singularity, the geometry is on the edge of the singular set.
-3. **Tier-2 RR with `allow_refinement=False`** on an ill-conditioned pose. The algebraic candidates miss `fk_atol` and get dropped. Try `allow_refinement=True` and inspect the returned `refinement_iters` — high iteration counts (>5) suggest the solver is struggling and the pose is genuinely difficult.
-4. **A topology-precondition mismatch.** You called `spherical_two_parallel.solve` on an arm that isn't actually spherical-wrist-with-parallel-shoulder. Tier-0 solvers raise `ValueError` on topology mismatch up front; tier-2 solvers accept any 6R but may struggle if the arm is at a degenerate pose for that algorithm.
+**1. Target unreachable.** The arm physically can't get to `T_target`. Check your target pose against the reachable workspace. If you computed `T_target = FK(q)` for some known `q`, this can't happen — the target is reachable by definition. If `T_target` came from elsewhere (a planner, a desired pose), it might be outside the workspace.
 
-## Performance numbers (current at writing)
+**2. Singular pose.** The arm *can* reach `T_target` but does so at a kinematic singularity (wrist pitch zero, elbow fully extended, shoulder-pan zero). At a singularity, two or more IK branches collapse into one and the solver may return fewer solutions than the generic case (4 instead of 8, for example). If `is_ls=True` at a singularity, you're on the very edge of the singular set — usually the corresponding `q` is at a value like exactly `0` or exactly `π`.
 
-Real JACO 2 j2n6s200 (60° twists, the hard case), warm cache, 100 random poses:
+**3. Tier-2 RR with `allow_refinement=False`** on an ill-conditioned pose. The algebraic candidates miss `policy.subproblem_numerical` and get dropped per the [#74 contract](06_refinement.md). Try `allow_refinement=True`:
+
+```python
+solutions, is_ls = general_6r.solve(kb, T_target, allow_refinement=True)
+```
+
+If that returns solutions with `refinement_iters > 5`, your arm or pose is in a difficult conditioning regime — see [Chapter 5](05_conditioning.md) for the conditioning theory and [`pick_best_leftvar`](https://github.com/siddhss5/ikfastpy/blob/main/src/ssik/solvers/ikgeo/_raghavan_roth.py) for the AE-3 leftvar selection mechanism (which usually fixes this; if it didn't, you've found a case worth filing as a bug).
+
+**4. Topology mismatch.** You called `spherical_two_parallel.solve` on an arm that isn't actually spherical-wrist-with-parallel-shoulder. Tier-0 solvers raise `ValueError` on topology mismatch up front, with a message identifying which precondition failed. Tier-2 solvers (`general_6r`) accept any 6R but may struggle if the arm is at a degenerate pose for that algorithm — usually that shows up as `is_ls=True` rather than a raised error.
+
+## Performance numbers
+
+Real Kinova JACO 2 (j2n6s200), warm cache, 100 random poses, post-Tier-2.3 of [#86](https://github.com/siddhss5/ikfastpy/pull/90):
 
 | metric | value |
 |---|---|
@@ -100,16 +182,35 @@ Real JACO 2 j2n6s200 (60° twists, the hard case), warm cache, 100 random poses:
 | mean | 3.49 ms |
 | p95 | 10.24 ms |
 | max | 29.61 ms |
-| solutions / pose | median 6, range 1–12 |
+| solutions / pose | median 6, range 1-12 |
 | FK error | median 3.7e-13, max 9.6e-08 |
 | failures (`is_ls=True`) | 0 / 100 |
 
-Cold-cache cost (first IK on a new arm): ~150-300 s of one-time sympy preprocessing for the AE-3 leftvar selection. Cached on disk after that.
+Cumulative since the original PR #85 baseline (4.5 ms median): roughly **2× speedup** on the JACO 2 hot path while keeping FK error at machine precision and 0 failures across the whole sequence.
 
-For Pieper-class arms (UR5, Puma), the tier-0 solvers run in ~50–200 µs warm-cache, comparable to EAIK.
+For Pieper-class arms (UR5, Puma 560, etc.), the tier-0 solvers run in ~50–200 µs warm-cache, comparable to EAIK. The cold-cache cost (first IK on a new arm) is tier-dependent:
 
-See [#86](https://github.com/siddhss5/ikfastpy/issues/86) for ongoing speed work; the Phase M codegen / Rust runtime is the next order-of-magnitude lift.
+- Tier-0 closed-form: instant; no symbolic preprocessing needed.
+- Tier-1 univariate-search: instant.
+- Tier-2 grid-search (`gen_six_dof`): instant.
+- **Tier-2 numeric RR (`general_6r`)**: ~150-300 s of one-time sympy preprocessing per arm. Dominated by the AE-3 leftvar selection — the library tries all three leftvar choices, builds (P, Q) symbolically for each, and picks the lowest-condition option. Cached on disk via `lru_cache`; subsequent imports pay zero cost.
+
+The 150-300s is the price of admission for non-Pieper arms. If you're loading the library once per ROS node startup and serving IK calls on a long-running service, this is paid once at startup. If you're running ssik in a short-lived script that processes a few poses and exits, you'll feel it.
 
 ## Reading test output
 
-When a CI job shows xpassed/xfailed counts on test_solve_all_ik_recovers_q_star_and_alternatives, that's the platform-sensitive [#82](https://github.com/siddhss5/ikfastpy/issues/82) coverage gap on MC Table I (a synthetic benchmark). Different LAPACK backends pick different IK branches; the test passes either way (xfail with `strict=False`) but the counts surface the actual recovery rate per platform.
+When a CI job shows `xpassed` / `xfailed` counts on `test_solve_all_ik_recovers_q_star_and_alternatives`, that's the platform-sensitive [#82](https://github.com/siddhss5/ikfastpy/issues/82) coverage gap on MC Table I (a synthetic 1994-Manocha–Canny benchmark). Different LAPACK backends pick different IK branches due to floating-point variance in the eigenvalue / dedup path; the test passes either way (`xfail` with `strict=False`) but the counts surface the actual recovery rate per platform. When #82 closes, all four MC seeds will `xpass` and we'll drop the marks.
+
+This is *not* a correctness bug on real arms. The MC Table I synthetic was deliberately constructed by Manocha and Canny in 1994 to have unusual algebraic properties; it's a stress test, not a typical use case. Real arms (JACO 2, UR5, Puma) round-trip at machine precision on every CI matrix entry.
+
+## Common pitfalls
+
+A few things first-time users sometimes hit:
+
+**Building the kb inside an IK loop.** The `poe_to_dh(kb)` conversion is cached on the kb instance; if you rebuild kb every IK call, the cache misses every time and you pay the conversion cost (~1.6 ms on a typical chain). Build kb once outside the loop, reuse.
+
+**Confusing `policy.subproblem_numerical` with `Solution.fk_residual`.** The policy field is the *filter* — solutions with `fk_residual > policy.subproblem_numerical` are dropped. The reported `Solution.fk_residual` is the actual measured value, which can be much smaller than the filter (typical: 1e-13 vs filter at 1e-5).
+
+**Expecting `ikgeo.spherical` to handle JACO 2.** It can't — the topology gate refuses non-spherical wrists. Use `general_6r` instead. ssik will emit a `ValueError` with the exact reason if you call the wrong solver; pay attention to the error message, it identifies the topology mismatch.
+
+**Treating `is_ls=True` as an error.** It's a *signal* — the algebraic pipeline didn't find a solution within tolerance. The right response depends on your application: try `allow_refinement=True`, try a different tolerance, or check the target reachability. Don't assume the kb is broken; the pipeline tells you when it can't solve.

--- a/docs/tutorial/10_whats_next.md
+++ b/docs/tutorial/10_whats_next.md
@@ -1,53 +1,89 @@
 # 10. Roadmap
 
-!!! warning "Scaffolding"
-    Outline below; prose to be filled in.
+The previous nine chapters cover what ssik ships today: ten public solvers spanning Pieper-class closed-form (tier-0/1) and non-Pieper numeric Raghavan–Roth (tier-2), all gated by the bulletproof validation discipline of [Chapter 8](08_bulletproof.md), all returning the same `Solution` shape with the algebraic-first / opt-in-Newton contract from [Chapter 6](06_refinement.md). The library closes the EAIK gap for 6R arms and provides joint-locking for 7R arms with one redundant joint.
 
-## What this chapter covers
-
-The next-order lifts that aren't in ssik today, ranked by user impact.
+This chapter walks through what's *not* in ssik today, ranked by user impact. Each item has a tracking issue on GitHub; pick whichever feels closest to your needs and follow the issue thread to see current state.
 
 ## Husty–Pfurner universal fallback
 
-[Husty & Pfurner 2007](https://doi.org/10.1115/1.2780537) Study-quaternion method gives a degree-16 univariate polynomial covering **any** 6R arm, even when Raghavan–Roth's $A$ pencil is fundamentally singular (rare but real). Lower registry priority than the tier-2 RR solver; auto-selected on fallback. ~10 ms target latency. Clean-room from the published paper, no LGPL dependency.
+[Husty & Pfurner 2007](https://doi.org/10.1115/1.2780537) gives a degree-16 univariate polynomial covering **any** 6R arm via a Study-quaternion parameterisation. It's slower than Raghavan–Roth on well-conditioned arms (the polynomial degree is the same but the back-substitution is more involved) but it has one major advantage: it works on the rare cases where RR's $A$ pencil is *fundamentally singular* — singular pencils that survive even the Möbius reparameterization fallback from [Chapter 5](05_conditioning.md).
+
+The tier-2 RR solver in `ikgeo.general_6r` falls through to a generalised-eigenvalue route (scipy's `linalg.eig` on the matrix pencil $M_1 - x M_2$) when AE-1/3/4 + Möbius all fail. That generalised-eigenvalue route handles most singular-pencil cases. But there exist (rare) 6R configurations where every Möbius transform leaves the pencil singular and the generalised-eigenvalue route still fails. Husty–Pfurner is the universal escape hatch.
+
+Plan: lower registry priority than the tier-2 RR solver; auto-selected on fallback when RR raises `LinAlgError`. Estimated latency ~10 ms (degree-16 polynomial root-finding is cheap; the back-substitution is the cost). Clean-room implementation from the published paper, no LGPL dependency.
+
+Status: not started. Tracking issue: see umbrella rebuild plan.
 
 ## Specialist 7R solvers
 
-For 7-DOF arms with full-redundancy IK (sweeping the 1D redundancy manifold rather than locking one joint to a sample):
+The joint-locking wrapper (`jointlock.seven_r`) handles any 7R arm by sweeping one redundant joint and dispatching the resulting 6R sub-chain. This works but it doesn't *parametrise* the redundancy — it picks one slice. For applications that need to optimise across the redundancy (collision avoidance, workspace coverage, smooth trajectories), you want a solver that works over the 1D redundancy manifold directly.
 
-- **GeoFIK** for Franka Panda. Specialist solver matched to the SRS topology.
-- **Stereographic SEW** (Wenger / NASA 2024) for KUKA iiwa-class arms.
-- **Moz1 NonSRS 7R** for Flexiv Rizon and similar non-SRS chains.
+Three specialist 7R solvers cover the major commercial families:
 
-Each plugs in as an independent module via `[project.entry-points."ssik.solvers"]`; no core patches needed.
+- **GeoFIK** for Franka Panda (Emika). Specialist solver matched to Panda's specific SRS topology; closed-form per-redundancy-value.
+- **Stereographic SEW** (Wenger / NASA 2024) for KUKA iiwa-class arms. Stereographic projection of the SE(3)-redundancy manifold to a closed-form parametrisation.
+- **Moz1 NonSRS 7R** for Flexiv Rizon and similar non-SRS chains. Different algorithmic family for arms whose 7R topology isn't shoulder-elbow-wrist with intersecting axes.
+
+Each plugs in via Python `[project.entry-points."ssik.solvers"]` — independent packages on PyPI that ssik picks up at registration time. Zero core patches needed. The dispatcher routes Franka kinbodies to GeoFIK, iiwa kinbodies to Stereographic SEW, etc., automatically.
+
+Status: not started; registry mechanism exists in the rebuild plan but no specialist solvers ported yet.
 
 ## Codegen / Rust runtime (Phase M)
 
-Per-arm AOT-compile the Raghavan–Roth pipeline to a `.so` extension:
+The biggest remaining speed lift on the tier-2 RR path. The current bottleneck is Python-numpy dispatch overhead — every `np.linalg.solve`, every `@`-matmul, every `np.linalg.eig` pays ~1-5 µs of dispatch glue per call, and the RR pipeline has dozens of these per IK. Codegen amortises that overhead.
 
-- Replaces the lambdified-sympy `build_pq` callable with a numpy-only or C-array-only callable.
-- Replaces the Python loop overhead with a Rust hot loop linking `dgeev` + a hand-vectorised back-substitution.
-- Estimated tier-2 latency: ~300–500 µs (vs current 2.25 ms median).
-- Estimated tier-0 latency: ~30–50 µs (matches / beats EAIK on the same algorithm).
+Two-stage plan:
 
-See [#86](https://github.com/siddhss5/ikfastpy/issues/86) Tier 3 for the speed roadmap.
+1. **Per-arm AOT compile of `build_pq`** to a numpy-only callable that doesn't go through sympy's lambdify wrapper. The lambdified callable is effectively a Python function calling numpy ops; replacing it with a single `np.einsum`-based emitter saves ~30-50 µs per IK and removes sympy from the runtime hot path. This is a relatively narrow change inside `_raghavan_roth.py`.
+
+2. **Rust port of the runtime** with Python bindings (`ssik-rust` or similar). The Rust hot path links `dgeev` directly via `lapack-sys`, vectorises the back-substitution branches into a single batched LAPACK call, and skips Python's interpreter-level overhead. Estimated tier-2 latency: ~300-500 µs (vs current 2.25 ms median). Tier-0 closed-form latency: ~30-50 µs, matching or beating EAIK on the same algorithm.
+
+The numbers are bounded by what's amortisable. The 24×24 eigendecomposition itself is ~100-150 µs of pure LAPACK time on standard hardware — that's a hard floor we can't undercut without a fundamentally different algorithm. But the Python interpreter and numpy dispatch overhead is roughly 1-2 ms of the current 2.25 ms median; that's all eliminable with careful codegen.
+
+Status: not started. Tracked under Phase M of the rewrite plan and called out as Tier 3 of [#86](https://github.com/siddhss5/ikfastpy/issues/86).
 
 ## Vendored ikfast retirement (Phase K)
 
-[#84](https://github.com/siddhss5/ikfastpy/issues/84). The `_legacy/` tree contains LGPL-tainted code from the abandoned port-and-patch attempt. Once the new pipeline has full conformance against the cases the vendored solver covered (Puma 560 in tier-0, etc.), the legacy tree gets deleted. No code currently imports from it; the cleanup is purely housekeeping + license hygiene.
+The `_legacy/` directory contains the LGPL-licensed vendored OpenRAVE IKFast tree from the abandoned port-and-patch attempt. No code currently imports from it; it exists only because removing it requires a coordinated PR (the legacy conformance tests, the cross-check fixtures, the deprecation shim).
+
+Once the new pipeline has full conformance against the cases the vendored solver covered (Puma 560 in tier-0 — already proven via the cross-validation in [Chapter 8](08_bulletproof.md)), the legacy tree gets deleted. License hygiene only; doesn't affect runtime behaviour.
+
+Status: tracked in [#84](https://github.com/siddhss5/ikfastpy/issues/84). Low-risk, scoped, ready to ship whenever the queue clears.
 
 ## IK modes beyond Transform6D
 
-IKFast supported 16 distinct IK modes (Translation3D, Rotation3D, Direction3D, Ray4D, Lookat3D, ...). ssik currently ships Transform6D only. Each non-trivial mode requires its own loop-closure derivation and back-substitution. The reference table is in [`docs/reference/ik-modes/`](../reference/ik-modes/index.md). Tracking issue: [#18](https://github.com/siddhss5/ikfastpy/issues/18).
+IKFast originally supported 16 distinct IK modes — Translation3D (place a point in space, orientation free), Rotation3D (orient a frame, translation free), Direction3D (point a single axis), Ray4D (drilling / screwing along a line), Lookat3D (camera pointing), and 11 more axis-angle / mixed-DOF combinations. Each is a different loop-closure derivation and a different back-substitution pattern.
+
+ssik currently ships Transform6D only. Adding the other modes requires:
+
+- Per-mode loop-closure derivation (mostly mechanical from the IKFast precedent).
+- Per-mode `Solution` semantics (e.g. Translation3D returns up to a 3-DOF redundancy manifold for 6R arms; what does that mean in our `Solution` shape?).
+- Per-mode test fixtures (welding seams for TranslationDirection5D, drilling for Ray4D, etc.).
+
+The reference table for the 16 modes lives in [`docs/reference/ik-modes/`](../reference/ik-modes/index.md). Tracking: [#18](https://github.com/siddhss5/ikfastpy/issues/18).
+
+This is a substantial body of work. Realistic timeline depends on demand: most users want Transform6D; the other modes are "specialty". The roadmap is to land them in priority order driven by issue requests.
 
 ## MJCF front-end parallel to URDF
 
-Most modern simulation environments use MuJoCo MJCF rather than URDF. Building a `KinBody` from MJCF directly (rather than transcribing joint frames by hand as JACO 2 does) is a separable concern. Tracking: ada-style MJCF parser, parallel to `ssik._urdf`.
+ssik currently has a URDF loader (`ssik._urdf.load_urdf_kinbody_normalized`, requires the `[urdf]` extra). For MJCF input, users transcribe joint frames by hand (see [`tests/fixtures/jaco2.py`](https://github.com/siddhss5/ikfastpy/blob/main/tests/fixtures/jaco2.py) for the pattern).
+
+A native MJCF loader is a separable concern. The MuJoCo XML schema is well-defined; `mujoco-py` or the lighter `dm_control.mjcf` library can parse it; the conversion to ssik's POE-form `KinBody` is mechanical. Tracking: pending issue.
+
+This matters for the modern simulation ecosystem: `isaac-sim`, `mujoco`, `geodude`, `dm_control` all use MJCF natively. Expecting users to transcribe joint frames or convert MJCF → URDF first is friction.
 
 ## Extensibility — third-party solvers
 
-The Solver / TopologyClaim / SolverRegistry protocols (`src/ssik/core/`) admit external solvers via Python entry points. The aspiration: someone publishes `ssik-geofik` on PyPI, ssik picks it up at registration time, and the dispatcher routes Franka calls to it without core patches. Real example pending; rebuild-plan covers the protocol.
+The core architectural commitment is that future analytical-IK algorithms plug in via Python entry points without core patches. The `Solver` / `TopologyClaim` / `SolverRegistry` protocols (in `src/ssik/core/`) admit external modules — someone publishes `ssik-geofik` on PyPI, ssik picks it up at registration time, and the dispatcher routes Franka calls to it.
 
----
+This isn't aspirational architecture; it's a hard constraint from the rebuild plan. The first specialist 7R solver (GeoFIK or Stereographic SEW) will exercise the protocol end-to-end and prove (or expose problems with) the entry-point boundary. That's where the architecture becomes concrete.
 
-This is also the conclusion of the tutorial. The implementation tracking lives on GitHub issues; the math is done; the bulletproof discipline is shipped; the speed work continues. Open questions live in active issues — start there if you want to contribute.
+Status: protocols exist; no third-party solvers exercise them yet. The dispatcher is in progress.
+
+## Tutorial completion
+
+This tutorial chapter is the structural conclusion. The previous nine chapters are written in full as of PR #92; the only "to-do" is updates as the library evolves — when the GeoFIK / Stereographic SEW specialists land, [Chapter 10](10_whats_next.md) gets shorter and a new specialist-7R chapter slots between Chapter 6 and Chapter 7. When the codegen / Rust runtime lands, [Chapter 9](09_practical_guide.md)'s performance numbers get updated.
+
+The math (Chapter 4) is stable. The conditioning theory (Chapter 5) is stable. The bulletproof discipline (Chapter 8) is stable. The convention bugs we found in real-arm fixtures (Chapter 7) are stable as cautionary tales. Those are the load-bearing portions of the tutorial; they don't depend on which algorithms ship next.
+
+If you want to contribute, the live issues on GitHub are the entry points. [#82](https://github.com/siddhss5/ikfastpy/issues/82) (MC Table I coverage gap), [#86](https://github.com/siddhss5/ikfastpy/issues/86) (speed Tier 3 / Rust port), [#80](https://github.com/siddhss5/ikfastpy/issues/80) (more real-arm fixtures), [#84](https://github.com/siddhss5/ikfastpy/issues/84) (vendored ikfast retirement) are all in scope. Pick the one you care about; each issue is self-contained enough that you can dive in without reading the entire codebase first.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -33,4 +33,6 @@ This tutorial walks the math step by step, names every robustness trick we neede
 
 ## Status
 
-Chapters 1, 4, 5 are complete. Chapters 2, 3, 6–10 are scaffolded outlines being filled in alongside the public-API stabilisation. See [#87](https://github.com/siddhss5/ikfastpy/issues/87) for the rewrite tracking issue.
+All ten chapters are written. Updates land alongside the library's evolution — when specialist 7R solvers (GeoFIK, Stereographic SEW) ship, the tutorial gets a new specialist chapter between 6 and 7; when the Rust runtime ships, Chapter 9's performance numbers update. The math (Chapter 4), conditioning theory (Chapter 5), and bulletproof discipline (Chapter 8) are the load-bearing material and don't depend on which algorithms ship next.
+
+Tracking issue: [#87](https://github.com/siddhss5/ikfastpy/issues/87).


### PR DESCRIPTION
## Summary

Closes the prose portion of [#87](https://github.com/siddhss5/ikfastpy/issues/87) (tutorial rewrite). PR #91 shipped the structure with chapters 1, 4, 5 fully written and the rest scaffolded with `!!! warning "Scaffolding"` admonitions. This PR fills them in.

## Chapter coverage

| # | Title | Was | Now |
|---|---|---|---|
| 1 | The IK problem | Full | Full |
| 2 | The Pieper class and subproblem composition | Scaffolded | **Full** |
| 3 | The EAIK gap | Scaffolded | **Full** |
| 4 | Raghavan–Roth in 8 stages | Full | Full |
| 5 | Conditioning is the hard part | Full | Full |
| 6 | Algebraic-first, refinement-second | Scaffolded | **Full** |
| 7 | The KinBody-input bridge | Scaffolded | **Full** |
| 8 | Bulletproof validation | Scaffolded | **Full** |
| 9 | Practical guide | Scaffolded | **Full** |
| 10 | Roadmap | Scaffolded | **Full** |

## Stats

- **+654 lines of prose** (1273 → 1927 net); each chapter is now self-contained reading rather than a section-level outline.
- All `!!! warning "Scaffolding"` admonitions removed.
- All source-code references use absolute GitHub URLs (mkdocs strict-mode compliant).
- `mkdocs build --strict`: clean, 6.02s.

## Highlights of what each chapter now covers

- **Chapter 2:** SP1-SP6 walk-through with closed-form intuition for each subproblem, four per-family compositions, the SP5/SP6 cluster-root pathology and Gauss-Newton fix.
- **Chapter 3:** Catalogue of arms in the EAIK gap (JACO 2, Piper, Rizon 4, custom), explicit list of why each obvious workaround fails, three architectural decisions ssik makes in response.
- **Chapter 6:** The #74 contract end-to-end: why hidden refinement is the worst-of-both-worlds antipattern, the Day-4 scipy-LM-embedded misadventure, lm_refine's no-divergence-abort design, when refinement actually fires.
- **Chapter 7:** The load-bearing T_pre bug story — UR5's accidental world-z alignment hid the bug for months until JACO 2's link_1.quat=(0,0,1,0) exposed it. Bridge residual 0.81 → 1.6e-15 after fix.
- **Chapter 8:** Five gates (hand-picked generic, hand-picked near-singular, synthetic alternative-geometry, 500-pose hypothesis, N-way cross-solver agreement on Puma) with what each catches. "No papering over" antipatterns explicitly listed.
- **Chapter 9:** Install + three KinBody construction patterns + solver selection + Solution field-by-field semantics + four debug causes for is_ls=True + performance numbers + common pitfalls.
- **Chapter 10:** Husty-Pfurner universal fallback, specialist 7R solvers, codegen/Rust Phase M (estimated ~300-500µs tier-2 / ~30-50µs tier-0), Phase K legacy retirement, IK modes beyond Transform6D, MJCF front-end, third-party solver extensibility.

## Validation

- [x] `mkdocs build --strict`: clean
- [x] All KaTeX expressions render
- [x] All chapter-to-chapter cross-references resolve
- [x] All source-code links use absolute GitHub URLs

## Out of scope

- Per-mode reference pages (`docs/reference/ik-modes/`) — separate effort, [#18](https://github.com/siddhss5/ikfastpy/issues/18).
- mkdocstrings-based API auto-reference pages — separate effort.
- Tutorial chapter on specialist 7R solvers — slots between Chapter 6 and 7 once GeoFIK / Stereographic SEW land.

Closes the prose portion of #87.