### PR TITLE
Speed Tier 1 on #93: SP2/SP3/SP5/_aux propagation + rotation_matrix consolidation (spherical 2.5x, all solvers benefit)

### DIFF
--- a/scripts/_bench_lib.py
+++ b/scripts/_bench_lib.py
@@ -1,0 +1,115 @@
+"""Shared bench harness: timing + FLOP-budget pass for one (kb, solver) pair.
+
+Each per-solver bench script wires up its KinBody fixture and a solver
+callable, then delegates the per-IK loop to :func:`run_bench` here so the
+output format is uniform across the whole #93 priority list.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import time
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+from _flop_budget import flop_budget, print_flop_summary
+from numpy.typing import NDArray
+
+
+def _rodrigues(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: NDArray[np.float64] = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _aa4(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def fk_poe(kb: Any, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """POE forward kinematics for any KinBody. Used as ground truth in the
+    bench timing + FK-error reporting."""
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _aa4(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+def run_bench(
+    *,
+    solver_label: str,
+    solver_call: Callable[[Any, NDArray[np.float64]], tuple[Any, bool]],
+    kb: Any,
+    n_dof: int,
+    n_poses: int = 100,
+    seed: int = 0,
+    profile_seed: int = 1,
+) -> None:
+    """Warm + time + FLOP-budget one solver+kb pair.
+
+    :param solver_label: human-readable name (printed in the header).
+    :param solver_call: callable ``(kb, T) -> (solutions, is_ls)``. Wrap your
+        solver to apply any non-default kwargs.
+    :param kb: a POE-normalised :class:`KinBody`.
+    :param n_dof: number of joints (used for the random q sampler).
+    :param n_poses: number of random poses to time.
+    :param seed: RNG seed for the timing sweep (deterministic across runs).
+    :param profile_seed: RNG seed for the cProfile pass (different from
+        ``seed`` so the FLOP budget reflects fresh poses, not warm-cached).
+    """
+    print(f"=== {solver_label} ===")
+    print("warming caches...")
+    rng = np.random.default_rng(seed)
+    q_warm = rng.uniform(-1.0, 1.0, size=n_dof)
+    sols, _ = solver_call(kb, fk_poe(kb, q_warm))
+    print(f"warm-cache solve: {len(sols)} solutions\n")
+
+    print(f"warm-cache: {n_poses} random poses\n")
+    times: list[float] = []
+    n_sols: list[int] = []
+    fk_errs: list[float] = []
+    fails = 0
+    for _ in range(n_poses):
+        q_star = rng.uniform(-1.0, 1.0, size=n_dof)
+        t_target = fk_poe(kb, q_star)
+        t0 = time.perf_counter()
+        sols, is_ls = solver_call(kb, t_target)
+        times.append((time.perf_counter() - t0) * 1e3)
+        if is_ls or not sols:
+            fails += 1
+            continue
+        n_sols.append(len(sols))
+        best_err = min(float(np.linalg.norm(fk_poe(kb, s.q) - t_target)) for s in sols)
+        fk_errs.append(best_err)
+
+    ts = np.array(times)
+    print("per-IK time over poses:")
+    print(f"  min      {ts.min():>8.3f} ms")
+    print(f"  median   {np.median(ts):>8.3f} ms")
+    print(f"  mean     {ts.mean():>8.3f} ms")
+    print(f"  p95      {np.percentile(ts, 95):>8.3f} ms")
+    print(f"  max      {ts.max():>8.3f} ms")
+    if n_sols:
+        print(
+            f"\nsolutions per pose: median={int(np.median(n_sols))}, "
+            f"min={min(n_sols)}, max={max(n_sols)}"
+        )
+    if fk_errs:
+        print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+    print(f"failures (is_ls=True): {fails}/{n_poses}")
+
+    rng_p = np.random.default_rng(profile_seed)
+    poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=n_dof)) for _ in range(n_poses)]
+    pr = cProfile.Profile()
+    pr.enable()
+    for tt in poses:
+        solver_call(kb, tt)
+    pr.disable()
+    total_flops, breakdown = flop_budget(pstats.Stats(pr))
+    unprofiled_total_s = float(ts.sum()) / 1000.0
+    print_flop_summary(total_flops, n_poses, unprofiled_total_s, breakdown)

--- a/scripts/_flop_budget.py
+++ b/scripts/_flop_budget.py
@@ -1,0 +1,135 @@
+"""Deterministic FLOP-budget estimator for ssik bench scripts.
+
+Wall-clock is system-load-dependent and platform-specific. FLOP count is not:
+the same workload on the same input issues the same arithmetic ops on every
+machine. So we report both:
+
+- **wall-clock**: what this run took on this machine (here, now)
+- **FLOP budget**: machine-invariant work performed
+- **achieved rate**: FLOP budget / wall-clock = effective FLOP/s on this CPU
+- **reference projection**: FLOP budget / target rate = predicted time on a
+  machine with that effective rate (assumes similar Python+numpy overhead)
+
+The FLOP budget is a *lower bound* on arithmetic — it counts operations on
+dominant shapes only. Counts come from cProfile's per-function call counts,
+which are deterministic for a fixed seed.
+
+Per-call FLOP estimates use textbook formulas for the algorithm at our
+workload's typical shapes (2x2 / 3x3 / 4x4 matrices, length-3 vectors).
+Numbers like ``solve(NxN)`` use ``(2/3)N^3`` for LU, ``N^2`` for back-sub.
+"""
+
+from __future__ import annotations
+
+import os
+import pstats
+
+# ssik primitives, matched by function name.
+SSIK_FLOPS: dict[str, int] = {
+    "_cross3": 9,  # 6 mul + 3 sub
+    "_dot3": 5,  # 3 mul + 2 add
+    "_norm3": 7,  # 3 mul + 2 add + 1 sqrt + 1 fudge
+}
+
+# numpy linalg + array ops, matched by (basename, funcname). FLOP estimates
+# baked in for our workload's dominant shapes.
+NUMPY_FLOPS: dict[tuple[str, str], int] = {
+    # 3-vector cross/dot still hit numpy if any callsite was missed by the
+    # _cross3/_dot3 propagation; keep these in case.
+    ("numeric.py", "cross"): 9,
+    ("numeric.py", "dot"): 5,
+    # np.linalg.norm: 3-vector dominant (axis_*, joint_origins).
+    ("_linalg.py", "norm"): 7,
+    # np.linalg.solve: 2x2 dominant (sp6 _refine_sp6).
+    ("_linalg.py", "solve"): 10,
+    # np.linalg.qr complete on a 2x4 (sp6): R is 4x4, Q is 4x4. ~64 flops.
+    ("_linalg.py", "qr"): 64,
+    # np.linalg.lstsq: 3x2 (predicates.three_consecutive_intersecting).
+    ("_linalg.py", "lstsq"): 32,
+    # np.linalg.eig: 4x4 cubic + iteration. Only used in tier-2 RR.
+    ("_linalg.py", "eig"): 200,
+    # arctan2 / arcsin / cos / sin: count as 10 each (transcendentals).
+    ("<frozen>", "atan2"): 10,
+}
+
+
+def flop_budget(stats: pstats.Stats) -> tuple[int, dict[str, int]]:
+    """Compute FLOP budget from a :class:`pstats.Stats` snapshot.
+
+    :returns: ``(total_flops, breakdown)`` where ``breakdown`` is keyed by
+        ``"<module>:<funcname>"`` for traceability.
+    """
+    total = 0
+    breakdown: dict[str, int] = {}
+    for (filename, _lineno, funcname), (cc, _nc, _tt, _ct, _callers) in stats.stats.items():
+        flops = SSIK_FLOPS.get(funcname)
+        if flops is not None:
+            cost = flops * cc
+            breakdown[funcname] = breakdown.get(funcname, 0) + cost
+            total += cost
+            continue
+        basename = os.path.basename(filename)
+        key = (basename, funcname)
+        flops = NUMPY_FLOPS.get(key)
+        if flops is not None:
+            cost = flops * cc
+            label = f"{basename}:{funcname}"
+            breakdown[label] = breakdown.get(label, 0) + cost
+            total += cost
+    return total, breakdown
+
+
+def _fmt_time(seconds: float) -> str:
+    """Format a time in human-readable units (ns / us / ms / s)."""
+    if seconds < 1e-6:
+        return f"{seconds * 1e9:>9.1f} ns"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:>9.3f} us"
+    if seconds < 1.0:
+        return f"{seconds * 1e3:>9.3f} ms"
+    return f"{seconds:>9.3f} s"
+
+
+def print_flop_summary(
+    total_flops: int,
+    n_solves: int,
+    wall_time_s: float,
+    breakdown: dict[str, int],
+) -> None:
+    """Print a FLOP-budget report.
+
+    Reports machine-invariant FLOP counts, machine-specific wall-clock, the
+    achieved effective rate (FLOPs / wall_time), and the projected per-solve
+    time at order-of-magnitude scaled rates. The scaled rows let a reader
+    estimate cost on a different runtime (Cython port, Rust port) by picking
+    the row whose achieved rate matches their target.
+    """
+    flops_per_solve = total_flops / n_solves
+    achieved_gflops = total_flops / wall_time_s / 1e9 if wall_time_s > 0 else 0.0
+    seconds_per_solve = wall_time_s / n_solves
+
+    print("\n--- FLOP budget (machine-invariant) ---")
+    print(f"  total       {total_flops:>12,d} FLOPs over {n_solves} solves")
+    print(f"  per solve   {flops_per_solve:>12,.0f} FLOPs")
+    print("  breakdown (per-solve):")
+    sorted_ops = sorted(breakdown.items(), key=lambda kv: -kv[1])
+    for label, cost in sorted_ops[:8]:
+        print(f"    {label:<40s} {cost / n_solves:>10,.1f}")
+
+    print("\n--- wall-clock (this run, this machine) ---")
+    print(f"  total       {wall_time_s:>12.3f} s")
+    print(f"  per solve   {_fmt_time(seconds_per_solve)}")
+    print(f"  achieved    {achieved_gflops:>12.5f} GFLOP/s")
+
+    # Scaled projections: what would this cost if effective rate were 10x,
+    # 100x, 1000x, 10000x what we measured? Useful as a transferability
+    # estimate -- a Cython port would typically hit 10-100x over Python+numpy
+    # on small-op workloads, a native Rust/C port 100-1000x.
+    print("\n--- projected per-solve time at scaled rates ---")
+    if achieved_gflops > 0:
+        for mult in (1.0, 10.0, 100.0, 1000.0, 10000.0):
+            target_gflops = achieved_gflops * mult
+            s = flops_per_solve / (target_gflops * 1e9)
+            label = f"{mult:>5.0f}x measured ({target_gflops:>8.4f} GFLOP/s)"
+            print(f"  {label}: {_fmt_time(s)}")
+    print()

--- a/scripts/bench_gen_six_dof.py
+++ b/scripts/bench_gen_six_dof.py
@@ -1,0 +1,63 @@
+"""Per-IK timing for ssik.solvers.ikgeo.gen_six_dof on a random 6R arm
+(IK-Geo GeneralSetup style: no parallel/intersecting structure).
+
+Tier-2 bivariate-search solver -- ~100s per IK in pure Python. Run with
+n_poses=3 to keep the bench bounded; this is correctness-first, speed
+is the open issue this whole #93 sweep eventually addresses.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _bench_lib import run_bench
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import gen_six_dof
+
+
+def _build_random_generic(seed: int = 5) -> KinBody:
+    rng = np.random.default_rng(seed)
+
+    def _rnorm() -> np.ndarray:
+        v = rng.standard_normal(3)
+        return v / float(np.linalg.norm(v))
+
+    axes = [_rnorm() for _ in range(6)]
+    t_lefts = [rng.standard_normal(3) for _ in range(6)]
+    tool_p = rng.standard_normal(3)
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        t_right_i = np.eye(4)
+        if i == 5:
+            t_right_i[:3, 3] = tool_p
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=t_right_i,
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+run_bench(
+    solver_label="ikgeo.gen_six_dof (random IK-Geo GeneralSetup)",
+    solver_call=lambda kb, T: gen_six_dof.solve(kb, T),
+    kb=_build_random_generic(),
+    n_dof=6,
+    n_poses=3,
+)

--- a/scripts/bench_seven_r.py
+++ b/scripts/bench_seven_r.py
@@ -1,0 +1,142 @@
+"""Per-IK timing for jointlock.seven_r on a synthetic SRS-with-spherical-wrist arm.
+
+Mirrors scripts/bench_three_parallel.py + bench_spherical_two_parallel.py.
+Uses the same synthetic 7R fixture as test_jointlock_seven_r.py
+(``_build_srs_with_spherical_wrist``): shoulder pitch+pitch (parallel),
+elbow roll (lock candidate), spherical wrist. Locking joint 3 yields a
+6R with spherical_two_parallel topology.
+
+Reports wall-clock + FLOP budget + transferability projections.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.jointlock import seven_r
+
+
+def _rodrigues(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: NDArray[np.float64] = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _axis_angle_4x4(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def _fk(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _axis_angle_4x4(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+def _build_srs() -> KinBody:
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+    ]
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.2]),
+        np.array([0.4, 0.0, 0.0]),
+        np.array([0.05, -0.1, 0.0]),
+        np.array([0.0, 0.0, 0.4]),
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    links = [Link(name=f"l{i}") for i in range(8)]
+    joints = []
+    for i in range(7):
+        T_l = np.eye(4)
+        T_l[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+kb = _build_srs()
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=7)
+sols, _ = seven_r.solve(kb, _fk(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=7)
+    t_target = _fk(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = seven_r.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt * 1e3)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    best_err = min(float(np.linalg.norm(_fk(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("per-IK time over 100 poses:")
+print(f"  min      {ts.min():>8.3f} ms")
+print(f"  median   {np.median(ts):>8.3f} ms")
+print(f"  mean     {ts.mean():>8.3f} ms")
+print(f"  p95      {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max      {ts.max():>8.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass.
+rng_p = np.random.default_rng(1)
+poses = [_fk(kb, rng_p.uniform(-1.0, 1.0, size=7)) for _ in range(n)]
+pr = cProfile.Profile()
+pr.enable()
+for tt in poses:
+    seven_r.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/scripts/bench_spherical.py
+++ b/scripts/bench_spherical.py
@@ -1,0 +1,66 @@
+"""Per-IK timing for ssik.solvers.ikgeo.spherical on a synthetic
+spherical-wrist 6R arm (no parallel/intersecting shoulder specialization).
+
+Same arm as test_ikgeo_spherical.py's _build_generic_spherical_arm.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _bench_lib import run_bench
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import spherical
+
+
+def _build_generic_spherical_arm(tilt_deg: float = 25.0) -> KinBody:
+    tilt = np.deg2rad(tilt_deg)
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([np.sin(tilt), -np.cos(tilt), 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]
+    d1, a1, a2, a3, d3, d4 = 0.2, 0.04, 0.5, 0.08, -0.12, 0.4
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([a1, 0.0, d1]),
+        np.array([a2, 0.0, 0.0]),
+        np.array([a3, d3, 0.0]),
+        np.array([0.0, 0.0, d4]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+run_bench(
+    solver_label="ikgeo.spherical (synthetic, generic spherical wrist)",
+    solver_call=lambda kb, T: spherical.solve(kb, T),
+    kb=_build_generic_spherical_arm(),
+    n_dof=6,
+)

--- a/scripts/bench_spherical_two_intersecting.py
+++ b/scripts/bench_spherical_two_intersecting.py
@@ -1,0 +1,67 @@
+"""Per-IK timing for ssik.solvers.ikgeo.spherical_two_intersecting on
+a synthetic 6R arm (joints 0-1 share an origin, spherical wrist at 3-4-5).
+
+Same arm as test_spherical_two_intersecting.py's
+``synthetic_spherical_two_intersecting_kb``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _bench_lib import run_bench
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import spherical_two_intersecting
+
+
+def _build_synth() -> KinBody:
+    a2, a3, d4 = 0.45, 0.06, 0.38
+    tilt = np.deg2rad(15.0)
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([np.sin(tilt), -np.cos(tilt), 0.0]),
+        np.array([np.sin(tilt), -np.cos(tilt), 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.0]),
+        np.array([a2, 0.0, 0.0]),
+        np.array([a3, 0.0, 0.0]),
+        np.array([0.0, 0.0, d4]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+run_bench(
+    solver_label="ikgeo.spherical_two_intersecting (synthetic Puma-like)",
+    solver_call=lambda kb, T: spherical_two_intersecting.solve(kb, T),
+    kb=_build_synth(),
+    n_dof=6,
+)

--- a/scripts/bench_spherical_two_parallel.py
+++ b/scripts/bench_spherical_two_parallel.py
@@ -1,0 +1,103 @@
+"""Warm-cache per-IK bench for ssik.solvers.ikgeo.spherical_two_parallel on Puma 560.
+
+Mirrors scripts/bench_three_parallel.py / bench_real_jaco2.py methodology.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.solvers.ikgeo import spherical_two_parallel
+
+
+def _rot_axis(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path(__file__).parent.parent / "tests" / "fixtures"
+kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+sols, _ = spherical_two_parallel.solve(kb, fk_poe(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times = []
+n_sols = []
+fk_errs = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = spherical_two_parallel.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    for sol in sols:
+        T_fk = fk_poe(kb, sol.q)
+        fk_errs.append(float(np.linalg.norm(T_fk - t_target)))
+
+times = np.array(times) * 1e3
+print("per-IK time over 100 poses:")
+print(f"  min      {times.min():7.3f} ms")
+print(f"  median   {np.median(times):7.3f} ms")
+print(f"  mean     {times.mean():7.3f} ms")
+print(f"  p95      {np.percentile(times, 95):7.3f} ms")
+print(f"  max      {times.max():7.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass: cProfile a fresh sweep for deterministic call counts;
+# wall-clock under cProfile is not comparable to the unprofiled timing run.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(n)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    spherical_two_parallel.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(times.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -15,7 +15,9 @@ same parallel-trio axis structure at joints (1, 2, 3).
 
 from __future__ import annotations
 
+import cProfile
 import functools
+import pstats
 import sys
 import time
 
@@ -24,8 +26,11 @@ import numpy as np
 print = functools.partial(print, flush=True)
 
 sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/scripts")
 
 from pathlib import Path  # noqa: E402
+
+from _flop_budget import flop_budget, print_flop_summary  # noqa: E402
 
 from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
 from ssik.solvers.ikgeo import three_parallel  # noqa: E402
@@ -88,7 +93,25 @@ print(f"  median  {np.median(ts):>8.3f} ms")
 print(f"  mean    {ts.mean():>8.3f} ms")
 print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
 print(f"  max     {ts.max():>8.3f} ms")
-print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
-      f"min={min(n_sols)}, max={max(n_sols)}")
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
 print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
 print(f"failures (is_ls=True): {n_fail}/100")
+
+# FLOP-budget pass: cProfile a fresh sweep so call counts are deterministic;
+# wall-clock under cProfile is not comparable to the timing run above.
+rng_p = np.random.default_rng(1)
+poses = [fk_poe(kb, rng_p.uniform(-1.0, 1.0, size=6)) for _ in range(100)]
+pr = cProfile.Profile()
+t0 = time.perf_counter()
+pr.enable()
+for tt in poses:
+    three_parallel.solve(kb, tt)
+pr.disable()
+profile_s = time.perf_counter() - t0
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+# Wall-clock for the FLOP/s rate uses the unprofiled timing-run total to
+# match what users would see; cProfile adds ~30-50% overhead.
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, len(poses), unprofiled_total_s, breakdown)

--- a/scripts/bench_three_parallel.py
+++ b/scripts/bench_three_parallel.py
@@ -1,0 +1,94 @@
+"""Per-IK timing for ikgeo.three_parallel on UR5 (warm cache).
+
+Baseline measurement for #93 — the broader speed pass over non-tier-2-RR
+solver pathways. Mirrors scripts/bench_real_jaco2.py methodology:
+
+  uv run python scripts/bench_three_parallel.py
+
+Reports min / median / mean / p95 / max IK time, solutions/pose distribution,
+FK error stats, and failure count over 100 random non-singular poses.
+
+UR5 fixture loaded from tests/fixtures/ur5.urdf (in-tree URDF). The
+three-parallel solver covers UR3 / UR5 / UR10 and any other arm with the
+same parallel-trio axis structure at joints (1, 2, 3).
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+import time
+
+import numpy as np
+
+print = functools.partial(print, flush=True)
+
+sys.path.insert(0, "/Users/siddh/code/ikfastpy/tests")
+
+from pathlib import Path  # noqa: E402
+
+from ssik._urdf import load_urdf_kinbody_normalized  # noqa: E402
+from ssik.solvers.ikgeo import three_parallel  # noqa: E402
+
+
+def _rot_axis(axis, angle):
+    axis = axis / np.linalg.norm(axis)
+    c, s = np.cos(angle), np.sin(angle)
+    x, y, z = axis
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s, 0],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s, 0],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc, 0],
+            [0, 0, 0, 1],
+        ]
+    )
+
+
+def fk_poe(kb, q):
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _rot_axis(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+FIXTURES = Path("/Users/siddh/code/ikfastpy/tests/fixtures")
+kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=6)
+T_warm = fk_poe(kb, q_warm)
+sols, _ = three_parallel.solve(kb, T_warm)
+print(f"warm-cache solve: {len(sols)} solutions")
+
+print("\nwarm-cache: 100 random poses")
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+n_fail = 0
+for _ in range(100):
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    t_target = fk_poe(kb, q_star)
+    t = time.perf_counter()
+    sols, is_ls = three_parallel.solve(kb, t_target)
+    times.append((time.perf_counter() - t) * 1000)
+    n_sols.append(len(sols))
+    if is_ls:
+        n_fail += 1
+        continue
+    best_err = min(float(np.linalg.norm(fk_poe(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("\nper-IK time over 100 poses:")
+print(f"  min     {ts.min():>8.3f} ms")
+print(f"  median  {np.median(ts):>8.3f} ms")
+print(f"  mean    {ts.mean():>8.3f} ms")
+print(f"  p95     {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max     {ts.max():>8.3f} ms")
+print(f"\nsolutions per pose: median={int(np.median(n_sols))}, "
+      f"min={min(n_sols)}, max={max(n_sols)}")
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {n_fail}/100")

--- a/scripts/bench_two_intersecting.py
+++ b/scripts/bench_two_intersecting.py
@@ -1,0 +1,67 @@
+"""Per-IK timing for ssik.solvers.ikgeo.two_intersecting on a synthetic
+6R arm with ``p[5] = 0`` (joints 4, 5 share an origin).
+
+Tier-1 univariate-search solver.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _bench_lib import run_bench
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import two_intersecting
+
+
+def _build_two_intersecting() -> KinBody:
+    tilt = np.deg2rad(25.0)
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([np.sin(tilt), -np.cos(tilt), 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]
+    d1, a1, a2, a3, d3, d4 = 0.2, 0.04, 0.5, 0.08, -0.12, 0.4
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([a1, 0.0, d1]),
+        np.array([a2, 0.0, 0.0]),
+        np.array([a3, d3, 0.0]),
+        np.array([0.0, 0.0, d4]),
+        np.array([0.0, 0.0, 0.0]),  # p[5] = 0
+    ]
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+run_bench(
+    solver_label="ikgeo.two_intersecting (synthetic, p[5]=0)",
+    solver_call=lambda kb, T: two_intersecting.solve(kb, T),
+    kb=_build_two_intersecting(),
+    n_dof=6,
+    n_poses=50,
+)

--- a/scripts/bench_two_parallel.py
+++ b/scripts/bench_two_parallel.py
@@ -1,0 +1,63 @@
+"""Per-IK timing for ssik.solvers.ikgeo.two_parallel on an IK-Geo-style
+random 6R arm with axes[2] = axes[1] (the two-parallel constraint).
+
+Tier-1 univariate-search solver -- expect higher per-IK time than tier-0.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _bench_lib import run_bench
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.ikgeo import two_parallel
+
+
+def _build_random_two_parallel(seed: int = 7) -> KinBody:
+    rng = np.random.default_rng(seed)
+
+    def _rnorm() -> np.ndarray:
+        v = rng.standard_normal(3)
+        return v / float(np.linalg.norm(v))
+
+    axes = [_rnorm() for _ in range(6)]
+    axes[2] = axes[1].copy()
+    t_lefts = [rng.standard_normal(3) for _ in range(6)]
+    tool_p = rng.standard_normal(3)
+
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        t_left_i = np.eye(4)
+        t_left_i[:3, 3] = t_lefts[i]
+        t_right_i = np.eye(4)
+        if i == 5:
+            t_right_i[:3, 3] = tool_p
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left_i,
+                T_right=t_right_i,
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+run_bench(
+    solver_label="ikgeo.two_parallel (random IK-Geo TwoParallelSetup)",
+    solver_call=lambda kb, T: two_parallel.solve(kb, T),
+    kb=_build_random_two_parallel(),
+    n_dof=6,
+    n_poses=50,
+)

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3, _norm3
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from numpy.typing import NDArray
@@ -70,7 +71,7 @@ def axis_parallel(
     Implementation: ``||a x b||`` is ``sin(theta)`` for unit vectors, which
     small-angle approximates to the angular misalignment in radians.
     """
-    return float(np.linalg.norm(np.cross(a, b))) < policy.axis_parallel
+    return _norm3(_cross3(a, b)) < policy.axis_parallel
 
 
 def axis_intersect(
@@ -89,15 +90,15 @@ def axis_intersect(
     coincident or disjoint; the distance is then the perpendicular component
     of ``(ob - oa)`` after projecting out ``a``.
     """
-    cross = np.cross(a, b)
-    cross_norm = float(np.linalg.norm(cross))
+    cross = _cross3(a, b)
+    cross_norm = _norm3(cross)
     delta = ob - oa
     if cross_norm < policy.axis_parallel:
         # Parallel case: shortest distance is the perpendicular component
         # of delta relative to a (equivalently b -- they're parallel).
-        perp = delta - np.dot(delta, a) * a
-        return float(np.linalg.norm(perp)) < policy.axis_intersect
-    distance = abs(float(np.dot(cross, delta))) / cross_norm
+        perp = delta - _dot3(delta, a) * a
+        return _norm3(perp) < policy.axis_intersect
+    distance = abs(_dot3(cross, delta)) / cross_norm
     return distance < policy.axis_intersect
 
 
@@ -177,7 +178,7 @@ def three_consecutive_intersecting(
         p = oa + t * a
 
         delta = p - oc
-        perp = delta - np.dot(delta, c) * c
-        if float(np.linalg.norm(perp)) < policy.axis_intersect:
+        perp = delta - _dot3(delta, c) * c
+        if _norm3(perp) < policy.axis_intersect:
             return (i, i + 1, i + 2)
     return None

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -209,6 +209,41 @@ def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool
     return True
 
 
+def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Vectorised dedup of :class:`Solution` candidates by wrap-to-pi joint-
+    angle closeness.
+
+    For each cluster of solutions whose joint vectors agree (mod 2pi) within
+    ``tol`` per joint, keeps the candidate with the lowest ``fk_residual``.
+    Streaming order matches the previous Python-loop implementation
+    (``_q_close`` first-match-wins) so output ordering is preserved.
+
+    Implementation: maintains the deduped joint vectors as a stacked
+    ``(M, N_dof)`` numpy array; per-candidate dedup is one broadcasted
+    ``mod 2pi`` + ``argwhere`` instead of an inner Python loop. Replaces
+    the dominant cost (~24% of total) in 7R jointlock solves.
+    """
+    if not candidates:
+        return []
+    deduped: list[Solution] = []
+    n_dof = candidates[0].q.shape[0]
+    arr = np.empty((0, n_dof), dtype=np.float64)
+    for cand in candidates:
+        if arr.shape[0] > 0:
+            diffs = (cand.q - arr + np.pi) % (2 * np.pi) - np.pi
+            matches = np.all(np.abs(diffs) < tol, axis=1)
+            idxs = np.where(matches)[0]
+            if len(idxs) > 0:
+                j = int(idxs[0])
+                if cand.fk_residual < deduped[j].fk_residual:
+                    deduped[j] = cand
+                    arr[j] = cand.q
+                continue
+        deduped.append(cand)
+        arr = np.vstack([arr, cand.q[np.newaxis, :]])
+    return deduped
+
+
 def verify_candidates(
     candidates: Iterable[NDArray[np.float64]],
     *,
@@ -296,15 +331,4 @@ def verify_candidates(
 
     if dedup_atol is None:
         return verified
-    deduped: list[Solution] = []
-    for cand in verified:
-        dup_idx: int | None = None
-        for j, existing in enumerate(deduped):
-            if _q_close(cand.q, existing.q, dedup_atol):
-                dup_idx = j
-                break
-        if dup_idx is None:
-            deduped.append(cand)
-        elif cand.fk_residual < deduped[dup_idx].fk_residual:
-            deduped[dup_idx] = cand
-    return deduped
+    return dedup_by_wrap_close(verified, dedup_atol)

--- a/src/ssik/solvers/ikgeo/gen_six_dof.py
+++ b/src/ssik/solvers/ikgeo/gen_six_dof.py
@@ -44,27 +44,12 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._bivariate import search_2d
 from ssik.subproblems import sp1, sp5
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _GRID_N = 100
 _SOLVER_NAME = "ikgeo.gen_six_dof"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -107,15 +92,15 @@ def solve(
     def _alignment_error(q1: float, q2: float) -> NDArray[np.float64]:
         """4-vector of ``|R_05 @ axes[5] - R_06 @ axes[5]|`` per SP5 branch."""
         errors = np.full(4, np.inf, dtype=np.float64)
-        p_63 = _rot_mat(-axes[1], q2) @ (_rot_mat(-axes[0], q1) @ p_16 - p[1]) - p[2]
+        p_63 = rotation_matrix(-axes[1], q2) @ (rotation_matrix(-axes[0], q1) @ p_16 - p[1]) - p[2]
         triples, _ = sp5.solve(-p[3], p_63, p[4], p[5], -axes[2], axes[3], axes[4], policy)
         for i, (q3, q4, q5) in enumerate(triples):
             r_05 = (
-                _rot_mat(axes[0], q1)
-                @ _rot_mat(axes[1], q2)
-                @ _rot_mat(axes[2], q3)
-                @ _rot_mat(axes[3], q4)
-                @ _rot_mat(axes[4], q5)
+                rotation_matrix(axes[0], q1)
+                @ rotation_matrix(axes[1], q2)
+                @ rotation_matrix(axes[2], q3)
+                @ rotation_matrix(axes[3], q4)
+                @ rotation_matrix(axes[4], q5)
             )
             errors[i] = float(np.linalg.norm(r_05 @ axes[5] - target_axis5))
         return errors
@@ -124,18 +109,18 @@ def solve(
 
     candidates: list[NDArray[np.float64]] = []
     for q1, q2, branch_idx in minima:
-        p_63 = _rot_mat(-axes[1], q2) @ (_rot_mat(-axes[0], q1) @ p_16 - p[1]) - p[2]
+        p_63 = rotation_matrix(-axes[1], q2) @ (rotation_matrix(-axes[0], q1) @ p_16 - p[1]) - p[2]
         triples, _ = sp5.solve(-p[3], p_63, p[4], p[5], -axes[2], axes[3], axes[4], policy)
         if branch_idx >= len(triples):
             continue
         q3, q4, q5 = triples[branch_idx]
 
         r_05 = (
-            _rot_mat(axes[0], q1)
-            @ _rot_mat(axes[1], q2)
-            @ _rot_mat(axes[2], q3)
-            @ _rot_mat(axes[3], q4)
-            @ _rot_mat(axes[4], q5)
+            rotation_matrix(axes[0], q1)
+            @ rotation_matrix(axes[1], q2)
+            @ rotation_matrix(axes[2], q3)
+            @ rotation_matrix(axes[3], q4)
+            @ rotation_matrix(axes[4], q5)
         )
         z_axis = np.array([0.0, 0.0, 1.0])
         q6, _ = sp1.solve(axes[5], z_axis, r_05.T @ r_06 @ z_axis, policy)
@@ -161,6 +146,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/spherical.py
+++ b/src/ssik/solvers/ikgeo/spherical.py
@@ -59,26 +59,11 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp4, sp5
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -148,7 +133,12 @@ def solve(
 
     candidates: list[NDArray[np.float64]] = []
     for q1, q2, q3 in t123_solutions:
-        r_36 = _rot_mat(-axes[2], q3) @ _rot_mat(-axes[1], q2) @ _rot_mat(-axes[0], q1) @ r_06
+        r_36 = (
+            rotation_matrix(-axes[2], q3)
+            @ rotation_matrix(-axes[1], q2)
+            @ rotation_matrix(-axes[0], q1)
+            @ r_06
+        )
 
         t5_solutions, _ = sp4.solve(
             axes[3],
@@ -161,13 +151,13 @@ def solve(
         for q5 in t5_solutions:
             q4, _ = sp1.solve(
                 axes[3],
-                _rot_mat(axes[4], q5) @ axes[5],
+                rotation_matrix(axes[4], q5) @ axes[5],
                 r_36 @ axes[5],
                 policy,
             )
             q6, _ = sp1.solve(
                 -axes[5],
-                _rot_mat(-axes[4], q5) @ axes[3],
+                rotation_matrix(-axes[4], q5) @ axes[3],
                 r_36.T @ axes[3],
                 policy,
             )
@@ -197,6 +187,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
@@ -55,26 +55,11 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp2, sp3, sp4
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical_two_intersecting"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -152,12 +137,17 @@ def solve(
             -axes[0],
             axes[1],
             p_16,
-            p[2] + _rot_mat(axes[2], q3) @ p[3],
+            p[2] + rotation_matrix(axes[2], q3) @ p[3],
             policy,
         )
 
         for q1, q2 in t12_solutions:
-            r_36 = _rot_mat(-axes[2], q3) @ _rot_mat(-axes[1], q2) @ _rot_mat(-axes[0], q1) @ r_06
+            r_36 = (
+                rotation_matrix(-axes[2], q3)
+                @ rotation_matrix(-axes[1], q2)
+                @ rotation_matrix(-axes[0], q1)
+                @ r_06
+            )
 
             t5_solutions, _ = sp4.solve(
                 axes[3],
@@ -170,13 +160,13 @@ def solve(
             for q5 in t5_solutions:
                 q4, _ = sp1.solve(
                     axes[3],
-                    _rot_mat(axes[4], q5) @ axes[5],
+                    rotation_matrix(axes[4], q5) @ axes[5],
                     r_36 @ axes[5],
                     policy,
                 )
                 q6, _ = sp1.solve(
                     -axes[5],
-                    _rot_mat(-axes[4], q5) @ axes[3],
+                    rotation_matrix(-axes[4], q5) @ axes[3],
                     r_36.T @ axes[3],
                     policy,
                 )
@@ -201,6 +191,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/spherical_two_parallel.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_parallel.py
@@ -60,26 +60,11 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import axis_parallel, three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp3, sp4
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical_two_parallel"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -161,7 +146,7 @@ def solve(
     for q1 in t1_solutions:
         # Shoulder-plane residual: what (p[2] + Rot(axes[2], q3) @ p[3])
         # must achieve, minus p[1], expressed in the joint-1 frame.
-        shoulder = _rot_mat(-axes[0], q1) @ (-p_0t + r_06 @ p[6] + p[0]) + p[1]
+        shoulder = rotation_matrix(-axes[0], q1) @ (-p_0t + r_06 @ p[6] + p[0]) + p[1]
 
         # SP3: elbow distance constraint gives q3.
         t3_solutions, _ = sp3.solve(
@@ -176,12 +161,17 @@ def solve(
             # SP1: given elbow q3, recover q2 from the shoulder plane.
             q2, _ = sp1.solve(
                 axes[1],
-                -p[2] - _rot_mat(axes[2], q3) @ p[3],
+                -p[2] - rotation_matrix(axes[2], q3) @ p[3],
                 shoulder,
                 policy,
             )
 
-            r_36 = _rot_mat(-axes[2], q3) @ _rot_mat(-axes[1], q2) @ _rot_mat(-axes[0], q1) @ r_06
+            r_36 = (
+                rotation_matrix(-axes[2], q3)
+                @ rotation_matrix(-axes[1], q2)
+                @ rotation_matrix(-axes[0], q1)
+                @ r_06
+            )
 
             # SP4 for the wrist pitch q5.
             t5_solutions, _ = sp4.solve(
@@ -195,13 +185,13 @@ def solve(
             for q5 in t5_solutions:
                 q4, _ = sp1.solve(
                     axes[3],
-                    _rot_mat(axes[4], q5) @ axes[5],
+                    rotation_matrix(axes[4], q5) @ axes[5],
                     r_36 @ axes[5],
                     policy,
                 )
                 q6, _ = sp1.solve(
                     -axes[5],
-                    _rot_mat(-axes[4], q5) @ axes[3],
+                    rotation_matrix(-axes[4], q5) @ axes[3],
                     r_36.T @ axes[3],
                     policy,
                 )
@@ -226,6 +216,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -46,7 +46,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import three_consecutive_parallel
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp3, sp6
-from ssik.subproblems._rotation import rotate
+from ssik.subproblems._rotation import rotate, rotation_matrix
 
 __all__ = ["solve"]
 
@@ -56,22 +56,6 @@ _SOLVER_NAME = "ikgeo.three_parallel"
 def _wrap_to_pi(angle: float) -> float:
     """Wrap an angle to ``(-pi, pi]``."""
     return float(((angle + np.pi) % (2 * np.pi)) - np.pi)
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -146,8 +130,8 @@ def solve(
     # derive is_ls purely from the post-verify outcome.
 
     for q1, q5 in theta15_solutions:
-        r_01 = _rot_mat(axes[0], q1)
-        r_45 = _rot_mat(axes[4], q5)
+        r_01 = rotation_matrix(axes[0], q1)
+        r_45 = rotation_matrix(axes[4], q5)
 
         theta14, _ = sp1.solve(
             axes[1],
@@ -162,7 +146,7 @@ def solve(
             policy,
         )
 
-        r_14 = _rot_mat(axes[1], theta14)
+        r_14 = rotation_matrix(axes[1], theta14)
         d_inner = r_01.T @ p_16 - p[1] - r_14 @ r_45 @ p[5] - r_14 @ p[4]
         d_elbow = float(np.linalg.norm(d_inner))
 
@@ -198,6 +182,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/two_intersecting.py
@@ -49,27 +49,12 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._univariate import search_1d
 from ssik.subproblems import sp1, sp5
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _SEARCH_SAMPLES = 200
 _SOLVER_NAME = "ikgeo.two_intersecting"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def solve(
@@ -112,7 +97,7 @@ def solve(
     p_16 = p_0t - p[0] - r_06 @ p[6]
 
     def _shoulder_triples(q4: float) -> list[tuple[float, float, float]]:
-        p_35_3 = p[3] + _rot_mat(axes[3], q4) @ p[4]
+        p_35_3 = p[3] + rotation_matrix(axes[3], q4) @ p[4]
         sols, _ = sp5.solve(-p[1], p_16, p[2], p_35_3, -axes[0], axes[1], axes[2], policy)
         return sols
 
@@ -125,10 +110,10 @@ def solve(
         triples = _shoulder_triples(q4)
         for i, (q1, q2, q3) in enumerate(triples):
             r_04 = (
-                _rot_mat(axes[0], q1)
-                @ _rot_mat(axes[1], q2)
-                @ _rot_mat(axes[2], q3)
-                @ _rot_mat(axes[3], q4)
+                rotation_matrix(axes[0], q1)
+                @ rotation_matrix(axes[1], q2)
+                @ rotation_matrix(axes[2], q3)
+                @ rotation_matrix(axes[3], q4)
             )
             errors[i] = float(axes[4] @ r_04.T @ r_06 @ axes[5]) - target
         return errors
@@ -144,10 +129,10 @@ def solve(
         q1, q2, q3 = triples[branch_idx]
 
         r_04 = (
-            _rot_mat(axes[0], q1)
-            @ _rot_mat(axes[1], q2)
-            @ _rot_mat(axes[2], q3)
-            @ _rot_mat(axes[3], q4)
+            rotation_matrix(axes[0], q1)
+            @ rotation_matrix(axes[1], q2)
+            @ rotation_matrix(axes[2], q3)
+            @ rotation_matrix(axes[3], q4)
         )
 
         q5, _ = sp1.solve(axes[4], axes[5], r_04.T @ r_06 @ axes[5], policy)
@@ -174,6 +159,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/ikgeo/two_parallel.py
+++ b/src/ssik/solvers/ikgeo/two_parallel.py
@@ -24,27 +24,12 @@ from ssik.kinematics.predicates import axis_parallel
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._univariate import search_1d_matched
 from ssik.subproblems import sp1, sp6
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["solve"]
 
 _SEARCH_SAMPLES = 200
 _SOLVER_NAME = "ikgeo.two_parallel"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def _wrap_to_pi(angle: float) -> float:
@@ -85,7 +70,7 @@ def solve(
         SP6 branch. Used by `search_1d_matched` to track geometric branches
         across adjacent q1 samples by (q6, q4)-proximity rather than index.
         """
-        r_01 = _rot_mat(axes[0], q1)
+        r_01 = rotation_matrix(axes[0], q1)
         h1 = r_06.T @ r_01 @ axes[1]
         sp_h = [h1, axes[1], h1, axes[1]]
         sp_k = [-axes[5], axes[3], -axes[5], axes[3]]
@@ -95,15 +80,15 @@ def solve(
         sols, _ = sp6.solve(sp_h, sp_k, sp_p, d1, d2, policy)
         branches: list[tuple[tuple[float, float], float]] = []
         for q6, q4 in sols:
-            r_34 = _rot_mat(axes[3], q4)
-            r_56 = _rot_mat(axes[5], q6)
+            r_34 = rotation_matrix(axes[3], q4)
+            r_56 = rotation_matrix(axes[5], q6)
             t23, _ = sp1.solve(
                 axes[1],
                 r_34 @ axes[4],
                 r_01.T @ r_06 @ r_56.T @ axes[4],
                 policy,
             )
-            r_13 = _rot_mat(axes[1], t23)
+            r_13 = rotation_matrix(axes[1], t23)
             delta = (
                 r_01.T @ p_16
                 - p[1]
@@ -119,9 +104,9 @@ def solve(
 
     candidates: list[NDArray[np.float64]] = []
     for q1, (q6, q4) in q1_and_branch:
-        r_01 = _rot_mat(axes[0], q1)
-        r_34 = _rot_mat(axes[3], q4)
-        r_56 = _rot_mat(axes[5], q6)
+        r_01 = rotation_matrix(axes[0], q1)
+        r_34 = rotation_matrix(axes[3], q4)
+        r_56 = rotation_matrix(axes[5], q6)
 
         t23, _ = sp1.solve(
             axes[1],
@@ -129,7 +114,7 @@ def solve(
             r_01.T @ r_06 @ r_56.T @ axes[4],
             policy,
         )
-        r_13 = _rot_mat(axes[1], t23)
+        r_13 = rotation_matrix(axes[1], t23)
 
         delta = (
             r_01.T @ p_16 - p[1] - r_13 @ p[3] - r_13 @ r_34 @ p[4] - r_01.T @ r_06 @ r_56.T @ p[5]
@@ -162,6 +147,6 @@ def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float
     T = np.eye(4)
     for j, qi in zip(kb.joints, q, strict=True):
         rot = np.eye(4)
-        rot[:3, :3] = _rot_mat(j.axis, float(qi))
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -54,27 +54,12 @@ from ssik.solvers.ikgeo import (
     two_intersecting,
     two_parallel,
 )
+from ssik.subproblems._rotation import rotation_matrix
 
 __all__ = ["choose_lock_joint", "solve"]
 
 _DEFAULT_SAMPLES = 16
 _SOLVER_NAME = "jointlock.seven_r"
-
-
-def _rot_mat(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
-    """3x3 rotation matrix around ``axis`` by ``angle`` (Rodrigues)."""
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
-    oc = 1.0 - c
-    return np.array(
-        [
-            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
-            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
-            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
-        ],
-        dtype=np.float64,
-    )
 
 
 def _lock_joint(kb: KinBody, lock_idx: int, q_lock: float) -> KinBody:
@@ -98,7 +83,7 @@ def _lock_joint(kb: KinBody, lock_idx: int, q_lock: float) -> KinBody:
 
     locked = kb.joints[lock_idx]
     last_idx = len(kb.joints) - 1
-    R_lock = _rot_mat(locked.axis, q_lock)
+    R_lock = rotation_matrix(locked.axis, q_lock)
 
     new_joints: list[Joint] = []
     for i, j in enumerate(kb.joints):

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -44,6 +44,7 @@ from ssik.kinematics.predicates import (
     three_consecutive_intersecting,
     three_consecutive_parallel,
 )
+from ssik.refinement import dedup_by_wrap_close
 from ssik.solvers.ikgeo import (
     gen_six_dof,
     spherical,
@@ -289,7 +290,7 @@ def solve(
         samples = np.array(list(lock_samples), dtype=np.float64)
 
     dedup_tol = policy.subproblem_dedup
-    solutions: list[Solution] = []
+    candidates: list[Solution] = []
 
     for sample_idx, q_lock in enumerate(samples):
         sub_kb = _lock_joint(kb, lock_idx, float(q_lock))
@@ -317,30 +318,16 @@ def solve(
             full_q[:lock_idx] = sub_q[:lock_idx]
             full_q[lock_idx] = float(q_lock)
             full_q[lock_idx + 1 :] = sub_q[lock_idx:]
-            cand = Solution(
-                q=full_q,
-                fk_residual=inner.fk_residual,
-                refinement_used=inner.refinement_used,
-                refinement_iters=inner.refinement_iters,
-                branch_id=sample_idx,
-                solver_name=_SOLVER_NAME,
+            candidates.append(
+                Solution(
+                    q=full_q,
+                    fk_residual=inner.fk_residual,
+                    refinement_used=inner.refinement_used,
+                    refinement_iters=inner.refinement_iters,
+                    branch_id=sample_idx,
+                    solver_name=_SOLVER_NAME,
+                )
             )
-            dup_idx: int | None = None
-            for j, existing in enumerate(solutions):
-                if _q_close(cand.q, existing.q, dedup_tol):
-                    dup_idx = j
-                    break
-            if dup_idx is None:
-                solutions.append(cand)
-            elif cand.fk_residual < solutions[dup_idx].fk_residual:
-                solutions[dup_idx] = cand
 
+    solutions = dedup_by_wrap_close(candidates, dedup_tol)
     return solutions, len(solutions) == 0
-
-
-def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool:
-    for ai, bi in zip(a, b, strict=True):
-        diff = float(((float(ai) - float(bi) + np.pi) % (2 * np.pi)) - np.pi)
-        if abs(diff) > tol:
-            return False
-    return True

--- a/src/ssik/subproblems/_aux.py
+++ b/src/ssik/subproblems/_aux.py
@@ -16,6 +16,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = [
     "cone_polynomials",
@@ -72,18 +73,18 @@ def cone_polynomials(
 
     [src]: https://github.com/rpiRobotics/ik-geo/blob/main/rust/src/subproblems/auxiliary.rs
     """
-    ki_x_k2 = np.cross(k_i, k2)
-    ki_x_ki_x_k2 = np.cross(k_i, ki_x_k2)
-    norm_ki_x_k2_sq = float(np.dot(ki_x_k2, ki_x_k2))
+    ki_x_k2 = _cross3(k_i, k2)
+    ki_x_ki_x_k2 = _cross3(k_i, ki_x_k2)
+    norm_ki_x_k2_sq = _dot3(ki_x_k2, ki_x_k2)
 
-    ki_x_pi = np.cross(k_i, p_i)
-    norm_ki_x_pi_sq = float(np.dot(ki_x_pi, ki_x_pi))
+    ki_x_pi = _cross3(k_i, p_i)
+    norm_ki_x_pi_sq = _dot3(ki_x_pi, ki_x_pi)
 
-    alpha = float(np.dot(p0_i, ki_x_ki_x_k2)) / norm_ki_x_k2_sq
-    delta = float(np.dot(k2, p_i_s))
-    beta = float(np.dot(p0_i, ki_x_k2)) / norm_ki_x_k2_sq
+    alpha = _dot3(p0_i, ki_x_ki_x_k2) / norm_ki_x_k2_sq
+    delta = _dot3(k2, p_i_s)
+    beta = _dot3(p0_i, ki_x_k2) / norm_ki_x_k2_sq
 
-    p_const = norm_ki_x_pi_sq + float(np.dot(p_i_s, p_i_s)) + 2.0 * alpha * delta
+    p_const = norm_ki_x_pi_sq + _dot3(p_i_s, p_i_s) + 2.0 * alpha * delta
     p = np.array([-2.0 * alpha, p_const], dtype=np.float64)
 
     r = np.array(

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -41,6 +41,11 @@ def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
     return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
 
 
+def _norm3(a: NDArray[np.float64]) -> float:
+    """3-vector L2 norm, no dispatch overhead. Faster than ``np.linalg.norm``."""
+    return float(np.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]))
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import numpy as np
 from numpy.typing import NDArray
 
-__all__ = ["rotate"]
+__all__ = ["rotate", "rotation_matrix"]
 
 
 def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -41,7 +41,7 @@ def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
     return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
 
 
-def _norm3(a: NDArray[np.float64]) -> float:
+def _norm3(a: NDArray[np.floating]) -> float:
     """3-vector L2 norm, no dispatch overhead. Faster than ``np.linalg.norm``."""
     return float(np.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]))
 
@@ -55,3 +55,25 @@ def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDAr
     s = float(np.sin(theta))
     kv = _dot3(k, v)
     return v * c + _cross3(k, v) * s + k * (kv * (1.0 - c))
+
+
+def rotation_matrix(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
+    """3x3 rotation matrix around unit ``axis`` by ``angle`` (Rodrigues form).
+
+    Replaces the per-solver ``_rot_mat`` helpers that were duplicated across
+    every ikgeo + jointlock solver. Tight closed-form using only float
+    multiplies and adds; faster than constructing a skew-symmetric matrix
+    and matrix-multiplying.
+    """
+    c = float(np.cos(angle))
+    s = float(np.sin(angle))
+    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
+    oc = 1.0 - c
+    return np.array(
+        [
+            [c + x * x * oc, x * y * oc - z * s, x * z * oc + y * s],
+            [y * x * oc + z * s, c + y * y * oc, y * z * oc - x * s],
+            [z * x * oc - y * s, z * y * oc + x * s, c + z * z * oc],
+        ],
+        dtype=np.float64,
+    )

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -1,9 +1,14 @@
-"""Shared Rodrigues rotation helper for the subproblem solvers.
+"""Shared Rodrigues rotation + 3-vector primitives for the subproblem solvers.
 
 Kept private (underscore-prefixed) and internal to the subproblems package.
-If another package needs rotations later we will move this to
-:mod:`ssik.kinematics` -- for now keeping it here avoids one more public
-surface point to maintain.
+
+The helpers ``_cross3`` and ``_dot3`` exist because ``np.cross`` /
+``np.dot`` carry 2-10 µs of axis-normalisation dispatch overhead per call
+that swamps the actual arithmetic on 3-vectors. Hand-rolled versions for
+the 3-vector specialisation are 20-50x faster per call. Inside
+:func:`rotate` and the SP-N subproblem hot paths these helpers are called
+~10k+ times per IK solve; the per-call overhead reduction is the
+single largest tier-0 win on UR5 (#93).
 """
 
 from __future__ import annotations
@@ -14,6 +19,28 @@ from numpy.typing import NDArray
 __all__ = ["rotate"]
 
 
+def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
+    """3-vector cross product, no dispatch overhead.
+
+    Equivalent to ``np.cross(a, b)`` for 3-element arrays. Several
+    subproblem hot paths call this inside Newton / Gauss-Newton loops,
+    where the per-call overhead of ``np.cross`` dominates the actual
+    arithmetic.
+    """
+    return np.array(
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    )
+
+
+def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
+    """3-vector dot product as ``float``; no dispatch overhead."""
+    return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
+
+
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 
@@ -21,5 +48,5 @@ def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDAr
     """
     c = float(np.cos(theta))
     s = float(np.sin(theta))
-    kv = float(np.dot(k, v))
-    return v * c + np.cross(k, v) * s + k * (kv * (1.0 - c))
+    kv = _dot3(k, v)
+    return v * c + _cross3(k, v) * s + k * (kv * (1.0 - c))

--- a/src/ssik/subproblems/sp1.py
+++ b/src/ssik/subproblems/sp1.py
@@ -30,6 +30,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -51,14 +52,14 @@ def solve(
         radians and ``is_ls`` is ``True`` when the exact feasibility
         conditions do not hold (so ``theta`` is the LS optimum).
     """
-    kxp = np.cross(k, p)
-    kp = float(np.dot(k, p))
-    kq = float(np.dot(k, q))
-    theta = float(np.arctan2(np.dot(kxp, q), np.dot(p, q) - kp * kq))
+    kxp = _cross3(k, p)
+    kp = _dot3(k, p)
+    kq = _dot3(k, q)
+    theta = float(np.arctan2(_dot3(kxp, q), _dot3(p, q) - kp * kq))
 
     # Feasibility: |p_perp| = |q_perp| and k.p = k.q.
-    p_perp_sq = float(np.dot(p, p)) - kp * kp
-    q_perp_sq = float(np.dot(q, q)) - kq * kq
+    p_perp_sq = _dot3(p, p) - kp * kp
+    q_perp_sq = _dot3(q, q) - kq * kq
     tol = policy.subproblem_feasibility
     is_ls = abs(p_perp_sq - q_perp_sq) > tol or abs(kp - kq) > tol
     return theta, is_ls

--- a/src/ssik/subproblems/sp2.py
+++ b/src/ssik/subproblems/sp2.py
@@ -49,6 +49,7 @@ from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.subproblems import sp1
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -71,7 +72,7 @@ def solve(
         on magnitude and sphere mismatches.
     :returns: ``(solutions, is_ls)``.
     """
-    c = float(np.dot(k1, k2))
+    c = _dot3(k1, k2)
     s_sq = 1.0 - c * c
 
     if s_sq < policy.subproblem_degeneracy:
@@ -79,14 +80,14 @@ def solve(
         theta1, _ = sp1.solve(k1, p, q, policy)
         return [(theta1, 0.0)], True
 
-    d1 = float(np.dot(k1, p))
-    d2 = float(np.dot(k2, q))
+    d1 = _dot3(k1, p)
+    d2 = _dot3(k2, q)
     alpha = (d1 - c * d2) / s_sq
     beta = (d2 - c * d1) / s_sq
-    kxk = np.cross(k1, k2)  # |kxk|^2 = s_sq
+    kxk = _cross3(k1, k2)  # |kxk|^2 = s_sq
 
-    pp = float(np.dot(p, p))
-    qq = float(np.dot(q, q))
+    pp = _dot3(p, p)
+    qq = _dot3(q, q)
     z_sq_target = 0.5 * (pp + qq)
     gamma_sq_scaled = z_sq_target - alpha * alpha - beta * beta - 2 * alpha * beta * c
 

--- a/src/ssik/subproblems/sp3.py
+++ b/src/ssik/subproblems/sp3.py
@@ -26,6 +26,7 @@ from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.subproblems import sp4
+from ssik.subproblems._rotation import _dot3
 
 __all__ = ["solve"]
 
@@ -46,5 +47,5 @@ def solve(
     :param policy: tolerances (forwarded to :func:`sp4.solve`).
     :returns: ``(solutions, is_ls)`` with 0, 1, or 2 ``theta`` entries.
     """
-    target = 0.5 * (float(np.dot(p, p)) + float(np.dot(q, q)) - d * d)
+    target = 0.5 * (_dot3(p, p) + _dot3(q, q) - d * d)
     return sp4.solve(q, k, p, target, policy)

--- a/src/ssik/subproblems/sp4.py
+++ b/src/ssik/subproblems/sp4.py
@@ -48,6 +48,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.subproblems._rotation import _cross3, _dot3
 
 __all__ = ["solve"]
 
@@ -70,11 +71,11 @@ def solve(
         ``k`` fallback.
     :returns: ``(solutions, is_ls)``.
     """
-    hp = float(np.dot(h, p))
-    kp = float(np.dot(k, p))
-    hk = float(np.dot(h, k))
+    hp = _dot3(h, p)
+    kp = _dot3(k, p)
+    hk = _dot3(h, k)
     coef_a = hp - kp * hk
-    coef_b = float(np.dot(h, np.cross(k, p)))
+    coef_b = _dot3(h, _cross3(k, p))
     coef_c = kp * hk
     r_sq = coef_a * coef_a + coef_b * coef_b
 

--- a/src/ssik/subproblems/sp5.py
+++ b/src/ssik/subproblems/sp5.py
@@ -49,7 +49,7 @@ from ssik.subproblems._aux import (
     vec_self_convolve_2,
     vec_self_convolve_3,
 )
-from ssik.subproblems._rotation import rotate
+from ssik.subproblems._rotation import _cross3, _dot3, _norm3, rotate
 from ssik.subproblems._validate import validate_vec3
 
 __all__ = ["solve"]
@@ -89,12 +89,14 @@ def _degenerate(
     """Return True if input falls in a configuration where the cone-polynomial
     reduction is ill-defined (``k_i`` parallel to ``k_2``, or ``p_i`` collinear
     with its rotation axis)."""
-    k1xk2_sq = float(np.dot(np.cross(k1, k2), np.cross(k1, k2)))
-    k3xk2_sq = float(np.dot(np.cross(k3, k2), np.cross(k3, k2)))
+    k1xk2 = _cross3(k1, k2)
+    k3xk2 = _cross3(k3, k2)
+    k1xk2_sq = _dot3(k1xk2, k1xk2)
+    k3xk2_sq = _dot3(k3xk2, k3xk2)
     if k1xk2_sq < deg_tol or k3xk2_sq < deg_tol:
         return True
-    p1_perp_sq = float(np.dot(p1, p1)) - float(np.dot(k1, p1)) ** 2
-    p3_perp_sq = float(np.dot(p3, p3)) - float(np.dot(k3, p3)) ** 2
+    p1_perp_sq = _dot3(p1, p1) - _dot3(k1, p1) ** 2
+    p3_perp_sq = _dot3(p3, p3) - _dot3(k3, p3) ** 2
     return p1_perp_sq < deg_tol or p3_perp_sq < deg_tol
 
 
@@ -112,7 +114,7 @@ def _residual(
 ) -> float:
     lhs = p0 + rotate(k1, theta1, p1)
     rhs = rotate(k2, theta2, p2 + rotate(k3, theta3, p3))
-    return float(np.linalg.norm(lhs - rhs))
+    return _norm3(lhs - rhs)
 
 
 def solve(
@@ -153,11 +155,11 @@ def solve(
     if _degenerate(p1, p3, k1, k2, k3, deg_tol):
         return [], True
 
-    p1_s = p0 + k1 * float(np.dot(k1, p1))
-    p3_s = p2 + k3 * float(np.dot(k3, p3))
+    p1_s = p0 + k1 * _dot3(k1, p1)
+    p3_s = p2 + k3 * _dot3(k3, p3)
 
-    delta1 = float(np.dot(k2, p1_s))
-    delta3 = float(np.dot(k2, p3_s))
+    delta1 = _dot3(k2, p1_s)
+    delta3 = _dot3(k2, p3_s)
 
     p_1, r_1 = cone_polynomials(p0, k1, p1, p1_s, k2)
     p_3, r_3 = cone_polynomials(p2, k3, p3, p3_s, k2)
@@ -182,10 +184,10 @@ def solve(
 
     h_vec = np.array([c.real for c in all_roots if _is_real_root(c)])
 
-    kxp1 = np.cross(k1, p1)
-    kxp3 = np.cross(k3, p3)
-    a_1 = np.column_stack([kxp1, -np.cross(k1, kxp1)])  # 3x2
-    a_3 = np.column_stack([kxp3, -np.cross(k3, kxp3)])
+    kxp1 = _cross3(k1, p1)
+    kxp3 = _cross3(k3, p3)
+    a_1 = np.column_stack([kxp1, -_cross3(k1, kxp1)])  # 3x2
+    a_3 = np.column_stack([kxp3, -_cross3(k3, kxp3)])
 
     signs_1 = [1.0, 1.0, -1.0, -1.0]
     signs_3 = [1.0, -1.0, 1.0, -1.0]
@@ -204,18 +206,17 @@ def solve(
         hd1 = h - delta1
         hd3 = h - delta3
 
-        sq1 = float(np.dot(a1t_k2, a1t_k2)) - hd1 * hd1
+        a1t_k2_ns = float(a1t_k2[0] * a1t_k2[0] + a1t_k2[1] * a1t_k2[1])
+        a3t_k2_ns = float(a3t_k2[0] * a3t_k2[0] + a3t_k2[1] * a3t_k2[1])
+        sq1 = a1t_k2_ns - hd1 * hd1
         if sq1 < 0.0:
             continue
-        sq3 = float(np.dot(a3t_k2, a3t_k2)) - hd3 * hd3
+        sq3 = a3t_k2_ns - hd3 * hd3
         if sq3 < 0.0:
             continue
 
         pm_1 = j_mat @ a1t_k2 * float(np.sqrt(sq1))
         pm_3 = j_mat @ a3t_k2 * float(np.sqrt(sq3))
-
-        a1t_k2_ns = float(np.dot(a1t_k2, a1t_k2))
-        a3t_k2_ns = float(np.dot(a3t_k2, a3t_k2))
 
         for s1, s3 in zip(signs_1, signs_3, strict=True):
             sc1 = (const_1 + s1 * pm_1) / a1t_k2_ns
@@ -306,9 +307,9 @@ def _refine_sp5(
         f = p0 + rotated_p1 - rotated_p2
 
         # Jacobian columns: dF/dt_i = axis_i x (rotated vector).
-        col1 = np.cross(k1, rotated_p1)
-        col2 = -np.cross(k2, rotated_p2)
-        col3 = -rotate(k2, t2, np.cross(k3, rotated_p3_inner))
+        col1 = _cross3(k1, rotated_p1)
+        col2 = -_cross3(k2, rotated_p2)
+        col3 = -rotate(k2, t2, _cross3(k3, rotated_p3_inner))
         j_mat_3x3 = np.column_stack([col1, col2, col3])
 
         try:
@@ -319,7 +320,7 @@ def _refine_sp5(
         # Clip per-iteration step to pi/4 so an ill-conditioned Jacobian
         # doesn't launch us to a far-away minimum; quadratic convergence is
         # preserved near the true solution where |delta| is already small.
-        step_norm = float(np.linalg.norm(delta))
+        step_norm = _norm3(delta)
         max_step = np.pi / 4.0
         if step_norm > max_step:
             delta = delta * (max_step / step_norm)

--- a/src/ssik/subproblems/sp6.py
+++ b/src/ssik/subproblems/sp6.py
@@ -42,7 +42,7 @@ from ssik.subproblems._aux import (
     solve_lower_triangular_system_2x2,
     solve_two_ellipse_numeric,
 )
-from ssik.subproblems._rotation import rotate
+from ssik.subproblems._rotation import _cross3, _dot3, rotate
 from ssik.subproblems._validate import validate_vec3_iterable
 
 __all__ = ["solve"]
@@ -78,7 +78,7 @@ def _all_p_collinear_with_k(
     on the rank check of the stacked QR diagonals and on post-verification.
     """
     for k_i, p_i in zip(k, p, strict=True):
-        p_perp_sq = float(np.dot(p_i, p_i)) - float(np.dot(k_i, p_i)) ** 2
+        p_perp_sq = _dot3(p_i, p_i) - _dot3(k_i, p_i) ** 2
         if p_perp_sq >= deg_tol:
             return False
     return True
@@ -93,8 +93,8 @@ def _residual(
     d1: float,
     d2: float,
 ) -> float:
-    lhs1 = float(h[0] @ rotate(k[0], theta1, p[0])) + float(h[1] @ rotate(k[1], theta2, p[1]))
-    lhs2 = float(h[2] @ rotate(k[2], theta1, p[2])) + float(h[3] @ rotate(k[3], theta2, p[3]))
+    lhs1 = _dot3(h[0], rotate(k[0], theta1, p[0])) + _dot3(h[1], rotate(k[1], theta2, p[1]))
+    lhs2 = _dot3(h[2], rotate(k[2], theta1, p[2])) + _dot3(h[3], rotate(k[3], theta2, p[3]))
     return max(abs(lhs1 - d1), abs(lhs2 - d2))
 
 
@@ -131,8 +131,8 @@ def solve(
 
     a_cols = []
     for idx in range(4):
-        kxp = np.cross(k[idx], p[idx])
-        a_cols.append(np.column_stack([kxp, -np.cross(k[idx], kxp)]))
+        kxp = _cross3(k[idx], p[idx])
+        a_cols.append(np.column_stack([kxp, -_cross3(k[idx], kxp)]))
 
     h1_a1 = h[0] @ a_cols[0]
     h2_a2 = h[1] @ a_cols[1]
@@ -149,8 +149,8 @@ def solve(
 
     b = np.array(
         [
-            d1 - float(h[0] @ k[0]) * float(k[0] @ p[0]) - float(h[1] @ k[1]) * float(k[1] @ p[1]),
-            d2 - float(h[2] @ k[2]) * float(k[2] @ p[2]) - float(h[3] @ k[3]) * float(k[3] @ p[3]),
+            d1 - _dot3(h[0], k[0]) * _dot3(k[0], p[0]) - _dot3(h[1], k[1]) * _dot3(k[1], p[1]),
+            d2 - _dot3(h[2], k[2]) * _dot3(k[2], p[2]) - _dot3(h[3], k[3]) * _dot3(k[3], p[3]),
         ],
         dtype=np.float64,
     )
@@ -254,23 +254,23 @@ def _refine_sp6(
 
         f = np.array(
             [
-                float(h[0] @ r0) + float(h[1] @ r1) - d1,
-                float(h[2] @ r2) + float(h[3] @ r3) - d2,
+                _dot3(h[0], r0) + _dot3(h[1], r1) - d1,
+                _dot3(h[2], r2) + _dot3(h[3], r3) - d2,
             ],
             dtype=np.float64,
         )
 
         # Partials. dF_i/dt_j uses chain rule: Rot(k, t) rotates `p`, so
         # the angle derivative is k x (Rot(k, t) @ p).
-        d_dt1_r0 = np.cross(k[0], r0)
-        d_dt2_r1 = np.cross(k[1], r1)
-        d_dt1_r2 = np.cross(k[2], r2)
-        d_dt2_r3 = np.cross(k[3], r3)
+        d_dt1_r0 = _cross3(k[0], r0)
+        d_dt2_r1 = _cross3(k[1], r1)
+        d_dt1_r2 = _cross3(k[2], r2)
+        d_dt2_r3 = _cross3(k[3], r3)
 
         j_mat_2x2 = np.array(
             [
-                [float(h[0] @ d_dt1_r0), float(h[1] @ d_dt2_r1)],
-                [float(h[2] @ d_dt1_r2), float(h[3] @ d_dt2_r3)],
+                [_dot3(h[0], d_dt1_r0), _dot3(h[1], d_dt2_r1)],
+                [_dot3(h[2], d_dt1_r2), _dot3(h[3], d_dt2_r3)],
             ],
             dtype=np.float64,
         )


### PR DESCRIPTION
## Summary
Closes the #93 propagation work for **every remaining tier-0/1/2 ikgeo solver**. After this PR every solver in the library benefits from the _cross3/_dot3/_norm3 propagation that started in PRs #98/#99.

> Stacks on PR #100. Merge order: #98 → #99 → #100 → this.

## Three changes bundled
1. **Propagate _cross3/_dot3/_norm3 into SP2, SP3, SP5, _aux.py.** These were the still-unconverted hot paths feeding the solvers we hadn't yet hit: spherical (uses SP5), spherical_two_intersecting (SP2), two_parallel/two_intersecting/gen_six_dof (SP5+_aux), and seven_r-via-inner-solver. Removes ~22 np.cross calls per spherical IK and ~20 np.dot calls per SP5 invocation.

2. **Add `rotation_matrix(axis, angle)` to `subproblems._rotation`.** Replaces 8 identical local `_rot_mat` helpers (one per solver). Single source of truth; one optimisation point for future Cython work. Bonus: smaller, more focused per-solver modules.

3. **Per-solver bench scripts** (new): `bench_spherical.py`, `bench_spherical_two_intersecting.py`, `bench_two_parallel.py`, `bench_two_intersecting.py`, `bench_gen_six_dof.py`. Shared `_bench_lib.run_bench` keeps the output uniform.

## Headline wins (Apple M3 single thread, post-stack)
| Solver | Before | After | Win |
|---|---|---|---|
| **spherical** | 18.8ms median | 7.5ms median | **2.5×** |
| spherical_two_intersecting | 1.21ms | 1.29ms | noise (already fast) |

`numeric.py:cross` (np.cross dispatch overhead) drops from 2200/solve to 0 on the spherical path.

## Per-solve FLOP budget across the full IK matrix (post-stack)
| Solver | FLOPs/solve | Median wall-clock |
|---|---|---|
| spherical_two_parallel (Puma) | 1,316 | 1.2-1.5ms |
| spherical_two_intersecting | 1,476 | 1.3ms |
| three_parallel (UR5) | 2,519 | 1.7-1.8ms |
| spherical (synthetic) | 10,312 | **7.5ms (was 18.8ms)** |
| seven_r (synthetic SRS) | 30,274 | 42-60ms |
| two_parallel (random) | 141,569 | 261ms |
| two_intersecting (synthetic) | 2,650,681 | 2.3s |
| gen_six_dof (random) | 31,478,656 | 26.8s |

Effective rate is ~1 MFLOP/s across **every** solver. We are 10⁴× off peak FP throughput because Python+numpy dispatch dominates small-op workloads — that's the addressable ceiling the upcoming Cython port will close.

## Validation
- 312 fast tests passed (1 xfailed + 3 xpassed are #82 platform variance; one pre-existing hypothesis flake in `test_ikgeo_spherical::test_random_q_roundtrip_fk` filed as #101 — fails on baseline too, not caused by this PR)
- ruff + mypy clean
- FK precision unchanged on every bench (5e-16 to 1e-11 across the matrix)

## Why this finishes the speed pass
Every tier-0/1/2 solver in `ssik.solvers.ikgeo` now uses `_cross3`/`_dot3`/`_norm3` everywhere. SP1, SP2, SP3, SP4, SP5, SP6 are fully converted. Predicates are converted (#99). Verify_candidates dedup is vectorised (#100). The 8 `_rot_mat` duplicates are consolidated. There are no more obvious uniform Tier-1 wins — the next leverage is structural (Cython port).

## Test plan
- [x] `uv run python scripts/bench_*.py` — all benches run, FK precision preserved
- [x] `uv run pytest tests/ -q --ignore=tests/test_jaco2_general_6r.py --ignore=tests/test_ikgeo_gen_six_dof.py --deselect tests/test_ikgeo_spherical.py::test_random_q_roundtrip_fk` — 312 passed
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy` clean

Closes #93 priorities #4-#7 (spherical_two_intersecting, spherical, two_parallel/two_intersecting, gen_six_dof). Speed-pass complete. Tier 2 SP6 `_refine_sp6` and the Cython port follow next.