### PR TITLE
Speed Tier 1 on #93: vectorise wrap-to-pi dedup (7R 31% faster, all solvers benefit)

### DIFF
--- a/scripts/bench_seven_r.py
+++ b/scripts/bench_seven_r.py
@@ -1,0 +1,142 @@
+"""Per-IK timing for jointlock.seven_r on a synthetic SRS-with-spherical-wrist arm.
+
+Mirrors scripts/bench_three_parallel.py + bench_spherical_two_parallel.py.
+Uses the same synthetic 7R fixture as test_jointlock_seven_r.py
+(``_build_srs_with_spherical_wrist``): shoulder pitch+pitch (parallel),
+elbow roll (lock candidate), spherical wrist. Locking joint 3 yields a
+6R with spherical_two_parallel topology.
+
+Reports wall-clock + FLOP budget + transferability projections.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _flop_budget import flop_budget, print_flop_summary
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.solvers.jointlock import seven_r
+
+
+def _rodrigues(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    c, s = np.cos(t), np.sin(t)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    R: NDArray[np.float64] = np.eye(3) + s * K + (1 - c) * (K @ K)
+    return R
+
+
+def _axis_angle_4x4(k: NDArray[np.float64], t: float) -> NDArray[np.float64]:
+    T = np.eye(4)
+    T[:3, :3] = _rodrigues(k, t)
+    return T
+
+
+def _fk(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        T = T @ j.T_left @ _axis_angle_4x4(j.axis, float(qi)) @ j.T_right
+    return T
+
+
+def _build_srs() -> KinBody:
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+    ]
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.2]),
+        np.array([0.4, 0.0, 0.0]),
+        np.array([0.05, -0.1, 0.0]),
+        np.array([0.0, 0.0, 0.4]),
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    links = [Link(name=f"l{i}") for i in range(8)]
+    joints = []
+    for i in range(7):
+        T_l = np.eye(4)
+        T_l[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+kb = _build_srs()
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-1.0, 1.0, size=7)
+sols, _ = seven_r.solve(kb, _fk(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses\n")
+
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-1.0, 1.0, size=7)
+    t_target = _fk(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = seven_r.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt * 1e3)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    best_err = min(float(np.linalg.norm(_fk(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("per-IK time over 100 poses:")
+print(f"  min      {ts.min():>8.3f} ms")
+print(f"  median   {np.median(ts):>8.3f} ms")
+print(f"  mean     {ts.mean():>8.3f} ms")
+print(f"  p95      {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max      {ts.max():>8.3f} ms")
+
+print(
+    f"\nsolutions per pose: median={int(np.median(n_sols))}, min={min(n_sols)}, max={max(n_sols)}"
+)
+print(f"FK error: median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass.
+rng_p = np.random.default_rng(1)
+poses = [_fk(kb, rng_p.uniform(-1.0, 1.0, size=7)) for _ in range(n)]
+pr = cProfile.Profile()
+pr.enable()
+for tt in poses:
+    seven_r.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -209,6 +209,41 @@ def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool
     return True
 
 
+def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Vectorised dedup of :class:`Solution` candidates by wrap-to-pi joint-
+    angle closeness.
+
+    For each cluster of solutions whose joint vectors agree (mod 2pi) within
+    ``tol`` per joint, keeps the candidate with the lowest ``fk_residual``.
+    Streaming order matches the previous Python-loop implementation
+    (``_q_close`` first-match-wins) so output ordering is preserved.
+
+    Implementation: maintains the deduped joint vectors as a stacked
+    ``(M, N_dof)`` numpy array; per-candidate dedup is one broadcasted
+    ``mod 2pi`` + ``argwhere`` instead of an inner Python loop. Replaces
+    the dominant cost (~24% of total) in 7R jointlock solves.
+    """
+    if not candidates:
+        return []
+    deduped: list[Solution] = []
+    n_dof = candidates[0].q.shape[0]
+    arr = np.empty((0, n_dof), dtype=np.float64)
+    for cand in candidates:
+        if arr.shape[0] > 0:
+            diffs = (cand.q - arr + np.pi) % (2 * np.pi) - np.pi
+            matches = np.all(np.abs(diffs) < tol, axis=1)
+            idxs = np.where(matches)[0]
+            if len(idxs) > 0:
+                j = int(idxs[0])
+                if cand.fk_residual < deduped[j].fk_residual:
+                    deduped[j] = cand
+                    arr[j] = cand.q
+                continue
+        deduped.append(cand)
+        arr = np.vstack([arr, cand.q[np.newaxis, :]])
+    return deduped
+
+
 def verify_candidates(
     candidates: Iterable[NDArray[np.float64]],
     *,
@@ -296,15 +331,4 @@ def verify_candidates(
 
     if dedup_atol is None:
         return verified
-    deduped: list[Solution] = []
-    for cand in verified:
-        dup_idx: int | None = None
-        for j, existing in enumerate(deduped):
-            if _q_close(cand.q, existing.q, dedup_atol):
-                dup_idx = j
-                break
-        if dup_idx is None:
-            deduped.append(cand)
-        elif cand.fk_residual < deduped[dup_idx].fk_residual:
-            deduped[dup_idx] = cand
-    return deduped
+    return dedup_by_wrap_close(verified, dedup_atol)

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -44,6 +44,7 @@ from ssik.kinematics.predicates import (
     three_consecutive_intersecting,
     three_consecutive_parallel,
 )
+from ssik.refinement import dedup_by_wrap_close
 from ssik.solvers.ikgeo import (
     gen_six_dof,
     spherical,
@@ -289,7 +290,7 @@ def solve(
         samples = np.array(list(lock_samples), dtype=np.float64)
 
     dedup_tol = policy.subproblem_dedup
-    solutions: list[Solution] = []
+    candidates: list[Solution] = []
 
     for sample_idx, q_lock in enumerate(samples):
         sub_kb = _lock_joint(kb, lock_idx, float(q_lock))
@@ -317,30 +318,16 @@ def solve(
             full_q[:lock_idx] = sub_q[:lock_idx]
             full_q[lock_idx] = float(q_lock)
             full_q[lock_idx + 1 :] = sub_q[lock_idx:]
-            cand = Solution(
-                q=full_q,
-                fk_residual=inner.fk_residual,
-                refinement_used=inner.refinement_used,
-                refinement_iters=inner.refinement_iters,
-                branch_id=sample_idx,
-                solver_name=_SOLVER_NAME,
+            candidates.append(
+                Solution(
+                    q=full_q,
+                    fk_residual=inner.fk_residual,
+                    refinement_used=inner.refinement_used,
+                    refinement_iters=inner.refinement_iters,
+                    branch_id=sample_idx,
+                    solver_name=_SOLVER_NAME,
+                )
             )
-            dup_idx: int | None = None
-            for j, existing in enumerate(solutions):
-                if _q_close(cand.q, existing.q, dedup_tol):
-                    dup_idx = j
-                    break
-            if dup_idx is None:
-                solutions.append(cand)
-            elif cand.fk_residual < solutions[dup_idx].fk_residual:
-                solutions[dup_idx] = cand
 
+    solutions = dedup_by_wrap_close(candidates, dedup_tol)
     return solutions, len(solutions) == 0
-
-
-def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool:
-    for ai, bi in zip(a, b, strict=True):
-        diff = float(((float(ai) - float(bi) + np.pi) % (2 * np.pi)) - np.pi)
-        if abs(diff) > tol:
-            return False
-    return True


### PR DESCRIPTION
Stacked re-target after #105 merged. See original #100 for full description. Closes #93 priority #3.