### PR TITLE
Speed Tier 1 on #93: predicates use _cross3/_dot3/_norm3 + FLOP-budget bench (Puma 50%)

### DIFF
--- a/scripts/_flop_budget.py
+++ b/scripts/_flop_budget.py
@@ -1,0 +1,135 @@
+"""Deterministic FLOP-budget estimator for ssik bench scripts.
+
+Wall-clock is system-load-dependent and platform-specific. FLOP count is not:
+the same workload on the same input issues the same arithmetic ops on every
+machine. So we report both:
+
+- **wall-clock**: what this run took on this machine (here, now)
+- **FLOP budget**: machine-invariant work performed
+- **achieved rate**: FLOP budget / wall-clock = effective FLOP/s on this CPU
+- **reference projection**: FLOP budget / target rate = predicted time on a
+  machine with that effective rate (assumes similar Python+numpy overhead)
+
+The FLOP budget is a *lower bound* on arithmetic — it counts operations on
+dominant shapes only. Counts come from cProfile's per-function call counts,
+which are deterministic for a fixed seed.
+
+Per-call FLOP estimates use textbook formulas for the algorithm at our
+workload's typical shapes (2x2 / 3x3 / 4x4 matrices, length-3 vectors).
+Numbers like ``solve(NxN)`` use ``(2/3)N^3`` for LU, ``N^2`` for back-sub.
+"""
+
+from __future__ import annotations
+
+import os
+import pstats
+
+# ssik primitives, matched by function name.
+SSIK_FLOPS: dict[str, int] = {
+    "_cross3": 9,  # 6 mul + 3 sub
+    "_dot3": 5,  # 3 mul + 2 add
+    "_norm3": 7,  # 3 mul + 2 add + 1 sqrt + 1 fudge
+}
+
+# numpy linalg + array ops, matched by (basename, funcname). FLOP estimates
+# baked in for our workload's dominant shapes.
+NUMPY_FLOPS: dict[tuple[str, str], int] = {
+    # 3-vector cross/dot still hit numpy if any callsite was missed by the
+    # _cross3/_dot3 propagation; keep these in case.
+    ("numeric.py", "cross"): 9,
+    ("numeric.py", "dot"): 5,
+    # np.linalg.norm: 3-vector dominant (axis_*, joint_origins).
+    ("_linalg.py", "norm"): 7,
+    # np.linalg.solve: 2x2 dominant (sp6 _refine_sp6).
+    ("_linalg.py", "solve"): 10,
+    # np.linalg.qr complete on a 2x4 (sp6): R is 4x4, Q is 4x4. ~64 flops.
+    ("_linalg.py", "qr"): 64,
+    # np.linalg.lstsq: 3x2 (predicates.three_consecutive_intersecting).
+    ("_linalg.py", "lstsq"): 32,
+    # np.linalg.eig: 4x4 cubic + iteration. Only used in tier-2 RR.
+    ("_linalg.py", "eig"): 200,
+    # arctan2 / arcsin / cos / sin: count as 10 each (transcendentals).
+    ("<frozen>", "atan2"): 10,
+}
+
+
+def flop_budget(stats: pstats.Stats) -> tuple[int, dict[str, int]]:
+    """Compute FLOP budget from a :class:`pstats.Stats` snapshot.
+
+    :returns: ``(total_flops, breakdown)`` where ``breakdown`` is keyed by
+        ``"<module>:<funcname>"`` for traceability.
+    """
+    total = 0
+    breakdown: dict[str, int] = {}
+    for (filename, _lineno, funcname), (cc, _nc, _tt, _ct, _callers) in stats.stats.items():
+        flops = SSIK_FLOPS.get(funcname)
+        if flops is not None:
+            cost = flops * cc
+            breakdown[funcname] = breakdown.get(funcname, 0) + cost
+            total += cost
+            continue
+        basename = os.path.basename(filename)
+        key = (basename, funcname)
+        flops = NUMPY_FLOPS.get(key)
+        if flops is not None:
+            cost = flops * cc
+            label = f"{basename}:{funcname}"
+            breakdown[label] = breakdown.get(label, 0) + cost
+            total += cost
+    return total, breakdown
+
+
+def _fmt_time(seconds: float) -> str:
+    """Format a time in human-readable units (ns / us / ms / s)."""
+    if seconds < 1e-6:
+        return f"{seconds * 1e9:>9.1f} ns"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:>9.3f} us"
+    if seconds < 1.0:
+        return f"{seconds * 1e3:>9.3f} ms"
+    return f"{seconds:>9.3f} s"
+
+
+def print_flop_summary(
+    total_flops: int,
+    n_solves: int,
+    wall_time_s: float,
+    breakdown: dict[str, int],
+) -> None:
+    """Print a FLOP-budget report.
+
+    Reports machine-invariant FLOP counts, machine-specific wall-clock, the
+    achieved effective rate (FLOPs / wall_time), and the projected per-solve
+    time at order-of-magnitude scaled rates. The scaled rows let a reader
+    estimate cost on a different runtime (Cython port, Rust port) by picking
+    the row whose achieved rate matches their target.
+    """
+    flops_per_solve = total_flops / n_solves
+    achieved_gflops = total_flops / wall_time_s / 1e9 if wall_time_s > 0 else 0.0
+    seconds_per_solve = wall_time_s / n_solves
+
+    print("\n--- FLOP budget (machine-invariant) ---")
+    print(f"  total       {total_flops:>12,d} FLOPs over {n_solves} solves")
+    print(f"  per solve   {flops_per_solve:>12,.0f} FLOPs")
+    print("  breakdown (per-solve):")
+    sorted_ops = sorted(breakdown.items(), key=lambda kv: -kv[1])
+    for label, cost in sorted_ops[:8]:
+        print(f"    {label:<40s} {cost / n_solves:>10,.1f}")
+
+    print("\n--- wall-clock (this run, this machine) ---")
+    print(f"  total       {wall_time_s:>12.3f} s")
+    print(f"  per solve   {_fmt_time(seconds_per_solve)}")
+    print(f"  achieved    {achieved_gflops:>12.5f} GFLOP/s")
+
+    # Scaled projections: what would this cost if effective rate were 10x,
+    # 100x, 1000x, 10000x what we measured? Useful as a transferability
+    # estimate -- a Cython port would typically hit 10-100x over Python+numpy
+    # on small-op workloads, a native Rust/C port 100-1000x.
+    print("\n--- projected per-solve time at scaled rates ---")
+    if achieved_gflops > 0:
+        for mult in (1.0, 10.0, 100.0, 1000.0, 10000.0):
+            target_gflops = achieved_gflops * mult
+            s = flops_per_solve / (target_gflops * 1e9)
+            label = f"{mult:>5.0f}x measured ({target_gflops:>8.4f} GFLOP/s)"
+            print(f"  {label}: {_fmt_time(s)}")
+    print()

--- a/scripts/bench_spherical_two_parallel.py
+++ b/scripts/bench_spherical_two_parallel.py
@@ -1,0 +1,103 @@
+"""Warm-cache per-IK bench for ssik.solvers.ikgeo.spherical_two_parallel on Puma 560.
+
+Mirrors scripts/bench_three_parallel.py / bench_real_jaco2.py methodology.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.solvers.ikgeo import spherical_two_parallel
+
+
+def _rot_axis(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path(__file__).parent.parent / "tests" / "fixtures"
+kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+sols, _ = spherical_two_parallel.solve(kb, fk_poe(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times = []
+n_sols = []
+fk_errs = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = spherical_two_parallel.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    for sol in sols:
+        T_fk = fk_poe(kb, sol.q)
+        fk_errs.append(float(np.linalg.norm(T_fk - t_target)))
+
+times = np.array(times) * 1e3
+print("per-IK time over 100 poses:")
+print(f"  min      {times.min():7.3f} ms")
+print(f"  median   {np.median(times):7.3f} ms")
+print(f"  mean     {times.mean():7.3f} ms")
+print(f"  p95      {np.percentile(times, 95):7.3f} ms")
+print(f"  max      {times.max():7.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass: cProfile a fresh sweep for deterministic call counts;
+# wall-clock under cProfile is not comparable to the unprofiled timing run.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(n)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    spherical_two_parallel.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(times.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -15,7 +15,9 @@ same parallel-trio axis structure at joints (1, 2, 3).
 
 from __future__ import annotations
 
+import cProfile
 import functools
+import pstats
 import sys
 import time
 
@@ -24,8 +26,11 @@ import numpy as np
 print = functools.partial(print, flush=True)
 
 sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/scripts")
 
 from pathlib import Path  # noqa: E402
+
+from _flop_budget import flop_budget, print_flop_summary  # noqa: E402
 
 from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
 from ssik.solvers.ikgeo import three_parallel  # noqa: E402
@@ -88,7 +93,25 @@ print(f"  median  {np.median(ts):>8.3f} ms")
 print(f"  mean    {ts.mean():>8.3f} ms")
 print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
 print(f"  max     {ts.max():>8.3f} ms")
-print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
-      f"min={min(n_sols)}, max={max(n_sols)}")
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
 print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
 print(f"failures (is_ls=True): {n_fail}/100")
+
+# FLOP-budget pass: cProfile a fresh sweep so call counts are deterministic;
+# wall-clock under cProfile is not comparable to the timing run above.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(100)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    three_parallel.solve(kb, tt)
+pr.disable()
+profile_s = time.perf_counter() - t0
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+# Wall-clock for the FLOP/s rate uses the unprofiled timing-run total to
+# match what users would see; cProfile adds ~30-50% overhead.
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, len(poses), unprofiled_total_s, breakdown)

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3, _norm3
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from numpy.typing import NDArray
@@ -70,7 +71,7 @@ def axis_parallel(
     Implementation: ``||a x b||`` is ``sin(theta)`` for unit vectors, which
     small-angle approximates to the angular misalignment in radians.
     """
-    return float(np.linalg.norm(np.cross(a, b))) < policy.axis_parallel
+    return _norm3(_cross3(a, b)) < policy.axis_parallel
 
 
 def axis_intersect(
@@ -89,15 +90,15 @@ def axis_intersect(
     coincident or disjoint; the distance is then the perpendicular component
     of ``(ob - oa)`` after projecting out ``a``.
     """
-    cross = np.cross(a, b)
-    cross_norm = float(np.linalg.norm(cross))
+    cross = _cross3(a, b)
+    cross_norm = _norm3(cross)
     delta = ob - oa
     if cross_norm < policy.axis_parallel:
         # Parallel case: shortest distance is the perpendicular component
         # of delta relative to a (equivalently b -- they're parallel).
-        perp = delta - np.dot(delta, a) * a
-        return float(np.linalg.norm(perp)) < policy.axis_intersect
-    distance = abs(float(np.dot(cross, delta))) / cross_norm
+        perp = delta - _dot3(delta, a) * a
+        return _norm3(perp) < policy.axis_intersect
+    distance = abs(_dot3(cross, delta)) / cross_norm
     return distance < policy.axis_intersect
 
 
@@ -177,7 +178,7 @@ def three_consecutive_intersecting(
         p = oa + t * a
 
         delta = p - oc
-        perp = delta - np.dot(delta, c) * c
-        if float(np.linalg.norm(perp)) < policy.axis_intersect:
+        perp = delta - _dot3(delta, c) * c
+        if _norm3(perp) < policy.axis_intersect:
             return (i, i + 1, i + 2)
     return None

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -41,6 +41,11 @@ def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
     return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
 
 
+def _norm3(a: NDArray[np.float64]) -> float:
+    """3-vector L2 norm, no dispatch overhead. Faster than ``np.linalg.norm``."""
+    return float(np.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]))
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 


### PR DESCRIPTION
## Summary
- **Puma 560 spherical_two_parallel: 1.84ms → 0.94ms median (~50% faster)**
- Propagates `_cross3` / `_dot3` / `_norm3` into `kinematics.predicates` (axis_parallel, axis_intersect, three_consecutive_intersecting). cProfile showed `three_consecutive_intersecting` at 35% of total Puma solve time, dominated by `np.cross` (2400 calls) + `np.linalg.norm` (6000 calls) on 3-vectors — pure dispatch overhead
- New `scripts/_flop_budget.py`: deterministic, machine-invariant work measurement based on cProfile call counts
- Bench scripts now report **wall-clock + FLOP budget + achieved GFLOP/s + projected per-solve time at 1× / 10× / 100× / 1000× / 10000× the measured rate** for transferability across machines and runtimes

> **Stacks on #98** — base branch is `m2-speed-three-parallel`. Merge #98 first, then this rebases cleanly to main.

## FLOP-budget headlines (this run, Apple M3 single thread, Python+numpy)
```
UR5 three_parallel:           2,519 FLOPs/solve   ~1.7ms median   1 MFLOP/s achieved
Puma spherical_two_parallel:  1,316 FLOPs/solve   ~0.94ms median  1 MFLOP/s achieved
```

The 1 MFLOP/s effective rate is the headline finding: **we are 10⁴× off peak FP throughput** because Python+numpy dispatch dominates small-op workloads. A native port (Rust/C) that closes that gap would deliver ~µs-scale IK — which is the original IKFast promise.

Sample bench output:
```
--- FLOP budget (machine-invariant) ---
  total            131,600 FLOPs over 100 solves
  per solve          1,316 FLOPs
  breakdown (per-solve):
    _dot3                                         765.0
    _cross3                                       351.0
    _norm3                                         98.0
    _linalg.py:norm                                70.0
    _linalg.py:lstsq                               32.0

--- wall-clock (this run, this machine) ---
  per solve       1.188 ms
  achieved         0.00111 GFLOP/s

--- projected per-solve time at scaled rates ---
      1x measured (  0.0011 GFLOP/s):     1.188 ms
     10x measured (  0.0111 GFLOP/s):   118.758 us
    100x measured (  0.1108 GFLOP/s):    11.876 us
   1000x measured (  1.1081 GFLOP/s):     1.188 us  ← Cython port territory
  10000x measured ( 11.0813 GFLOP/s):     118.8 ns  ← Rust/C with SIMD
```

## Why FLOP budget matters
- **Reproducible across machines.** cProfile call counts are deterministic for the same seed; FLOP budget computed from them is independent of CPU, OS, Python version
- **Transfer estimation.** Given the FLOP budget and a target machine's effective rate (or a target runtime's expected rate), users can predict per-solve time without re-running the bench
- **Optimization targeting.** `_dot3` dominates at 765 ops/solve in Puma — that's the next thing to vectorise if we wanted more

## Validation (bulletproof preserved)
- `bench_spherical_two_parallel.py` (new): Puma 560, 100 random poses, median 0.94ms, FK ≤ 1e-8, 0 failures
- `bench_three_parallel.py`: UR5, FK 5e-16, 0 failures
- 154 tests passed across predicates + every solver going through the predicates: three_parallel, spherical_two_parallel, ikgeo_general_6r, ikgeo_spherical, ikgeo_two_intersecting, ikgeo_two_parallel, spherical_two_intersecting, ikgeo_gen_six_dof, jointlock_seven_r, puma_cross_validation
- `ruff check` + `ruff format --check` + `mypy` clean

## Test plan
- [x] `uv run python scripts/bench_spherical_two_parallel.py` — Puma median ≤ 1.5ms, 0 failures
- [x] `uv run python scripts/bench_three_parallel.py` — UR5 0 failures, FK ≤ 1e-12
- [x] All predicate / solver tests green
- [x] FLOP budget reports match expected order of magnitude (~1-3k FLOPs/solve)

Closes #93 priority #2 (spherical_two_parallel on Puma 560). Adds the FLOP-budget tooling to use across the rest of the priority list.