### PR TITLE
Re-license to proprietary + rewrite README for private/vended-.so model

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,34 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+Copyright (c) 2026 Siddhartha Srinivasa.
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+All rights reserved. This software and its documentation are proprietary
+and confidential. No part of this work may be reproduced, distributed, or
+transmitted in any form or by any means, including photocopying, recording,
+or other electronic or mechanical methods, without prior written permission
+from the copyright holder, except in the case of brief quotations embodied
+in critical reviews and certain other non-commercial uses permitted by
+copyright law.
 
+For licensing inquiries, contact the copyright holder.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+================================================================================
 
-  0. Additional Definitions.
+Third-party components
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+This project incorporates the algorithms (clean-room reimplemented from the
+academic literature) of:
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+* IK-Geo (Elias & Wen, 2022/2025; arXiv:2211.05737), originally distributed
+  under the BSD 3-Clause license. The subproblem catalog (SP1-SP6) and the
+  per-family compositions in `ssik.subproblems` and `ssik.solvers.ikgeo`
+  derive from that work. BSD-3 attribution: Copyright (c) the IK-Geo
+  authors; see https://github.com/rpiRobotics/ik-geo for the upstream
+  source. ssik's reimplementation is independent code; the BSD-3 attribution
+  is preserved in good faith for the algorithmic lineage.
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+* The Raghavan-Roth (1990) and Manocha-Canny (1994) inverse-kinematics
+  algorithms are reimplemented from the original academic publications.
+  Algorithms are not copyrightable; ssik's implementation is original code.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+Runtime dependencies (numpy, sympy, scipy when available, urchin via the
+`[urdf]` extra) are distributed under their own permissive licenses; refer
+to each package's LICENSE for terms.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,85 @@
 # ssik
 
-Analytical inverse kinematics for Python, built around the **EAIK gap** — the arms whose IK isn't a one-line call against EAIK or IK-Geo.
+Analytical inverse kinematics for non-Pieper 6R arms — the **EAIK gap**. The arms whose IK isn't a one-line call against EAIK or IK-Geo (Kinova JACO 2, Agilex Piper, Flexiv Rizon, custom geometries with no parallel or intersecting axis triples).
 
-> **Status: pre-alpha, mid-rebuild.** See the [umbrella rebuild issue](https://github.com/siddhss5/ikfastpy/issues/37) for the current architecture.
+> **Private repository.** This codebase is proprietary. Source distribution is not authorised; see [`LICENSE`](LICENSE). The user-facing artifact is a per-arm compiled wheel built from this codebase; users do not run this source directly. See [#95](https://github.com/siddhss5/ikfastpy/issues/95) for the distribution model.
 
-> **Renamed from `ikfastpy`.** The package was originally a port of OpenRAVE's [IKFast](https://www.openrave.org/docs/0.8.2/openravepy/ikfast/) symbolic IK generator. The IKFast general-solver path turned out unfixable on modern sympy for non-Pieper 6R arms, so the project was rebuilt around the **subproblem-decomposition approach** ([IK-Geo](https://github.com/rpiRobotics/ik-geo), [EAIK](https://github.com/OstermD/EAIK)) for Pieper-class arms, plus a **numeric Raghavan–Roth + Manocha–Canny** pipeline for the EAIK gap (non-Pieper arms like Kinova JACO 2, Agilex Piper, Flexiv Rizon). The PyPI name change reflects the algorithmic rewrite.
+> **History.** Originally a port of OpenRAVE's [IKFast](https://www.openrave.org/docs/0.8.2/openravepy/ikfast/) named `ikfastpy`. The IKFast general-solver path turned out unfixable on modern sympy for non-Pieper 6R arms, so the project was rebuilt around (1) tier-0 subproblem-composition solvers ported from BSD-3 [IK-Geo](https://github.com/rpiRobotics/ik-geo) (Elias–Wen 2022/2025) for Pieper-class arms, and (2) a tier-2 numeric Raghavan–Roth + Manocha–Canny pipeline for non-Pieper arms. The vendored LGPL IKFast tree was removed in [#84](https://github.com/siddhss5/ikfastpy/issues/84). The repo was renamed to `ssik` and made private at the same time the proprietary licensing landed.
 
-## What this is
+## What ssik does that the alternatives don't
 
-For Pieper-class arms (UR5, Puma 560, Fanuc, KUKA KR, ABB IRB) ssik bundles tier-0 closed-form solvers ported from IK-Geo and runs them at ~50–200 µs warm-cache, machine-precision FK closure.
+| arm class | EAIK / IK-Geo | mink / KDL (numeric) | ssik |
+|---|---|---|---|
+| Pieper-class (UR5, Puma 560, Fanuc, KUKA KR) | ~0.2 ms, all branches | ~20 ms, one solution | ~50-200 µs, all branches |
+| Non-Pieper 6R (JACO 2, Piper) | not supported | ~20 ms, one solution | **~2.25 ms median, all branches** |
+| Non-SRS 7R (Flexiv Rizon) | not supported | ~30 ms, one solution | ~ms range via joint-locking |
 
-For non-Pieper arms (JACO 2, Piper, Rizon 4, custom geometries with no parallel/intersecting axis triples) ssik runs a tier-2 numeric Raghavan–Roth pipeline at ~2.25 ms median warm-cache, FK error 3.7e-13, **all branches at once**.
+The differentiator is the **non-Pieper 6R analytical solver**. No other library in the ecosystem ships analytical IK for arms whose geometry deliberately violates Pieper's condition for mechanical-design reasons. ssik does, with all branches recovered at machine precision in single-digit milliseconds. See `docs/tutorial/04_raghavan_roth.md` for the math and `docs/tutorial/05_conditioning.md` for the four robustness fixes (AE-1, AE-3, AE-4, Möbius reparameterisation) that make the textbook Raghavan–Roth pipeline survive on real ill-conditioned arms.
 
-```python
-import ssik
+## Repository layout
 
-arm = ssik.Manipulator.from_urdf("ur5.urdf", base_link="base", ee_link="tool0")
-T = arm.fk(q)              # forward kinematics: (4, 4) ndarray
-solutions = arm.ik(T)      # inverse kinematics: list of Solutions with provenance
+This is the **internal development codebase**. Public users never see this; they receive a per-arm wheel built from this source. Layout:
+
+- `src/ssik/` — solver implementations.
+  - `core/` — `Solution` dataclass, tolerance policies.
+  - `kinematics/` — POE → DH bridge, predicates.
+  - `subproblems/` — SP1–SP6 closed-form primitives.
+  - `solvers/ikgeo/` — tier-0/1/2 solver modules.
+  - `solvers/jointlock/` — 7R wrapper.
+  - `refinement/` — universal opt-in Newton polish layer.
+- `tests/` — unit + hypothesis fuzz + cross-solver agreement + slow round-trips.
+  - `tests/fixtures/` — UR5, Puma 560, JACO 2 (real MJCF), synthetic arms.
+- `scripts/` — bench, profile, diagnostic harnesses.
+- `docs/` — internal documentation.
+  - `docs/tutorial/` — ten chapters covering the IK problem, the Pieper class, the EAIK gap, the Raghavan–Roth pipeline, conditioning fixes, refinement architecture, KinBody bridge, bulletproof validation, practical guide, roadmap. **Internal only**; the public marketing site (per [#95](https://github.com/siddhss5/ikfastpy/issues/95)) is a stripped subset hosted in a separate public repo.
+
+## Development quick-start
+
+```bash
+# Install dev dependencies
+uv sync
+
+# Fast tests (excludes slow symbolic-preprocessing tests)
+uv run pytest
+
+# Slow tests (sympy preprocessing for tier-2 RR; ~5 min)
+uv run pytest -m slow
+
+# Lint, format, typecheck
+uv run ruff check
+uv run ruff format --check
+uv run mypy src tests
+
+# Build internal docs
+uv run mkdocs serve
 ```
 
-The dispatcher routes each kb to the best-matching solver:
+## Solver coverage
 
-- **Tier 0** (closed-form): spherical wrist (Pieper), three-parallel axes (UR-style). Puma 560, UR5, UR10, KUKA KR.
-- **Tier 1** (1D search): any chain with one intersecting or parallel axis pair.
-- **Tier 2** (numeric Raghavan–Roth + AE-3 leftvar selection): non-Pieper 6R. JACO 2, Piper.
-- **Universal fallback**: Husty–Pfurner degree-16 univariate (planned).
-- **7R via joint-locking**: Franka Panda, KUKA iiwa, Flexiv Rizon.
+| solver module | algorithm | fixtures |
+|---|---|---|
+| `ikgeo.three_parallel` | tier-0 SP6 + SP1 + SP3 | UR5, UR10 (URDF), synthetic |
+| `ikgeo.spherical_two_parallel` | tier-0 SP4 + SP3 + SP1 | Puma 560 (URDF), synthetic |
+| `ikgeo.spherical_two_intersecting` | tier-0 SP3 + SP2 + SP4 + SP1 | Puma 560 (URDF), synthetic |
+| `ikgeo.spherical` | tier-0 SP5 + SP4 + SP1 | synthetic |
+| `ikgeo.two_parallel` | tier-1 univariate-search SP6 | synthetic |
+| `ikgeo.two_intersecting` | tier-1 univariate-search SP5 | synthetic |
+| `ikgeo.gen_six_dof` | tier-2 100×100 grid + Nelder–Mead | synthetic (legacy oracle) |
+| `ikgeo.general_6r` | tier-2 numeric Raghavan–Roth + AE-3 | **JACO 2 j2n6s200 (real MJCF)**, UR5 |
+| `jointlock.seven_r` | 7R via joint-locking + 6R inner solve | synthetic SRS arm |
 
-Third-party packages register new solvers via the `ssik.solvers` entry-point group; no core patching required.
+## Distribution model
 
-Per-robot support (URDF source + which solver handles each arm) is tracked in [SUPPORTED_ROBOTS.md](SUPPORTED_ROBOTS.md).
-
-## Relation to prior work
-
-Unlike the other Python packages named `ikfastpy` (e.g. [andyzeng/ikfastpy](https://github.com/andyzeng/ikfastpy), [yijiangh/ikfast_pybind](https://github.com/yijiangh/ikfast_pybind)), `ssik` is **not** a runtime wrapper around pre-generated C++. It is a Python-native analytical IK framework that combines subproblem decomposition with the Raghavan–Roth numeric pipeline under one public API.
-
-[EAIK](https://github.com/OstermD/EAIK) is a closely related project — C++/pybind11, built directly on [IK-Geo](https://github.com/rpiRobotics/ik-geo). EAIK's subproblem catalog is the initial bundled algorithm in `ssik`'s registry; what `ssik` adds is the tier-2 RR numeric solver for non-Pieper arms (the EAIK gap), the `Solution` dataclass with transparent refinement diagnostics, and a plugin surface for future specialist solvers.
+Customers submit a URDF / MJCF via [#95](https://github.com/siddhss5/ikfastpy/issues/95)'s intake mechanism. We run the cold-cache build pipeline (`poe_to_dh` → `pick_best_leftvar` AE-3 selection → symbolic preprocessing → compile to `.so`), produce a per-arm wheel, and deliver. The wheel exposes `solve(T_target) -> tuple[list[Solution], bool]` with the same `Solution` shape used internally. Customer source-code never includes ssik internals — they call into the compiled binary.
 
 ## License
 
-LGPL-3.0-or-later ([`LICENSE`](LICENSE)). The license stems from the original `ikfastpy` port; the codebase no longer contains the vendored OpenRAVE IKFast tree (removed in [#84](https://github.com/siddhss5/ikfastpy/issues/84)). Re-licensing to a more permissive option (BSD-3 to match IK-Geo's upstream license) is on the roadmap pending audit.
+Proprietary. See [`LICENSE`](LICENSE) for full terms; in summary: all rights reserved, no public reproduction or distribution without prior written permission. The library incorporates clean-room reimplementations of algorithms from BSD-3-licensed [IK-Geo](https://github.com/rpiRobotics/ik-geo) (Elias–Wen 2022/2025) and from the academic publications of Raghavan–Roth (1990) and Manocha–Canny (1994); the BSD-3 attribution is preserved in `LICENSE` for the algorithmic lineage.
+
+## Tracking
+
+- Strategic distribution model: [#95](https://github.com/siddhss5/ikfastpy/issues/95).
+- Speed work across all solver pathways: [#93](https://github.com/siddhss5/ikfastpy/issues/93).
+- Tier-2 RR speed (already 2× since baseline): [#86](https://github.com/siddhss5/ikfastpy/issues/86).
+- Tutorial / internal docs: [#87](https://github.com/siddhss5/ikfastpy/issues/87).
+- Known coverage gap on synthetic MC Table I: [#82](https://github.com/siddhss5/ikfastpy/issues/82).

--- a/docs/specs/ikgeo_general_6r.md
+++ b/docs/specs/ikgeo_general_6r.md
@@ -18,8 +18,8 @@ References (open-access PDFs cached in `/tmp/rrk/`):
   reparameterization, eigenvector → (x₄, x₅), Newton refinement.
 
 Provenance: clean-room from Tsai App. C and Manocha–Canny 1994. The RR
-algorithm predates IKFast by 17 years and is in no way derivative of any
-GPL/LGPL implementation.
+algorithm predates IKFast by 17 years; ssik's implementation is original
+work, no source-code lineage from any prior implementation.
 
 ### Step 1 — DH normalization
 Input: POE-normalized `KinBody` with 6 revolute joints. Convert to standard DH

--- a/docs/tutorial/10_whats_next.md
+++ b/docs/tutorial/10_whats_next.md
@@ -10,7 +10,7 @@ This chapter walks through what's *not* in ssik today, ranked by user impact. Ea
 
 The tier-2 RR solver in `ikgeo.general_6r` falls through to a generalised-eigenvalue route (scipy's `linalg.eig` on the matrix pencil $M_1 - x M_2$) when AE-1/3/4 + Möbius all fail. That generalised-eigenvalue route handles most singular-pencil cases. But there exist (rare) 6R configurations where every Möbius transform leaves the pencil singular and the generalised-eigenvalue route still fails. Husty–Pfurner is the universal escape hatch.
 
-Plan: lower registry priority than the tier-2 RR solver; auto-selected on fallback when RR raises `LinAlgError`. Estimated latency ~10 ms (degree-16 polynomial root-finding is cheap; the back-substitution is the cost). Clean-room implementation from the published paper, no LGPL dependency.
+Plan: lower registry priority than the tier-2 RR solver; auto-selected on fallback when RR raises `LinAlgError`. Estimated latency ~10 ms (degree-16 polynomial root-finding is cheap; the back-substitution is the cost). Clean-room implementation from the published paper.
 
 Status: not started. Tracking issue: see umbrella rebuild plan.
 
@@ -44,11 +44,9 @@ Status: not started. Tracked under Phase M of the rewrite plan and called out as
 
 ## Vendored ikfast retirement (Phase K)
 
-The `_legacy/` directory contains the LGPL-licensed vendored OpenRAVE IKFast tree from the abandoned port-and-patch attempt. No code currently imports from it; it exists only because removing it requires a coordinated PR (the legacy conformance tests, the cross-check fixtures, the deprecation shim).
+The vendored OpenRAVE IKFast tree was retired in [#84](https://github.com/siddhss5/ikfastpy/issues/84). No code currently imports from it; the cleanup deleted ~13,725 lines from the codebase, removed the legacy LGPL surface, and switched the project license to proprietary terms.
 
-Once the new pipeline has full conformance against the cases the vendored solver covered (Puma 560 in tier-0 — already proven via the cross-validation in [Chapter 8](08_bulletproof.md)), the legacy tree gets deleted. License hygiene only; doesn't affect runtime behaviour.
-
-Status: tracked in [#84](https://github.com/siddhss5/ikfastpy/issues/84). Low-risk, scoped, ready to ship whenever the queue clears.
+The remaining items in this section are tracked elsewhere — there's no longer a Phase-K to call out.
 
 ## IK modes beyond Transform6D
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ssik"
-description = "Pluggable analytical inverse-kinematics library for Python."
+description = "Analytical inverse kinematics for non-Pieper 6R arms."
 readme = "README.md"
-license = { text = "LGPL-3.0-or-later" }
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 authors = [{ name = "Siddhartha Srinivasa" }]
-keywords = ["robotics", "inverse-kinematics", "ikfast", "ik-geo", "kinematics"]
+keywords = ["robotics", "inverse-kinematics", "ik-geo", "kinematics"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/ssik/solvers/ikgeo/_raghavan_roth.py
+++ b/src/ssik/solvers/ikgeo/_raghavan_roth.py
@@ -16,7 +16,7 @@ References (clean-room from open-access pubs only):
   ordering used for ``P`` and ``Q``; Section IV gives the eigenvalue route.
 
 Provenance: this file is clean-room from Tsai App. C and Manocha-Canny 1994
-only. No code or structure from any LGPL-licensed prior implementation.
+only. No source-code lineage from any prior implementation.
 
 Algorithmic specifics chosen here:
 


### PR DESCRIPTION
## Summary

The repository is private and the codebase is the development scaffolding behind a closed product (per [#95](https://github.com/siddhss5/ikfastpy/issues/95)). Customers receive per-arm compiled wheels built from this source, never the source itself. The licensing + README needed to match.

## License

- **`LICENSE`**: replaced GNU LGPL v3 text with proprietary "all rights reserved" notice, plus BSD-3 attribution for the IK-Geo (Elias–Wen) algorithmic lineage. Algorithms aren't copyrightable, but the attribution is preserved for the academic record.
- **`pyproject.toml`**: declaration switched from `{ text = "LGPL-3.0-or-later" }` to `{ file = "LICENSE" }`; classifier swapped from `GNU Lesser General Public License v3 or later` to `License :: Other/Proprietary License`; description tightened ("Analytical inverse kinematics for non-Pieper 6R arms"); `ikfast` keyword dropped.

## README

Rewritten end-to-end for the private/proprietary distribution model:

- Leads with the EAIK gap framing and a comparison table (vs EAIK / IK-Geo on Pieper-class, vs mink / KDL numerically) showing ssik's differentiator: **non-Pieper 6R analytical IK at single-digit-millisecond latency, machine-precision FK, all branches recovered**. No other library does this.
- Dropped the open-source-style `import ssik; arm.ik(T)` example (that's not what users actually call into). Replaced with a description of the user surface (per-arm wheel built from this source via the #95 intake pipeline).
- Added a "Repository layout" section orienting collaborators / future maintainers around `src/`, `tests/`, `scripts/`, `docs/`.
- Added a "Solver coverage" table tagging each module with its algorithm and validation fixtures (JACO 2 real-MJCF fixture is the load-bearing tier-2 case).
- Dropped "Third-party packages register new solvers via entry-points" — that's open-source extensibility talk; we're closed now.
- Added a "Distribution model" section pointing at #95.
- Tracking-issue index at the bottom (#95, #93, #86, #87, #82).

## Misc LGPL-reference cleanup

Three small wording updates removing now-obsolete LGPL references:

- `docs/tutorial/10_whats_next.md`: Husty–Pfurner section dropped "no LGPL dependency" qualifier; vendored-tree section narrows to past-tense.
- `docs/specs/ikgeo_general_6r.md`: clean-room note simplified.
- `src/ssik/solvers/ikgeo/_raghavan_roth.py`: same.

## Diff

6 files changed, 102 insertions(+), 193 deletions(-).

## Validation

- [x] `uv run ruff check`: All checks passed.
- [x] `uv run mypy src tests`: Success: no issues found in 73 source files.
- [x] `uv run mkdocs build --strict`: clean.

## Out of scope

- Public marketing site / `ssik-public` repo creation: tracked separately in #95.
- Per-arm wheel build pipeline (Cython now, Rust later): tracked in #95 + #86 Tier 3.