### PR TITLE
Speed Tier 1 on #93: vectorise wrap-to-pi dedup (7R 31% faster, all solvers benefit)

### DIFF
--- a/scripts/_flop_budget.py
+++ b/scripts/_flop_budget.py
@@ -1,0 +1,135 @@
+"""Deterministic FLOP-budget estimator for ssik bench scripts.
+
+Wall-clock is system-load-dependent and platform-specific. FLOP count is not:
+the same workload on the same input issues the same arithmetic ops on every
+machine. So we report both:
+
+- **wall-clock**: what this run took on this machine (here, now)
+- **FLOP budget**: machine-invariant work performed
+- **achieved rate**: FLOP budget / wall-clock = effective FLOP/s on this CPU
+- **reference projection**: FLOP budget / target rate = predicted time on a
+  machine with that effective rate (assumes similar Python+numpy overhead)
+
+The FLOP budget is a *lower bound* on arithmetic — it counts operations on
+dominant shapes only. Counts come from cProfile's per-function call counts,
+which are deterministic for a fixed seed.
+
+Per-call FLOP estimates use textbook formulas for the algorithm at our
+workload's typical shapes (2x2 / 3x3 / 4x4 matrices, length-3 vectors).
+Numbers like ``solve(NxN)`` use ``(2/3)N^3`` for LU, ``N^2`` for back-sub.
+"""
+
+from __future__ import annotations
+
+import os
+import pstats
+
+# ssik primitives, matched by function name.
+SSIK_FLOPS: dict[str, int] = {
+    "_cross3": 9,  # 6 mul + 3 sub
+    "_dot3": 5,  # 3 mul + 2 add
+    "_norm3": 7,  # 3 mul + 2 add + 1 sqrt + 1 fudge
+}
+
+# numpy linalg + array ops, matched by (basename, funcname). FLOP estimates
+# baked in for our workload's dominant shapes.
+NUMPY_FLOPS: dict[tuple[str, str], int] = {
+    # 3-vector cross/dot still hit numpy if any callsite was missed by the
+    # _cross3/_dot3 propagation; keep these in case.
+    ("numeric.py", "cross"): 9,
+    ("numeric.py", "dot"): 5,
+    # np.linalg.norm: 3-vector dominant (axis_*, joint_origins).
+    ("_linalg.py", "norm"): 7,
+    # np.linalg.solve: 2x2 dominant (sp6 _refine_sp6).
+    ("_linalg.py", "solve"): 10,
+    # np.linalg.qr complete on a 2x4 (sp6): R is 4x4, Q is 4x4. ~64 flops.
+    ("_linalg.py", "qr"): 64,
+    # np.linalg.lstsq: 3x2 (predicates.three_consecutive_intersecting).
+    ("_linalg.py", "lstsq"): 32,
+    # np.linalg.eig: 4x4 cubic + iteration. Only used in tier-2 RR.
+    ("_linalg.py", "eig"): 200,
+    # arctan2 / arcsin / cos / sin: count as 10 each (transcendentals).
+    ("<frozen>", "atan2"): 10,
+}
+
+
+def flop_budget(stats: pstats.Stats) -> tuple[int, dict[str, int]]:
+    """Compute FLOP budget from a :class:`pstats.Stats` snapshot.
+
+    :returns: ``(total_flops, breakdown)`` where ``breakdown`` is keyed by
+        ``"<module>:<funcname>"`` for traceability.
+    """
+    total = 0
+    breakdown: dict[str, int] = {}
+    for (filename, _lineno, funcname), (cc, _nc, _tt, _ct, _callers) in stats.stats.items():
+        flops = SSIK_FLOPS.get(funcname)
+        if flops is not None:
+            cost = flops * cc
+            breakdown[funcname] = breakdown.get(funcname, 0) + cost
+            total += cost
+            continue
+        basename = os.path.basename(filename)
+        key = (basename, funcname)
+        flops = NUMPY_FLOPS.get(key)
+        if flops is not None:
+            cost = flops * cc
+            label = f"{basename}:{funcname}"
+            breakdown[label] = breakdown.get(label, 0) + cost
+            total += cost
+    return total, breakdown
+
+
+def _fmt_time(seconds: float) -> str:
+    """Format a time in human-readable units (ns / us / ms / s)."""
+    if seconds < 1e-6:
+        return f"{seconds * 1e9:>9.1f} ns"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:>9.3f} us"
+    if seconds < 1.0:
+        return f"{seconds * 1e3:>9.3f} ms"
+    return f"{seconds:>9.3f} s"
+
+
+def print_flop_summary(
+    total_flops: int,
+    n_solves: int,
+    wall_time_s: float,
+    breakdown: dict[str, int],
+) -> None:
+    """Print a FLOP-budget report.
+
+    Reports machine-invariant FLOP counts, machine-specific wall-clock, the
+    achieved effective rate (FLOPs / wall_time), and the projected per-solve
+    time at order-of-magnitude scaled rates. The scaled rows let a reader
+    estimate cost on a different runtime (Cython port, Rust port) by picking
+    the row whose achieved rate matches their target.
+    """
+    flops_per_solve = total_flops / n_solves
+    achieved_gflops = total_flops / wall_time_s / 1e9 if wall_time_s > 0 else 0.0
+    seconds_per_solve = wall_time_s / n_solves
+
+    print("\n--- FLOP budget (machine-invariant) ---")
+    print(f"  total       {total_flops:>12,d} FLOPs over {n_solves} solves")
+    print(f"  per solve   {flops_per_solve:>12,.0f} FLOPs")
+    print("  breakdown (per-solve):")
+    sorted_ops = sorted(breakdown.items(), key=lambda kv: -kv[1])
+    for label, cost in sorted_ops[:8]:
+        print(f"    {label:<40s} {cost / n_solves:>10,.1f}")
+
+    print("\n--- wall-clock (this run, this machine) ---")
+    print(f"  total       {wall_time_s:>12.3f} s")
+    print(f"  per solve   {_fmt_time(seconds_per_solve)}")
+    print(f"  achieved    {achieved_gflops:>12.5f} GFLOP/s")
+
+    # Scaled projections: what would this cost if effective rate were 10x,
+    # 100x, 1000x, 10000x what we measured? Useful as a transferability
+    # estimate -- a Cython port would typically hit 10-100x over Python+numpy
+    # on small-op workloads, a native Rust/C port 100-1000x.
+    print("\n--- projected per-solve time at scaled rates ---")
+    if achieved_gflops > 0:
+        for mult in (1.0, 10.0, 100.0, 1000.0, 10000.0):
+            target_gflops = achieved_gflops * mult
+            s = flops_per_solve / (target_gflops * 1e9)
+            label = f"{mult:>5.0f}x measured ({target_gflops:>8.4f} GFLOP/s)"
+            print(f"  {label}: {_fmt_time(s)}")
+    print()

--- a/scripts/bench_seven_r.py
+++ b/scripts/bench_seven_r.py
@@ -1,0 +1,142 @@
+"""Per-IK timing for jointlock.seven_r on a synthetic SRS-with-spherical-wrist arm.
+
+Mirrors scripts/bench_three_parallel.py + bench_spherical_two_parallel.py.
+Uses the same synthetic 7R fixture as test_jointlock_seven_r.py
+(``_build_srs_with_spherical_wrist``): shoulder pitch+pitch (parallel),
+elbow roll (lock candidate), spherical wrist. Locking joint 3 yields a
+6R with spherical_two_parallel topology.
+
+Reports wall-clock + FLOP budget + transferability projections.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.jointlock import seven_r
+
+
+def _rodrigues(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: NDArray[np.float64] = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _axis_angle_4x4(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def _fk(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _axis_angle_4x4(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+def _build_srs() -> KinBody:
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+    ]
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.2]),
+        np.array([0.4, 0.0, 0.0]),
+        np.array([0.05, -0.1, 0.0]),
+        np.array([0.0, 0.0, 0.4]),
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    links = [Link(name=f"l{i}") for i in range(8)]
+    joints = []
+    for i in range(7):
+        T_l = np.eye(4)
+        T_l[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+kb = _build_srs()
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=7)
+sols, _ = seven_r.solve(kb, _fk(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=7)
+    t_target = _fk(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = seven_r.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt * 1e3)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    best_err = min(float(np.linalg.norm(_fk(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("per-IK time over 100 poses:")
+print(f"  min      {ts.min():>8.3f} ms")
+print(f"  median   {np.median(ts):>8.3f} ms")
+print(f"  mean     {ts.mean():>8.3f} ms")
+print(f"  p95      {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max      {ts.max():>8.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass.
+rng_p = np.random.default_rng(1)
+poses = [_fk(kb, rng_p.uniform(-1.0, 1.0, size=7)) for _ in range(n)]
+pr = cProfile.Profile()
+pr.enable()
+for tt in poses:
+    seven_r.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/scripts/bench_spherical_two_parallel.py
+++ b/scripts/bench_spherical_two_parallel.py
@@ -1,0 +1,103 @@
+"""Warm-cache per-IK bench for ssik.solvers.ikgeo.spherical_two_parallel on Puma 560.
+
+Mirrors scripts/bench_three_parallel.py / bench_real_jaco2.py methodology.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.solvers.ikgeo import spherical_two_parallel
+
+
+def _rot_axis(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path(__file__).parent.parent / "tests" / "fixtures"
+kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+sols, _ = spherical_two_parallel.solve(kb, fk_poe(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times = []
+n_sols = []
+fk_errs = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = spherical_two_parallel.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    for sol in sols:
+        T_fk = fk_poe(kb, sol.q)
+        fk_errs.append(float(np.linalg.norm(T_fk - t_target)))
+
+times = np.array(times) * 1e3
+print("per-IK time over 100 poses:")
+print(f"  min      {times.min():7.3f} ms")
+print(f"  median   {np.median(times):7.3f} ms")
+print(f"  mean     {times.mean():7.3f} ms")
+print(f"  p95      {np.percentile(times, 95):7.3f} ms")
+print(f"  max      {times.max():7.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass: cProfile a fresh sweep for deterministic call counts;
+# wall-clock under cProfile is not comparable to the unprofiled timing run.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(n)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    spherical_two_parallel.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(times.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -15,7 +15,9 @@ same parallel-trio axis structure at joints (1, 2, 3).
 
 from __future__ import annotations
 
+import cProfile
 import functools
+import pstats
 import sys
 import time
 
@@ -24,8 +26,11 @@ import numpy as np
 print = functools.partial(print, flush=True)
 
 sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/scripts")
 
 from pathlib import Path  # noqa: E402
+
+from _flop_budget import flop_budget, print_flop_summary  # noqa: E402
 
 from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
 from ssik.solvers.ikgeo import three_parallel  # noqa: E402
@@ -88,7 +93,25 @@ print(f"  median  {np.median(ts):>8.3f} ms")
 print(f"  mean    {ts.mean():>8.3f} ms")
 print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
 print(f"  max     {ts.max():>8.3f} ms")
-print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
-      f"min={min(n_sols)}, max={max(n_sols)}")
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
 print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
 print(f"failures (is_ls=True): {n_fail}/100")
+
+# FLOP-budget pass: cProfile a fresh sweep so call counts are deterministic;
+# wall-clock under cProfile is not comparable to the timing run above.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(100)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    three_parallel.solve(kb, tt)
+pr.disable()
+profile_s = time.perf_counter() - t0
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+# Wall-clock for the FLOP/s rate uses the unprofiled timing-run total to
+# match what users would see; cProfile adds ~30-50% overhead.
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, len(poses), unprofiled_total_s, breakdown)

--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -1,0 +1,94 @@
+"""Per-IK timing for ikgeo.three_parallel on UR5 (warm cache).
+
+Baseline measurement for #93 — the broader speed pass over non-tier-2-RR
+solver pathways. Mirrors scripts/bench_real_jaco2.py methodology:
+
+  uv run python scripts/bench_three_parallel.py
+
+Reports min / median / mean / p95 / max IK time, solutions/pose distribution,
+FK error stats, and failure count over 100 random non-singular poses.
+
+UR5 fixture loaded from tests/fixtures/ur5.urdf (in-tree URDF). The
+three-parallel solver covers UR3 / UR5 / UR10 and any other arm with the
+same parallel-trio axis structure at joints (1, 2, 3).
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+import time
+
+import numpy as np
+
+print = functools.partial(print, flush=True)
+
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+
+from pathlib import Path  # noqa: E402
+
+from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
+from ssik.solvers.ikgeo import three_parallel  # noqa: E402
+
+
+def _rot_axis(axis, angle):
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q):
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path("/Users/siddh/code/ikfastpy/tests/fixtures")
+kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+T_warm = fk_poe(kb, q_warm)
+sols, _ = three_parallel.solve(kb, T_warm)
+print(f"warm-cache solve: {len(sols)} solutions")
+
+print("\nwarm-cache: 100 random poses")
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+n_fail = 0
+for _ in range(100):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t = time.perf_counter()
+    sols, is_ls = three_parallel.solve(kb, t_target)
+    times.append((time.perf_counter() - t) * 1000)
+    n_sols.append(len(sols))
+    if is_ls:
+        n_fail += 1
+        continue
+    best_err = min(float(np.linalg.norm(fk_poe(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("\nper-IK time over 100 poses:")
+print(f"  min     {ts.min():>8.3f} ms")
+print(f"  median  {np.median(ts):>8.3f} ms")
+print(f"  mean    {ts.mean():>8.3f} ms")
+print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max     {ts.max():>8.3f} ms")
+print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
+      f"min={min(n_sols)}, max={max(n_sols)}")
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {n_fail}/100")

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3, _norm3
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from numpy.typing import NDArray
@@ -70,7 +71,7 @@ def axis_parallel(
     Implementation: ``||a x b||`` is ``sin(theta)`` for unit vectors, which
     small-angle approximates to the angular misalignment in radians.
     """
-    return float(np.linalg.norm(np.cross(a, b))) < policy.axis_parallel
+    return _norm3(_cross3(a, b)) < policy.axis_parallel
 
 
 def axis_intersect(
@@ -89,15 +90,15 @@ def axis_intersect(
     coincident or disjoint; the distance is then the perpendicular component
     of ``(ob - oa)`` after projecting out ``a``.
     """
-    cross = np.cross(a, b)
-    cross_norm = float(np.linalg.norm(cross))
+    cross = _cross3(a, b)
+    cross_norm = _norm3(cross)
     delta = ob - oa
     if cross_norm < policy.axis_parallel:
         # Parallel case: shortest distance is the perpendicular component
         # of delta relative to a (equivalently b -- they're parallel).
-        perp = delta - np.dot(delta, a) * a
-        return float(np.linalg.norm(perp)) < policy.axis_intersect
-    distance = abs(float(np.dot(cross, delta))) / cross_norm
+        perp = delta - _dot3(delta, a) * a
+        return _norm3(perp) < policy.axis_intersect
+    distance = abs(_dot3(cross, delta)) / cross_norm
     return distance < policy.axis_intersect
 
 
@@ -177,7 +178,7 @@ def three_consecutive_intersecting(
         p = oa + t * a
 
         delta = p - oc
-        perp = delta - np.dot(delta, c) * c
-        if float(np.linalg.norm(perp)) < policy.axis_intersect:
+        perp = delta - _dot3(delta, c) * c
+        if _norm3(perp) < policy.axis_intersect:
             return (i, i + 1, i + 2)
     return None

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -209,6 +209,41 @@ def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool
     return True
 
 
+def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Vectorised dedup of :class:`Solution` candidates by wrap-to-pi joint-
+    angle closeness.
+
+    For each cluster of solutions whose joint vectors agree (mod 2pi) within
+    ``tol`` per joint, keeps the candidate with the lowest ``fk_residual``.
+    Streaming order matches the previous Python-loop implementation
+    (``_q_close`` first-match-wins) so output ordering is preserved.
+
+    Implementation: maintains the deduped joint vectors as a stacked
+    ``(M, N_dof)`` numpy array; per-candidate dedup is one broadcasted
+    ``mod 2pi`` + ``argwhere`` instead of an inner Python loop. Replaces
+    the dominant cost (~24% of total) in 7R jointlock solves.
+    """
+    if not candidates:
+        return []
+    deduped: list[Solution] = []
+    n_dof = candidates[0].q.shape[0]
+    arr = np.empty((0, n_dof), dtype=np.float64)
+    for cand in candidates:
+        if arr.shape[0] > 0:
+            diffs = (cand.q - arr + np.pi) % (2 * np.pi) - np.pi
+            matches = np.all(np.abs(diffs) < tol, axis=1)
+            idxs = np.where(matches)[0]
+            if len(idxs) > 0:
+                j = int(idxs[0])
+                if cand.fk_residual < deduped[j].fk_residual:
+                    deduped[j] = cand
+                    arr[j] = cand.q
+                continue
+        deduped.append(cand)
+        arr = np.vstack([arr, cand.q[np.newaxis, :]])
+    return deduped
+
+
 def verify_candidates(
     candidates: Iterable[NDArray[np.float64]],
     *,
@@ -296,15 +331,4 @@ def verify_candidates(
 
     if dedup_atol is None:
         return verified
-    deduped: list[Solution] = []
-    for cand in verified:
-        dup_idx: int | None = None
-        for j, existing in enumerate(deduped):
-            if _q_close(cand.q, existing.q, dedup_atol):
-                dup_idx = j
-                break
-        if dup_idx is None:
-            deduped.append(cand)
-        elif cand.fk_residual < deduped[dup_idx].fk_residual:
-            deduped[dup_idx] = cand
-    return deduped
+    return dedup_by_wrap_close(verified, dedup_atol)

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -44,6 +44,7 @@ from ssik.kinematics.predicates import (
     three_consecutive_intersecting,
     three_consecutive_parallel,
 )
+from ssik.refinement import dedup_by_wrap_close
 from ssik.solvers.ikgeo import (
     gen_six_dof,
     spherical,
@@ -289,7 +290,7 @@ def solve(
         samples = np.array(list(lock_samples), dtype=np.float64)
 
     dedup_tol = policy.subproblem_dedup
-    solutions: list[Solution] = []
+    candidates: list[Solution] = []
 
     for sample_idx, q_lock in enumerate(samples):
         sub_kb = _lock_joint(kb, lock_idx, float(q_lock))
@@ -317,30 +318,16 @@ def solve(
             full_q[:lock_idx] = sub_q[:lock_idx]
             full_q[lock_idx] = float(q_lock)
             full_q[lock_idx + 1 :] = sub_q[lock_idx:]
-            cand = Solution(
-                q=full_q,
-                fk_residual=inner.fk_residual,
-                refinement_used=inner.refinement_used,
-                refinement_iters=inner.refinement_iters,
-                branch_id=sample_idx,
-                solver_name=_SOLVER_NAME,
+            candidates.append(
+                Solution(
+                    q=full_q,
+                    fk_residual=inner.fk_residual,
+                    refinement_used=inner.refinement_used,
+                    refinement_iters=inner.refinement_iters,
+                    branch_id=sample_idx,
+                    solver_name=_SOLVER_NAME,
+                )
             )
-            dup_idx: int | None = None
-            for j, existing in enumerate(solutions):
-                if _q_close(cand.q, existing.q, dedup_tol):
-                    dup_idx = j
-                    break
-            if dup_idx is None:
-                solutions.append(cand)
-            elif cand.fk_residual < solutions[dup_idx].fk_residual:
-                solutions[dup_idx] = cand
 
+    solutions = dedup_by_wrap_close(candidates, dedup_tol)
     return solutions, len(solutions) == 0
-
-
-def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool:
-    for ai, bi in zip(a, b, strict=True):
-        diff = float(((float(ai) - float(bi) + np.pi) % (2 * np.pi)) - np.pi)
-        if abs(diff) > tol:
-            return False
-    return True

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -41,6 +41,11 @@ def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
     return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
 
 
+def _norm3(a: NDArray[np.float64]) -> float:
+    """3-vector L2 norm, no dispatch overhead. Faster than ``np.linalg.norm``."""
+    return float(np.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]))
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -1,9 +1,14 @@
-"""Shared Rodrigues rotation helper for the subproblem solvers.
+"""Shared Rodrigues rotation + 3-vector primitives for the subproblem solvers.
 
 Kept private (underscore-prefixed) and internal to the subproblems package.
-If another package needs rotations later we will move this to
-:mod:`ssik.kinematics` -- for now keeping it here avoids one more public
-surface point to maintain.
+
+The helpers ``_cross3`` and ``_dot3`` exist because ``np.cross`` /
+``np.dot`` carry 2-10 µs of axis-normalisation dispatch overhead per call
+that swamps the actual arithmetic on 3-vectors. Hand-rolled versions for
+the 3-vector specialisation are 20-50x faster per call. Inside
+:func:`rotate` and the SP-N subproblem hot paths these helpers are called
+~10k+ times per IK solve; the per-call overhead reduction is the
+single largest tier-0 win on UR5 (#93).
 """
 
 from __future__ import annotations
@@ -14,6 +19,28 @@ from numpy.typing import NDArray
 __all__ = ["rotate"]
 
 
+def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
+    """3-vector cross product, no dispatch overhead.
+
+    Equivalent to ``np.cross(a, b)`` for 3-element arrays. Several
+    subproblem hot paths call this inside Newton / Gauss-Newton loops,
+    where the per-call overhead of ``np.cross`` dominates the actual
+    arithmetic.
+    """
+    return np.array(
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    )
+
+
+def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
+    """3-vector dot product as ``float``; no dispatch overhead."""
+    return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 
@@ -21,5 +48,5 @@ def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDAr
     """
     c = float(np.cos(theta))
     s = float(np.sin(theta))
-    kv = float(np.dot(k, v))
-    return v * c + np.cross(k, v) * s + k * (kv * (1.0 - c))
+    kv = _dot3(k, v)
+    return v * c + _cross3(k, v) * s + k * (kv * (1.0 - c))

--- a/src/ssik/subproblems/sp1.py
+++ b/src/ssik/subproblems/sp1.py
@@ -30,6 +30,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -51,14 +52,14 @@ def solve(
         radians and ``is_ls`` is ``True`` when the exact feasibility
         conditions do not hold (so ``theta`` is the LS optimum).
     """
-    kxp = np.cross(k, p)
-    kp = float(np.dot(k, p))
-    kq = float(np.dot(k, q))
-    theta = float(np.arctan2(np.dot(kxp, q), np.dot(p, q) - kp * kq))
+    kxp = _cross3(k, p)
+    kp = _dot3(k, p)
+    kq = _dot3(k, q)
+    theta = float(np.arctan2(_dot3(kxp, q), _dot3(p, q) - kp * kq))
 
     # Feasibility: |p_perp| = |q_perp| and k.p = k.q.
-    p_perp_sq = float(np.dot(p, p)) - kp * kp
-    q_perp_sq = float(np.dot(q, q)) - kq * kq
+    p_perp_sq = _dot3(p, p) - kp * kp
+    q_perp_sq = _dot3(q, q) - kq * kq
     tol = policy.subproblem_feasibility
     is_ls = abs(p_perp_sq - q_perp_sq) > tol or abs(kp - kq) > tol
     return theta, is_ls

--- a/src/ssik/subproblems/sp4.py
+++ b/src/ssik/subproblems/sp4.py
@@ -48,6 +48,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -70,11 +71,11 @@ def solve(
         ``k`` fallback.
     :returns: ``(solutions, is_ls)``.
     """
-    hp = float(np.dot(h, p))
-    kp = float(np.dot(k, p))
-    hk = float(np.dot(h, k))
+    hp = _dot3(h, p)
+    kp = _dot3(k, p)
+    hk = _dot3(h, k)
     coef_a = hp - kp * hk
-    coef_b = float(np.dot(h, np.cross(k, p)))
+    coef_b = _dot3(h, _cross3(k, p))
     coef_c = kp * hk
     r_sq = coef_a * coef_a + coef_b * coef_b
 

--- a/src/ssik/subproblems/sp6.py
+++ b/src/ssik/subproblems/sp6.py
@@ -42,7 +42,7 @@ from ssik.subproblems._aux import (
     solve_lower_triangular_system_2x2,
     solve_two_ellipse_numeric,
 )
-from ssik.subproblems._rotation import rotate
+from ssik.subproblems._rotation import _cross3, _dot3, rotate
 from ssik.subproblems._validate import validate_vec3_iterable
 
 __all__ = ["solve"]
@@ -78,7 +78,7 @@ def _all_p_collinear_with_k(
     on the rank check of the stacked QR diagonals and on post-verification.
     """
     for k_i, p_i in zip(k, p, strict=True):
-        p_perp_sq = float(np.dot(p_i, p_i)) - float(np.dot(k_i, p_i)) ** 2
+        p_perp_sq = _dot3(p_i, p_i) - _dot3(k_i, p_i) ** 2
         if p_perp_sq >= deg_tol:
             return False
     return True
@@ -93,8 +93,8 @@ def _residual(
     d1: float,
     d2: float,
 ) -> float:
-    lhs1 = float(h[0] @ rotate(k[0], theta1, p[0])) + float(h[1] @ rotate(k[1], theta2, p[1]))
-    lhs2 = float(h[2] @ rotate(k[2], theta1, p[2])) + float(h[3] @ rotate(k[3], theta2, p[3]))
+    lhs1 = _dot3(h[0], rotate(k[0], theta1, p[0])) + _dot3(h[1], rotate(k[1], theta2, p[1]))
+    lhs2 = _dot3(h[2], rotate(k[2], theta1, p[2])) + _dot3(h[3], rotate(k[3], theta2, p[3]))
     return max(abs(lhs1 - d1), abs(lhs2 - d2))
 
 
@@ -131,8 +131,8 @@ def solve(
 
     a_cols = []
     for idx in range(4):
-        kxp = np.cross(k[idx], p[idx])
-        a_cols.append(np.column_stack([kxp, -np.cross(k[idx], kxp)]))
+        kxp = _cross3(k[idx], p[idx])
+        a_cols.append(np.column_stack([kxp, -_cross3(k[idx], kxp)]))
 
     h1_a1 = h[0] @ a_cols[0]
     h2_a2 = h[1] @ a_cols[1]
@@ -149,8 +149,8 @@ def solve(
 
     b = np.array(
         [
-            d1 - float(h[0] @ k[0]) * float(k[0] @ p[0]) - float(h[1] @ k[1]) * float(k[1] @ p[1]),
-            d2 - float(h[2] @ k[2]) * float(k[2] @ p[2]) - float(h[3] @ k[3]) * float(k[3] @ p[3]),
+            d1 - _dot3(h[0], k[0]) * _dot3(k[0], p[0]) - _dot3(h[1], k[1]) * _dot3(k[1], p[1]),
+            d2 - _dot3(h[2], k[2]) * _dot3(k[2], p[2]) - _dot3(h[3], k[3]) * _dot3(k[3], p[3]),
         ],
         dtype=np.float64,
     )
@@ -254,23 +254,23 @@ def _refine_sp6(
 
         f = np.array(
             [
-                float(h[0] @ r0) + float(h[1] @ r1) - d1,
-                float(h[2] @ r2) + float(h[3] @ r3) - d2,
+                _dot3(h[0], r0) + _dot3(h[1], r1) - d1,
+                _dot3(h[2], r2) + _dot3(h[3], r3) - d2,
             ],
             dtype=np.float64,
         )
 
         # Partials. dF_i/dt_j uses chain rule: Rot(k, t) rotates `p`, so
         # the angle derivative is k x (Rot(k, t) @ p).
-        d_dt1_r0 = np.cross(k[0], r0)
-        d_dt2_r1 = np.cross(k[1], r1)
-        d_dt1_r2 = np.cross(k[2], r2)
-        d_dt2_r3 = np.cross(k[3], r3)
+        d_dt1_r0 = _cross3(k[0], r0)
+        d_dt2_r1 = _cross3(k[1], r1)
+        d_dt1_r2 = _cross3(k[2], r2)
+        d_dt2_r3 = _cross3(k[3], r3)
 
         j_mat_2x2 = np.array(
             [
-                [float(h[0] @ d_dt1_r0), float(h[1] @ d_dt2_r1)],
-                [float(h[2] @ d_dt1_r2), float(h[3] @ d_dt2_r3)],
+                [_dot3(h[0], d_dt1_r0), _dot3(h[1], d_dt2_r1)],
+                [_dot3(h[2], d_dt1_r2), _dot3(h[3], d_dt2_r3)],
             ],
             dtype=np.float64,
         )


### PR DESCRIPTION
## Summary
- **Synthetic SRS 7R: 61.3ms → 42.5ms median (-31%)**, p95 147→71ms, max 203→81ms, FK 2e-16 unchanged
- Vectorises the streaming wrap-to-pi dedup that was 24% of seven_r's total time (357k Python-loop calls per 50 IKs)
- Same dedup pattern also lives in `refinement.verify_candidates` (called by every ssik solver) — factored into one helper, both sites benefit

> **Stacks on #99** — base branch is `m2-speed-predicates`. Merge #98 → #99 → #100.

## Where the time was going
cProfile of seven_r on synthetic SRS, 50 IKs, 5.55s total:
```
357000  1.238   _q_close          24% of total -- streaming O(N^2) dedup
   800  2.346   spherical_two_parallel.solve
   800  1.345   verify_candidates
  5600  0.919   _forward_kinematics
  1700  0.619   three_consecutive_intersecting
```
Dedup over up-to-120 candidates per pose = `120 * 119 / 2 = 7140` `_q_close` calls; each is a 7-element Python loop with `.float() / mod / abs` per iteration.

## The fix
New helper `refinement.dedup_by_wrap_close(candidates, tol)`:
- Maintains deduped joint vectors as a stacked `(M, N_dof)` numpy array
- Per-candidate dedup is one broadcasted `(diff + π) % 2π - π` + `argwhere` instead of an inner Python loop
- Streaming first-match-wins + replace-if-better-fk_residual semantics preserved exactly

Two call sites updated:
- `refinement.verify_candidates`: replaces internal dedup loop
- `jointlock.seven_r.solve`: simplified to "accumulate candidates, dedup at end"; local `_q_close` removed

## FLOP-budget output (this run, Apple M3, post-fix)
```
Synthetic SRS 7R:      30,274 FLOPs/solve   ~42.5ms median   0.67 MFLOP/s achieved
                                           ~us-scale at 10000x (Rust/C with SIMD)
```

## Why this benefits every solver
`refinement.verify_candidates` is the back-half of every ikgeo + jointlock solver. The vectorised dedup applies to UR5/Puma/JACO/Franka/iiwa/Rizon — anywhere with N≥4 candidates per pose. The 7R win is the most dramatic only because N is largest there.

## Validation (bulletproof preserved)
- `bench_seven_r.py` (new): synthetic SRS, 100 random poses, median 42.5ms, FK 2e-16, 0 failures
- 128 tests passed across jointlock_seven_r + every solver through verify_candidates: three_parallel, spherical_two_parallel, ikgeo_general_6r, ikgeo_spherical, ikgeo_two_intersecting, ikgeo_two_parallel, spherical_two_intersecting, ikgeo_gen_six_dof, puma_cross_validation
- `ruff` + `mypy` clean

## Test plan
- [x] `uv run python scripts/bench_seven_r.py` — median ≤ 50ms, FK ≤ 1e-12, 0 failures
- [x] Solver tests across the verify_candidates surface — green
- [x] mypy + ruff clean

Closes #93 priority #3 (seven_r on synthetic SRS arm). Inner-solver dispatch dispatches to spherical_two_parallel which already benefited from PR #99's predicates fix.