### PR TITLE
Speed Tier 1 on #93: hand-roll _cross3/_dot3 (UR5 three_parallel 2.96x)

### DIFF
--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -1,0 +1,94 @@
+"""Per-IK timing for ikgeo.three_parallel on UR5 (warm cache).
+
+Baseline measurement for #93 — the broader speed pass over non-tier-2-RR
+solver pathways. Mirrors scripts/bench_real_jaco2.py methodology:
+
+  uv run python scripts/bench_three_parallel.py
+
+Reports min / median / mean / p95 / max IK time, solutions/pose distribution,
+FK error stats, and failure count over 100 random non-singular poses.
+
+UR5 fixture loaded from tests/fixtures/ur5.urdf (in-tree URDF). The
+three-parallel solver covers UR3 / UR5 / UR10 and any other arm with the
+same parallel-trio axis structure at joints (1, 2, 3).
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+import time
+
+import numpy as np
+
+print = functools.partial(print, flush=True)
+
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+
+from pathlib import Path  # noqa: E402
+
+from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
+from ssik.solvers.ikgeo import three_parallel  # noqa: E402
+
+
+def _rot_axis(axis, angle):
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q):
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path("/Users/siddh/code/ikfastpy/tests/fixtures")
+kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+T_warm = fk_poe(kb, q_warm)
+sols, _ = three_parallel.solve(kb, T_warm)
+print(f"warm-cache solve: {len(sols)} solutions")
+
+print("\nwarm-cache: 100 random poses")
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+n_fail = 0
+for _ in range(100):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t = time.perf_counter()
+    sols, is_ls = three_parallel.solve(kb, t_target)
+    times.append((time.perf_counter() - t) * 1000)
+    n_sols.append(len(sols))
+    if is_ls:
+        n_fail += 1
+        continue
+    best_err = min(float(np.linalg.norm(fk_poe(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("\nper-IK time over 100 poses:")
+print(f"  min     {ts.min():>8.3f} ms")
+print(f"  median  {np.median(ts):>8.3f} ms")
+print(f"  mean    {ts.mean():>8.3f} ms")
+print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max     {ts.max():>8.3f} ms")
+print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
+      f"min={min(n_sols)}, max={max(n_sols)}")
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {n_fail}/100")

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -1,9 +1,14 @@
-"""Shared Rodrigues rotation helper for the subproblem solvers.
+"""Shared Rodrigues rotation + 3-vector primitives for the subproblem solvers.
 
 Kept private (underscore-prefixed) and internal to the subproblems package.
-If another package needs rotations later we will move this to
-:mod:`ssik.kinematics` -- for now keeping it here avoids one more public
-surface point to maintain.
+
+The helpers ``_cross3`` and ``_dot3`` exist because ``np.cross`` /
+``np.dot`` carry 2-10 µs of axis-normalisation dispatch overhead per call
+that swamps the actual arithmetic on 3-vectors. Hand-rolled versions for
+the 3-vector specialisation are 20-50x faster per call. Inside
+:func:`rotate` and the SP-N subproblem hot paths these helpers are called
+~10k+ times per IK solve; the per-call overhead reduction is the
+single largest tier-0 win on UR5 (#93).
 """
 
 from __future__ import annotations
@@ -14,6 +19,28 @@ from numpy.typing import NDArray
 __all__ = ["rotate"]
 
 
+def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
+    """3-vector cross product, no dispatch overhead.
+
+    Equivalent to ``np.cross(a, b)`` for 3-element arrays. Several
+    subproblem hot paths call this inside Newton / Gauss-Newton loops,
+    where the per-call overhead of ``np.cross`` dominates the actual
+    arithmetic.
+    """
+    return np.array(
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    )
+
+
+def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
+    """3-vector dot product as ``float``; no dispatch overhead."""
+    return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 
@@ -21,5 +48,5 @@ def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDAr
     """
     c = float(np.cos(theta))
     s = float(np.sin(theta))
-    kv = float(np.dot(k, v))
-    return v * c + np.cross(k, v) * s + k * (kv * (1.0 - c))
+    kv = _dot3(k, v)
+    return v * c + _cross3(k, v) * s + k * (kv * (1.0 - c))

--- a/src/ssik/subproblems/sp1.py
+++ b/src/ssik/subproblems/sp1.py
@@ -30,6 +30,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -51,14 +52,14 @@ def solve(
         radians and ``is_ls`` is ``True`` when the exact feasibility
         conditions do not hold (so ``theta`` is the LS optimum).
     """
-    kxp = np.cross(k, p)
-    kp = float(np.dot(k, p))
-    kq = float(np.dot(k, q))
-    theta = float(np.arctan2(np.dot(kxp, q), np.dot(p, q) - kp * kq))
+    kxp = _cross3(k, p)
+    kp = _dot3(k, p)
+    kq = _dot3(k, q)
+    theta = float(np.arctan2(_dot3(kxp, q), _dot3(p, q) - kp * kq))
 
     # Feasibility: |p_perp| = |q_perp| and k.p = k.q.
-    p_perp_sq = float(np.dot(p, p)) - kp * kp
-    q_perp_sq = float(np.dot(q, q)) - kq * kq
+    p_perp_sq = _dot3(p, p) - kp * kp
+    q_perp_sq = _dot3(q, q) - kq * kq
     tol = policy.subproblem_feasibility
     is_ls = abs(p_perp_sq - q_perp_sq) > tol or abs(kp - kq) > tol
     return theta, is_ls

--- a/src/ssik/subproblems/sp4.py
+++ b/src/ssik/subproblems/sp4.py
@@ -48,6 +48,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -70,11 +71,11 @@ def solve(
         ``k`` fallback.
     :returns: ``(solutions, is_ls)``.
     """
-    hp = float(np.dot(h, p))
-    kp = float(np.dot(k, p))
-    hk = float(np.dot(h, k))
+    hp = _dot3(h, p)
+    kp = _dot3(k, p)
+    hk = _dot3(h, k)
     coef_a = hp - kp * hk
-    coef_b = float(np.dot(h, np.cross(k, p)))
+    coef_b = _dot3(h, _cross3(k, p))
     coef_c = kp * hk
     r_sq = coef_a * coef_a + coef_b * coef_b
 

--- a/src/ssik/subproblems/sp6.py
+++ b/src/ssik/subproblems/sp6.py
@@ -42,7 +42,7 @@ from ssik.subproblems._aux import (
     solve_lower_triangular_system_2x2,
     solve_two_ellipse_numeric,
 )
-from ssik.subproblems._rotation import rotate
+from ssik.subproblems._rotation import _cross3, _dot3, rotate
 from ssik.subproblems._validate import validate_vec3_iterable
 
 __all__ = ["solve"]
@@ -78,7 +78,7 @@ def _all_p_collinear_with_k(
     on the rank check of the stacked QR diagonals and on post-verification.
     """
     for k_i, p_i in zip(k, p, strict=True):
-        p_perp_sq = float(np.dot(p_i, p_i)) - float(np.dot(k_i, p_i)) ** 2
+        p_perp_sq = _dot3(p_i, p_i) - _dot3(k_i, p_i) ** 2
         if p_perp_sq >= deg_tol:
             return False
     return True
@@ -93,8 +93,8 @@ def _residual(
     d1: float,
     d2: float,
 ) -> float:
-    lhs1 = float(h[0] @ rotate(k[0], theta1, p[0])) + float(h[1] @ rotate(k[1], theta2, p[1]))
-    lhs2 = float(h[2] @ rotate(k[2], theta1, p[2])) + float(h[3] @ rotate(k[3], theta2, p[3]))
+    lhs1 = _dot3(h[0], rotate(k[0], theta1, p[0])) + _dot3(h[1], rotate(k[1], theta2, p[1]))
+    lhs2 = _dot3(h[2], rotate(k[2], theta1, p[2])) + _dot3(h[3], rotate(k[3], theta2, p[3]))
     return max(abs(lhs1 - d1), abs(lhs2 - d2))
 
 
@@ -131,8 +131,8 @@ def solve(
 
     a_cols = []
     for idx in range(4):
-        kxp = np.cross(k[idx], p[idx])
-        a_cols.append(np.column_stack([kxp, -np.cross(k[idx], kxp)]))
+        kxp = _cross3(k[idx], p[idx])
+        a_cols.append(np.column_stack([kxp, -_cross3(k[idx], kxp)]))
 
     h1_a1 = h[0] @ a_cols[0]
     h2_a2 = h[1] @ a_cols[1]
@@ -149,8 +149,8 @@ def solve(
 
     b = np.array(
         [
-            d1 - float(h[0] @ k[0]) * float(k[0] @ p[0]) - float(h[1] @ k[1]) * float(k[1] @ p[1]),
-            d2 - float(h[2] @ k[2]) * float(k[2] @ p[2]) - float(h[3] @ k[3]) * float(k[3] @ p[3]),
+            d1 - _dot3(h[0], k[0]) * _dot3(k[0], p[0]) - _dot3(h[1], k[1]) * _dot3(k[1], p[1]),
+            d2 - _dot3(h[2], k[2]) * _dot3(k[2], p[2]) - _dot3(h[3], k[3]) * _dot3(k[3], p[3]),
         ],
         dtype=np.float64,
     )
@@ -254,23 +254,23 @@ def _refine_sp6(
 
         f = np.array(
             [
-                float(h[0] @ r0) + float(h[1] @ r1) - d1,
-                float(h[2] @ r2) + float(h[3] @ r3) - d2,
+                _dot3(h[0], r0) + _dot3(h[1], r1) - d1,
+                _dot3(h[2], r2) + _dot3(h[3], r3) - d2,
             ],
             dtype=np.float64,
         )
 
         # Partials. dF_i/dt_j uses chain rule: Rot(k, t) rotates `p`, so
         # the angle derivative is k x (Rot(k, t) @ p).
-        d_dt1_r0 = np.cross(k[0], r0)
-        d_dt2_r1 = np.cross(k[1], r1)
-        d_dt1_r2 = np.cross(k[2], r2)
-        d_dt2_r3 = np.cross(k[3], r3)
+        d_dt1_r0 = _cross3(k[0], r0)
+        d_dt2_r1 = _cross3(k[1], r1)
+        d_dt1_r2 = _cross3(k[2], r2)
+        d_dt2_r3 = _cross3(k[3], r3)
 
         j_mat_2x2 = np.array(
             [
-                [float(h[0] @ d_dt1_r0), float(h[1] @ d_dt2_r1)],
-                [float(h[2] @ d_dt1_r2), float(h[3] @ d_dt2_r3)],
+                [_dot3(h[0], d_dt1_r0), _dot3(h[1], d_dt2_r1)],
+                [_dot3(h[2], d_dt1_r2), _dot3(h[3], d_dt2_r3)],
             ],
             dtype=np.float64,
         )


### PR DESCRIPTION
## Summary
- UR5 `three_parallel` solve drops from **4.7ms → 1.586ms median** (2.96× faster) via hand-rolled `_cross3`/`_dot3` 3-vector primitives
- Surfaced the universal hot-path: numpy's generic `cross`/`dot` carry 2-10µs of axis-normalisation dispatch overhead per call. cProfile showed `np.cross` at 21k calls / 62% cumulative time on UR5
- `_cross3` + `_dot3` propagated to `rotate()` (Rodrigues) and every dot/cross site in SP1, SP4, SP6 (including SP6's `_refine_sp6` Gauss-Newton residual + Jacobian)
- This benefits every solver downstream: spherical, three_parallel, two_parallel, two_intersecting, spherical_two_*, gen_six_dof, seven_r — anyone calling SP1/SP4/SP6 or `rotate()` gets the speedup

## Why this is the right shape
- Three-vector specialisation is the smallest possible change that captures the win — no algorithmic change, no new abstractions, identical numerics
- Helpers stay private (underscore-prefixed) to the subproblems package; public API unchanged
- Module docstring on `_rotation.py` explains the *why* so future readers don't naively re-introduce `np.cross` for "consistency"

## Validation (bulletproof preserved)
- **bench_three_parallel.py** (new, mirrors `bench_real_jaco2.py` methodology): 100 random UR5 poses
  - Before: median 4.7ms, p95 ~14ms
  - After: median 1.586ms, min 0.825ms, p95 8.772ms, FK error 5e-16, 0 failures
- **107 passed** across SP1/SP4/SP6-touching solvers: three_parallel, ikgeo_general_6r, ikgeo_spherical, ikgeo_two_intersecting, ikgeo_two_parallel, spherical_two_intersecting, spherical_two_parallel
- **54 passed** across JACO 2 (slow, full RR pipeline) + seven_r + gen_six_dof + puma cross-validation + RR-PQ. The 3 xpassed are the known #82 JACO 2 platform-variance tags (`xfail(strict=False)`)
- `ruff check` + `ruff format --check` + `mypy` clean

## Follow-up (next under #93)
- Tier 2 on three_parallel: SP6 `_refine_sp6` is still ~31% of total time; investigate per-iteration vectorisation
- Per #93 priority order: profile `spherical_two_parallel` next (Puma 560 path)

## Test plan
- [x] `uv run python scripts/bench_three_parallel.py` — UR5 median ≤ 2ms, 0 failures, FK ≤ 1e-12
- [x] `uv run pytest tests/test_three_parallel.py tests/test_ikgeo_*.py tests/test_spherical_*.py` — green
- [x] `uv run pytest tests/test_jaco2_general_6r.py tests/test_jointlock_seven_r.py tests/test_puma_cross_validation.py tests/test_raghavan_roth_pq.py` — green (3 xpass on #82 are expected)
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy src/ssik/subproblems/` — clean

Closes #93 priority #1 (three_parallel on UR5).