### PR TITLE
#110 Phase 1: ssik build / classify CLI + dispatcher + codegen + library logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,65 @@ Status legend: ✅ in-repo URDF/MJCF fixture exercised by the test suite — �
 | 2 — fallback oracle | `gen_six_dof` | ~10-100 s | 100×100 grid + Nelder–Mead; correctness oracle only |
 | 7R wrapper | `jointlock.seven_r` | ~40-60 ms | lock one joint, dispatch inner 6R, sweep 16 lock samples |
 
+## Per-arm artifact builder (`ssik build`)
+
+The user-facing flow: hand us a URDF, get back a self-contained Python module.
+
+```bash
+$ ssik build path/to/ur5.urdf --base base_link --ee ee_link
+[ssik] Loading path/to/ur5.urdf
+[ssik]   6 joints, 7 links — POE-normalized OK
+[ssik] Classifying topology
+[ssik]   → Best solver: ikgeo.three_parallel (tier 0)
+[ssik]   → Expected median IK time: ~1.6 ms
+[ssik]   → FLOP budget: ~2,519 FLOPs / solve
+[ssik]   → Reasoning:
+[ssik]       Three consecutive parallel axes at joints (1, 2, 3) — the UR-class structure.
+[ssik]       Closed-form via SP6 (joints 0+4) + SP1 + SP3.
+[ssik] No build-time precompute needed (tier-0 closed-form)
+[ssik] Emitting ./ur5_ik.py
+[ssik]   Wrote 5,004 bytes
+[ssik] Validating (100 random poses)
+[ssik]   ✓ 100 poses, median 0.78 ms, max FK error 6e-09, 0 failures
+[ssik] ✓ Done. Try:
+[ssik]     >>> import ur5_ik
+[ssik]     >>> sols, is_ls = ur5_ik.solve(T_target)
+```
+
+The emitted artifact wraps the dispatched solver around baked KinBody constants and exposes a rich API:
+
+```python
+import ur5_ik
+from ssik import TolerancePolicy
+
+# Default: fastest path, no Newton polish.
+sols, is_ls = ur5_ik.solve(T_target)
+
+# Tighter FK-closure threshold for high-precision applications.
+strict = TolerancePolicy(subproblem_numerical=1e-9)
+sols, is_ls = ur5_ik.solve(T_target, policy=strict)
+
+# Newton polish for near-singular poses (off by default).
+sols, is_ls = ur5_ik.solve(T_target, allow_refinement=True, refinement_max_iters=8)
+
+# is_ls=True signals the algebraic path didn't close; sols is best-LS or empty.
+# Callers wanting only "exact" solutions check is_ls and discard.
+if is_ls:
+    raise NoExactIK
+for sol in sols:
+    print(sol.q, sol.fk_residual, sol.refinement_used)
+```
+
+The dispatcher picks the best solver from the catalog above based on topology predicates (`three_consecutive_parallel`, `three_consecutive_intersecting`, etc.). Tier-1 univariate-search solvers are not auto-selected: tier-2 Raghavan–Roth (`general_6r`) handles the same chains at ~5 ms vs tier-1's 100 ms–2 s. Tier-1 modules remain importable for users who want them explicitly.
+
+For inspection without emitting an artifact:
+
+```bash
+$ ssik classify path/to/your.urdf --base base_link --ee tcp_link
+```
+
+Tier-2 (non-Pieper) arms today still trigger the symbolic preprocessing on first `solve()` call (~150–300 s). Phase 2 of [#110](https://github.com/siddhss5/ikfastpy/issues/110) bakes the preprocessing output into the artifact at build time so first-call latency is gone.
+
 ## Repository layout
 
 This is the **internal development codebase**. Public users never see this; they receive a per-arm wheel built from this source.
@@ -105,7 +164,7 @@ uv run mkdocs serve
 
 ## Distribution model
 
-Customers submit a URDF / MJCF via [#95](https://github.com/siddhss5/ikfastpy/issues/95)'s intake mechanism. We run the cold-cache build pipeline (`poe_to_dh` → `pick_best_leftvar` AE-3 selection → symbolic preprocessing → compile to `.so`), produce a per-arm wheel, and deliver. The wheel exposes `solve(T_target) -> tuple[list[Solution], bool]` with the same `Solution` shape used internally. Customer source code never includes ssik internals — they call into the compiled binary.
+Customers submit a URDF / MJCF via [#95](https://github.com/siddhss5/ikfastpy/issues/95)'s intake mechanism. We run `ssik build` (above) which produces a per-arm `.py` artifact today; the [#110](https://github.com/siddhss5/ikfastpy/issues/110) phasing extends this to a Cython `.so` artifact with the same `solve(T, *, policy=..., allow_refinement=..., refinement_max_iters=...)` API. The wheel ships the artifact and nothing else — customer source code never imports ssik internals.
 
 The Cython port (gated on the Python pipeline being stable) closes the ~10000× gap the FLOP budget says is on the table: every solver is currently dispatch-bound at ~1 MFLOP/s achieved, and a native port should hit ~µs IK on Pieper-class arms — the original IKFast promise, this time without IKFast's fragility.
 
@@ -115,6 +174,7 @@ Proprietary. See [`LICENSE`](LICENSE) for full terms; in summary: all rights res
 
 ## Tracking
 
+- Per-arm artifact builder + Cython port: [#110](https://github.com/siddhss5/ikfastpy/issues/110).
 - Strategic distribution model: [#95](https://github.com/siddhss5/ikfastpy/issues/95).
 - Speed work across all solver pathways: [#93](https://github.com/siddhss5/ikfastpy/issues/93).
 - Tier-2 RR speed (already ~2× since baseline): [#86](https://github.com/siddhss5/ikfastpy/issues/86).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ urdf = [
 Repository = "https://github.com/siddhss5/ikfastpy"
 Issues = "https://github.com/siddhss5/ikfastpy/issues"
 
+[project.scripts]
+ssik = "ssik.cli:main"
+
 # PEP 735 dependency groups — for tooling that's not an "extra" of the package.
 [dependency-groups]
 dev = [
@@ -64,6 +67,12 @@ packages = ["src/ssik"]
 line-length = 100
 target-version = "py311"
 src = ["src", "tests"]
+extend-exclude = [
+    # Generated reference artifacts. Not subject to lint rules; their format
+    # is dictated by ssik.core.codegen and validated via byte-equal snapshot
+    # tests in test_artifact_snapshots.py.
+    "tests/artifacts",
+]
 
 [tool.ruff.lint]
 select = [
@@ -81,6 +90,7 @@ select = [
 python_version = "3.11"
 strict = true
 files = ["src", "tests"]
+exclude = ['^tests/artifacts/']
 
 # sympy ships no type stubs; used at module-import time for offline
 # per-arm symbolic preprocessing in ssik.solvers.ikgeo._raghavan_roth.
@@ -91,6 +101,12 @@ ignore_missing_imports = true
 # urchin (URDF parser) ships no type stubs.
 [[tool.mypy.overrides]]
 module = "urchin.*"
+ignore_missing_imports = true
+
+# tests/fixtures/jaco2.py is reachable via sys.path injection in tests; mypy
+# resolves it correctly when run inside pytest but not from a top-level pass.
+[[tool.mypy.overrides]]
+module = "jaco2"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/scripts/regen_artifacts.py
+++ b/scripts/regen_artifacts.py
@@ -1,0 +1,94 @@
+"""Regenerate the committed reference artifacts under ``tests/artifacts/``.
+
+Run after any change to :mod:`ssik.core.codegen`, :mod:`ssik.core.dispatcher`,
+or any solver whose dispatch reasoning text might shift. The companion
+snapshot test (``tests/test_artifact_snapshots.py``) re-emits and asserts
+byte-equal against the committed file -- if you forget to run this script
+the test fails the build and tells you which artifact drifted.
+
+The committed artifacts serve three purposes:
+
+1. **Documentation.** They're the user-facing API surface; reviewers see
+   what ``ssik build`` produces without running the CLI.
+2. **Regression detection.** Any codegen-touching PR shows an artifact
+   diff -- you can scan the diff to confirm the change is intentional.
+3. **CI savings (Phase 2).** Once tier-2 RR's symbolic preprocessing is
+   baked at build time, the JACO 2 artifact will carry the precompute
+   output as data; CI compares against the committed copy instead of
+   rerunning the multi-minute sympy step.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ssik._kinbody import build_kinbody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.codegen import emit_artifact
+from ssik.core.dispatcher import dispatch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+ARTIFACTS = REPO_ROOT / "tests" / "artifacts"
+
+
+def main() -> int:
+    ARTIFACTS.mkdir(exist_ok=True)
+    print(f"writing reference artifacts to {ARTIFACTS}/")
+    _emit_urdf_artifact(
+        urdf=FIXTURES / "ur5.urdf",
+        base="base_link",
+        ee="ee_link",
+        module_name="ur5_ik",
+        arm_label="UR5",
+    )
+    _emit_urdf_artifact(
+        urdf=FIXTURES / "puma560.urdf",
+        base="base_link",
+        ee="wrist_3_link",
+        module_name="puma560_ik",
+        arm_label="Puma 560",
+    )
+    _emit_jaco2_artifact()
+    print("done.")
+    return 0
+
+
+def _emit_urdf_artifact(
+    *, urdf: Path, base: str, ee: str, module_name: str, arm_label: str
+) -> None:
+    kb = load_urdf_kinbody_normalized(urdf, base, ee)
+    plan = dispatch(kb)
+    out = ARTIFACTS / f"{module_name}.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name=module_name,
+        output_path=str(out),
+        arm_label=arm_label,
+    )
+    print(f"  {out.relative_to(REPO_ROOT)}: {plan.solver_name} (tier {plan.tier})")
+
+
+def _emit_jaco2_artifact() -> None:
+    """JACO 2 fixture: real MJCF transcription. Lives under tests/fixtures
+    as a Python builder (jaco2.py) rather than a URDF file."""
+    sys.path.insert(0, str(FIXTURES))
+    from jaco2 import jaco2_specs
+
+    kb = build_kinbody(jaco2_specs())
+    plan = dispatch(kb)
+    out = ARTIFACTS / "jaco2_ik.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="jaco2_ik",
+        output_path=str(out),
+        arm_label="Kinova JACO 2 (j2n6s200)",
+    )
+    print(f"  {out.relative_to(REPO_ROOT)}: {plan.solver_name} (tier {plan.tier})")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -1,13 +1,35 @@
-"""ssik -- pluggable analytical inverse-kinematics library for Python."""
+"""ssik -- pluggable analytical inverse-kinematics library for Python.
+
+Logging: the package emits hierarchical logs under the ``ssik`` namespace
+(``ssik.solvers.ikgeo.three_parallel``, etc.). By default a ``NullHandler``
+suppresses all output, so importing ssik never produces unsolicited stderr
+in user applications. To see solver diagnostics, install a handler:
+
+    import logging
+    logging.getLogger("ssik").setLevel(logging.INFO)
+    logging.basicConfig()  # or supply your own handler
+
+The ``ssik build`` CLI configures this automatically via ``--verbose``.
+"""
+
+import logging as _logging
 
 from ssik._version import __version__
+from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.core.topology import TopologyReport, describe_topology
 
+# Library best practice: prevent "No handlers could be found" warnings and
+# avoid emitting any log records unless the consuming application configures
+# the ``ssik`` namespace explicitly.
+_logging.getLogger(__name__).addHandler(_logging.NullHandler())
+
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",
+    "DispatchPlan",
     "TolerancePolicy",
     "TopologyReport",
     "__version__",
     "describe_topology",
+    "dispatch",
 ]

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -1,0 +1,327 @@
+"""``ssik`` command-line interface.
+
+Two subcommands:
+
+* ``ssik classify <urdf> --base <link> --ee <link>`` -- classify topology +
+  print which solver would be picked, without emitting an artifact.
+* ``ssik build <urdf> --base <link> --ee <link> [--out <path>]`` --
+  classify, emit a per-arm artifact (\\*_ik.py), validate it on random
+  poses, and report timing.
+
+Both commands print explanatory messages by default. ``-v`` raises log
+verbosity (per-solver INFO logs); ``-vv`` shows DEBUG.
+
+The CLI uses argparse so it has no external dependency and the help
+output is self-describing (``ssik --help``, ``ssik build --help``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import logging
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.codegen import emit_artifact
+from ssik.core.dispatcher import DispatchPlan, dispatch
+from ssik.subproblems._rotation import rotation_matrix
+
+__all__ = ["main"]
+
+_VALIDATE_DEFAULT_POSES = 100
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entrypoint for the ``ssik`` console script.
+
+    :param argv: command-line args (excluding the program name). ``None``
+        defaults to ``sys.argv[1:]`` so this function is also callable from
+        tests via ``main(["build", ...])``.
+    :returns: process exit status (0 success, non-zero failure).
+    """
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    _configure_logging(args.verbose)
+    if args.command == "classify":
+        return _run_classify(args)
+    if args.command == "build":
+        return _run_build(args)
+    parser.print_help()
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# Argparse construction.
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ssik",
+        description=(
+            "Build per-arm analytical IK artifacts. Loads a URDF, classifies "
+            "the kinematic topology, picks the best ssik solver, and emits a "
+            "self-contained Python module that wraps that solver."
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase log verbosity. -v shows solver INFO logs; -vv shows DEBUG.",
+    )
+    sub = parser.add_subparsers(dest="command", required=False)
+
+    classify_parser = sub.add_parser(
+        "classify",
+        help=(
+            "Inspect a URDF: print the inferred topology and the solver "
+            "that would be selected, without emitting an artifact."
+        ),
+    )
+    _add_common_kinbody_args(classify_parser)
+
+    build_parser = sub.add_parser(
+        "build",
+        help=(
+            "Generate a per-arm IK artifact: classify the topology, render a "
+            "<arm>_ik.py wrapper around the chosen solver, and validate it on "
+            "random poses."
+        ),
+    )
+    _add_common_kinbody_args(build_parser)
+    build_parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Path for the emitted artifact. Default: <urdf-stem>_ik.py in "
+            "the current working directory."
+        ),
+    )
+    build_parser.add_argument(
+        "--module-name",
+        type=str,
+        default=None,
+        help=(
+            "Python module name for the artifact. Default: <urdf-stem>_ik. "
+            "Used as the artifact's import name and in its docstring."
+        ),
+    )
+    build_parser.add_argument(
+        "--validate-poses",
+        type=int,
+        default=_VALIDATE_DEFAULT_POSES,
+        help=(
+            f"Number of random poses to use for post-emit validation. "
+            f"Default: {_VALIDATE_DEFAULT_POSES}. Set to 0 to skip validation."
+        ),
+    )
+    build_parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip post-emit validation entirely (equivalent to --validate-poses 0).",
+    )
+    return parser
+
+
+def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("urdf", type=Path, help="Path to the URDF file.")
+    parser.add_argument(
+        "--base",
+        required=True,
+        help="Link name to treat as the base of the kinematic chain.",
+    )
+    parser.add_argument(
+        "--ee",
+        required=True,
+        help="Link name to treat as the end-effector of the kinematic chain.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logging configuration.
+# ---------------------------------------------------------------------------
+
+
+def _configure_logging(verbose_count: int) -> None:
+    """Install a stderr handler on the ``ssik`` namespace at the chosen level.
+
+    -v raises to INFO (per-solver entry/exit logs); -vv raises to DEBUG.
+    Default (0) leaves the namespace at WARNING -- only anomalous-recovery
+    messages bubble through.
+    """
+    level = logging.WARNING
+    if verbose_count == 1:
+        level = logging.INFO
+    elif verbose_count >= 2:
+        level = logging.DEBUG
+    logger = logging.getLogger("ssik")
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("[%(name)s] %(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(level)
+
+
+# ---------------------------------------------------------------------------
+# `ssik classify` -- dry-run inspection.
+# ---------------------------------------------------------------------------
+
+
+def _run_classify(args: argparse.Namespace) -> int:
+    print(f"[ssik] Loading {args.urdf}")
+    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
+    print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
+    plan = dispatch(kb)
+    _print_dispatch_summary(plan)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# `ssik build` -- end-to-end artifact emission + validation.
+# ---------------------------------------------------------------------------
+
+
+def _run_build(args: argparse.Namespace) -> int:
+    print(f"[ssik] Loading {args.urdf}")
+    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
+    print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
+
+    print("[ssik] Classifying topology")
+    plan = dispatch(kb)
+    _print_dispatch_summary(plan)
+
+    if plan.needs_symbolic_precompute and plan.estimated_precompute_seconds is not None:
+        print(
+            f"[ssik] Build-time precompute (symbolic): "
+            f"~{plan.estimated_precompute_seconds:.0f} s estimated"
+        )
+        print(
+            "[ssik]   (Phase 1 of #110: precompute still runs at first solve(); "
+            "build-time baking is Phase 2.)"
+        )
+    else:
+        print("[ssik] No build-time precompute needed (tier-0 closed-form)")
+
+    module_name = args.module_name or f"{args.urdf.stem}_ik"
+    output_path = args.out or Path.cwd() / f"{module_name}.py"
+
+    print(f"[ssik] Emitting {output_path}")
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name=module_name,
+        output_path=str(output_path),
+        arm_label=args.urdf.stem,
+    )
+    print(f"[ssik]   Wrote {len(result.source):,} bytes")
+
+    n_validate = 0 if args.no_validate else args.validate_poses
+    if n_validate > 0:
+        print(f"[ssik] Validating ({n_validate} random poses)")
+        validation = _validate_artifact(output_path, module_name, kb, n_validate)
+        if validation.failures > 0:
+            print(
+                f"[ssik]   ✗ {validation.failures}/{n_validate} poses failed FK check; "
+                f"max FK error {validation.max_fk_err:.2e}"
+            )
+            print("[ssik] Build FAILED.")
+            return 1
+        print(
+            f"[ssik]   ✓ {n_validate} poses, median {validation.median_ms:.3f} ms, "
+            f"max FK error {validation.max_fk_err:.2e}, 0 failures"
+        )
+    else:
+        print("[ssik] Validation skipped")
+
+    print("[ssik] ✓ Done. Try:")
+    print(f"[ssik]     >>> import {module_name}")
+    print(f"[ssik]     >>> sols, is_ls = {module_name}.solve(T_target)")
+    return 0
+
+
+def _print_dispatch_summary(plan: DispatchPlan) -> None:
+    print(f"[ssik]   → Best solver: {plan.solver_name} (tier {plan.tier})")
+    print(f"[ssik]   → Expected median IK time: ~{plan.expected_ms_median} ms")
+    print(f"[ssik]   → FLOP budget: ~{plan.flop_budget:,} FLOPs / solve")
+    print("[ssik]   → Reasoning:")
+    for line in plan.reason.splitlines():
+        print(f"[ssik]       {line}")
+
+
+# ---------------------------------------------------------------------------
+# Post-emit validation.
+# ---------------------------------------------------------------------------
+
+
+class _ValidationResult:
+    __slots__ = ("failures", "max_fk_err", "median_ms")
+
+    def __init__(self, *, failures: int, max_fk_err: float, median_ms: float) -> None:
+        self.failures = failures
+        self.max_fk_err = max_fk_err
+        self.median_ms = median_ms
+
+
+def _validate_artifact(
+    artifact_path: Path,
+    module_name: str,
+    kb_source: object,
+    n_poses: int,
+) -> _ValidationResult:
+    """Import the emitted artifact, run ``n_poses`` random IK solves, verify
+    every returned solution closes FK against the seeded target."""
+    spec = importlib.util.spec_from_file_location(f"_ssik_validate_{module_name}", artifact_path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    rng = np.random.default_rng(seed=0)
+    n_dof = len(kb_source.joints)  # type: ignore[attr-defined]
+    times: list[float] = []
+    fk_errs: list[float] = []
+    failures = 0
+    for _ in range(n_poses):
+        q_star = rng.uniform(-1.0, 1.0, size=n_dof)
+        T_star = _fk_poe(kb_source, q_star)
+        t0 = time.perf_counter()
+        sols, is_ls = mod.solve(T_star)
+        times.append((time.perf_counter() - t0) * 1e3)
+        if is_ls or not sols:
+            failures += 1
+            continue
+        worst = 0.0
+        for sol in sols:
+            T_check = _fk_poe(kb_source, sol.q)
+            err = float(np.linalg.norm(T_check - T_star))
+            worst = max(worst, err)
+        fk_errs.append(worst)
+        if worst > 1e-6:
+            failures += 1
+    return _ValidationResult(
+        failures=failures,
+        max_fk_err=(max(fk_errs) if fk_errs else float("nan")),
+        median_ms=float(np.median(times)),
+    )
+
+
+def _fk_poe(kb: object, q: np.ndarray) -> np.ndarray:
+    """POE forward kinematics matching the artifact's representation."""
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):  # type: ignore[attr-defined]
+        rot = np.eye(4)
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
+        T = T @ j.T_left @ rot @ j.T_right
+    return T
+
+
+if __name__ == "__main__":  # pragma: no cover -- entry-point
+    sys.exit(main())

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -1,0 +1,309 @@
+"""Per-arm artifact emission. Renders a self-contained Python module that
+wraps the dispatched solver around baked KinBody constants.
+
+The emitted artifact is a single ``.py`` file with a stable public API:
+
+    >>> import ur5_ik
+    >>> solutions, is_ls = ur5_ik.solve(T_target)
+
+Internals: the emitted module imports the chosen ssik solver, reconstructs
+the POE-normalised :class:`KinBody` from baked numpy literals at import
+time, and exports ``solve(T) -> (list[Solution], bool)`` plus
+``SOLVER_NAME`` and ``DISPATCH_REASON`` constants for diagnostic visibility.
+
+This iteration emits source that has ``ssik`` as a runtime dependency. The
+forthcoming Cython port emits the equivalent compiled artifact under the
+same import-and-call API; the build CLI gains a flag to switch targets.
+
+For tier-2 ``general_6r`` arms today, the artifact's ``solve()`` triggers
+the lazy sympy preprocessing on first call (the existing behaviour). Phase
+2 of #110 bakes that preprocessing output into the artifact at build time
+so first-call latency is gone.
+"""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from dataclasses import dataclass
+from io import StringIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from ssik._kinbody import KinBody
+    from ssik.core.dispatcher import DispatchPlan
+
+__all__ = ["EmissionResult", "emit_artifact"]
+
+_LOG = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class EmissionResult:
+    """What :func:`emit_artifact` produced.
+
+    The CLI prints ``output_path`` and uses ``module_name`` for the "to
+    use it: ``import <module_name>``" line. Tests assert against
+    ``source`` directly (the rendered file content) so they don't have
+    to write to disk.
+    """
+
+    module_name: str
+    """Python module name, e.g. ``ur5_ik`` (no ``.py`` suffix)."""
+
+    output_path: str | None
+    """Filesystem path the artifact was written to, or ``None`` if the
+    caller asked for source-only emission."""
+
+    source: str
+    """Full rendered source of the artifact (also written to disk if
+    ``output_path`` is set)."""
+
+
+def emit_artifact(
+    *,
+    kb: KinBody,
+    plan: DispatchPlan,
+    module_name: str,
+    output_path: str | None = None,
+    arm_label: str | None = None,
+) -> EmissionResult:
+    """Render a per-arm IK module that wraps the dispatched solver.
+
+    :param kb: a POE-normalised :class:`KinBody` (the one passed to
+        :func:`ssik.dispatch`).
+    :param plan: dispatch result describing which solver to import and the
+        explanatory diagnostic to bake into the artifact's docstring.
+    :param module_name: stem for the emitted module (``ur5_ik``,
+        ``jaco2_ik``, ...). Used in the artifact's header comment.
+    :param output_path: where to write the rendered source. ``None`` means
+        return source only without touching disk -- useful in tests and
+        when the caller wants to post-process before writing.
+    :param arm_label: optional human-readable arm name to embed in the
+        artifact header (``"UR5"``, ``"Kinova JACO 2"``). Defaults to
+        the module name.
+    :returns: :class:`EmissionResult` carrying the rendered source and the
+        path where it landed (if any).
+    """
+    label = arm_label or module_name
+    source = _render(kb=kb, plan=plan, module_name=module_name, arm_label=label)
+    if output_path is not None:
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(source)
+        _LOG.info(
+            "codegen: emitted %s (%d bytes) for %s -> %s",
+            module_name,
+            len(source),
+            plan.solver_name,
+            output_path,
+        )
+    else:
+        _LOG.info(
+            "codegen: rendered %s (%d bytes, in-memory) for %s",
+            module_name,
+            len(source),
+            plan.solver_name,
+        )
+    return EmissionResult(
+        module_name=module_name,
+        output_path=output_path,
+        source=source,
+    )
+
+
+# Maps the dispatcher's solver_name (e.g. ``ikgeo.three_parallel``) onto the
+# fully-qualified Python module path under :mod:`ssik.solvers` that the
+# emitted artifact will import.
+_SOLVER_IMPORT_PATHS: dict[str, str] = {
+    "ikgeo.three_parallel": "ssik.solvers.ikgeo.three_parallel",
+    "ikgeo.spherical_two_parallel": "ssik.solvers.ikgeo.spherical_two_parallel",
+    "ikgeo.spherical_two_intersecting": "ssik.solvers.ikgeo.spherical_two_intersecting",
+    "ikgeo.spherical": "ssik.solvers.ikgeo.spherical",
+    "ikgeo.two_parallel": "ssik.solvers.ikgeo.two_parallel",
+    "ikgeo.two_intersecting": "ssik.solvers.ikgeo.two_intersecting",
+    "ikgeo.general_6r": "ssik.solvers.ikgeo.general_6r",
+    "ikgeo.gen_six_dof": "ssik.solvers.ikgeo.gen_six_dof",
+}
+
+
+def _render(*, kb: KinBody, plan: DispatchPlan, module_name: str, arm_label: str) -> str:
+    """Render the artifact source as a single string."""
+    solver_module = _SOLVER_IMPORT_PATHS[plan.solver_name]
+    solver_short = plan.solver_name.split(".")[-1]
+
+    buf = StringIO()
+    buf.write(_render_header(module_name, arm_label, plan))
+    buf.write("\n\nfrom __future__ import annotations\n\n")
+    buf.write("import numpy as np\n\n")
+    buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
+    buf.write("from ssik.core.solution import Solution\n")
+    buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
+    buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
+    buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
+    buf.write(f"SOLVER_TIER = {plan.tier}\n")
+    buf.write(f"EXPECTED_MS_MEDIAN = {plan.expected_ms_median!r}\n")
+    buf.write(f"FLOP_BUDGET = {plan.flop_budget}\n")
+    buf.write(_render_dispatch_reason(plan.reason))
+    buf.write("\n")
+    buf.write(_render_kinbody_constants(kb))
+    buf.write("\n")
+    buf.write(_render_kinbody_builder())
+    buf.write("\n")
+    buf.write(_render_solve_function(solver_short))
+    buf.write("\n")
+    buf.write(_render_all_export())
+    return buf.getvalue()
+
+
+def _render_header(module_name: str, arm_label: str, plan: DispatchPlan) -> str:
+    """Top-of-file docstring with provenance + usage."""
+    return textwrap.dedent(
+        f'''\
+        """Generated IK module for {arm_label}.
+
+        This file was emitted by ``ssik build`` and is the public artifact for
+        running analytical inverse kinematics on this specific arm. The
+        per-arm KinBody constants are baked in below; you do not need to
+        load a URDF or MJCF at runtime.
+
+        Solver: ``{plan.solver_name}`` (tier {plan.tier})
+        Expected median IK time: ~{plan.expected_ms_median} ms on commodity
+        single-thread hardware. FLOP budget: {plan.flop_budget:,} per solve.
+
+        Usage:
+
+            import {module_name}
+            import numpy as np
+            T_target = np.eye(4)  # 4x4 SE(3) pose
+            T_target[:3, 3] = [0.5, 0.1, 0.3]
+            solutions, is_ls = {module_name}.solve(T_target)
+            for sol in solutions:
+                print(sol.q, sol.fk_residual)
+
+        ``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
+        signals that no solution closed within the solver's FK tolerance,
+        and the returned list is the best-LS approximation (or empty).
+        """'''
+    )
+
+
+def _render_dispatch_reason(reason: str) -> str:
+    """Bake the dispatcher's explanatory diagnostic as a module-level constant."""
+    # ``repr`` keeps newlines and quoting safe inside the rendered source.
+    return f"DISPATCH_REASON = {reason!r}\n"
+
+
+def _render_kinbody_constants(kb: KinBody) -> str:
+    """Emit the joint axes / T_left / T_right matrices as numpy literals."""
+    lines: list[str] = []
+    lines.append("# --- baked KinBody constants ---\n")
+    lines.append(f"_LINK_NAMES = {[link.name for link in kb.links]!r}\n")
+    lines.append("_JOINT_NAMES = [")
+    for j in kb.joints:
+        lines.append(f"    {j.name!r},")
+    lines.append("]\n")
+    lines.append("_JOINT_AXES = [")
+    for j in kb.joints:
+        lines.append(f"    np.array({j.axis.tolist()!r}, dtype=np.float64),")
+    lines.append("]\n")
+    lines.append("_JOINT_T_LEFTS = [")
+    for j in kb.joints:
+        lines.append(f"    np.array({j.T_left.tolist()!r}, dtype=np.float64),")
+    lines.append("]\n")
+    lines.append("_JOINT_T_RIGHTS = [")
+    for j in kb.joints:
+        lines.append(f"    np.array({j.T_right.tolist()!r}, dtype=np.float64),")
+    lines.append("]\n")
+    lines.append("_JOINT_TYPES = [")
+    for j in kb.joints:
+        lines.append(f"    {j.joint_type!r},")
+    lines.append("]\n")
+    return "\n".join(lines)
+
+
+def _render_kinbody_builder() -> str:
+    """Emit the function that reconstructs the baked :class:`KinBody`."""
+    return textwrap.dedent(
+        """\
+
+        def _build_kb() -> KinBody:
+            \"\"\"Reconstruct the baked KinBody. Run once at module import.\"\"\"
+            links = [Link(name=n) for n in _LINK_NAMES]
+            joints = [
+                Joint(
+                    name=_JOINT_NAMES[i],
+                    dof_index=i,
+                    parent_link=links[i],
+                    T_left=_JOINT_T_LEFTS[i],
+                    T_right=_JOINT_T_RIGHTS[i],
+                    axis=_JOINT_AXES[i],
+                    joint_type=_JOINT_TYPES[i],
+                )
+                for i in range(len(_JOINT_NAMES))
+            ]
+            return KinBody(links=links, joints=joints)
+
+
+        _KB = _build_kb()
+        """
+    )
+
+
+def _render_solve_function(solver_short: str) -> str:
+    """Emit the public ``solve`` callable wrapping the chosen ssik solver."""
+    return textwrap.dedent(
+        f"""\
+
+        def solve(
+            T_target,
+            *,
+            policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+            allow_refinement: bool = False,
+            refinement_max_iters: int = 15,
+        ):
+            \"\"\"Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+
+            :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+            :param policy: tolerance policy. Pass a custom
+                :class:`ssik.TolerancePolicy` to tighten or relax the
+                FK-closure threshold (``subproblem_numerical``), the
+                axis-parallel / axis-intersect predicates, etc. Defaults to
+                :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
+            :param allow_refinement: opt into Newton-on-spatial-Jacobian
+                polish for near-miss algebraic candidates. Default ``False``;
+                turn on to recover candidates that don't quite meet
+                ``policy.subproblem_numerical`` on their own (e.g. near
+                kinematic singularities).
+            :param refinement_max_iters: cap on Newton iterations per
+                candidate when ``allow_refinement=True``.
+            :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
+                vector matching the source URDF's joint ordering;
+                ``solution.fk_residual`` reports closure against
+                ``T_target``. ``is_ls=True`` iff the algebraic path produced
+                no candidate meeting the FK tolerance -- callers wanting
+                only "exact" solutions check ``is_ls`` and discard.
+
+            Solver: {solver_short}.
+            \"\"\"
+            return _solver_solve(
+                _KB,
+                T_target,
+                policy=policy,
+                allow_refinement=allow_refinement,
+                refinement_max_iters=refinement_max_iters,
+            )
+        """
+    )
+
+
+def _render_all_export() -> str:
+    return (
+        "\n__all__ = ["
+        '\n    "DISPATCH_REASON",'
+        '\n    "EXPECTED_MS_MEDIAN",'
+        '\n    "FLOP_BUDGET",'
+        '\n    "SOLVER_NAME",'
+        '\n    "SOLVER_TIER",'
+        '\n    "solve",'
+        "\n]\n"
+    )

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -1,0 +1,267 @@
+"""Solver dispatcher: classify a KinBody and pick the best ssik solver.
+
+Pure function:
+
+    KinBody -> DispatchPlan
+
+The :class:`DispatchPlan` is the structured handoff between the topology
+classifier and the rest of the build pipeline. It carries everything the CLI
+needs to print explanatory output and everything the codegen module needs to
+emit a per-arm artifact:
+
+* ``solver_name``: dotted module path of the chosen solver (e.g.
+  ``ikgeo.three_parallel``).
+* ``tier``: 0 closed-form, 1 univariate-search, 2 numeric Raghavan-Roth.
+* ``reason``: human-readable explanation of which structural conditions
+  matched and why this solver was preferred over its siblings.
+* ``expected_ms_median``, ``flop_budget``: rough order-of-magnitude
+  estimates from the speed-pass benches (#93). For showing users "expect
+  ~X ms / IK on commodity hardware" before they run the artifact.
+* ``needs_symbolic_precompute``: True iff the chosen solver runs a sympy
+  preprocessing step. Tier-2 RR triggers this; tier-0/1 do not.
+* ``estimated_precompute_seconds``: rough cold-cache time when applicable.
+
+Dispatch decision order (best to worst):
+
+1. Three consecutive parallel axes at (1, 2, 3) -> ``three_parallel``.
+2. Three consecutive intersecting axes at (3, 4, 5):
+   - + axes[1] || axes[2] -> ``spherical_two_parallel``.
+   - + p[1] near zero      -> ``spherical_two_intersecting``.
+   - else                  -> ``spherical``.
+3. otherwise               -> ``general_6r`` (tier-2 Raghavan-Roth).
+
+**Tier-1 univariate-search solvers (``two_parallel``, ``two_intersecting``)
+are not auto-dispatched.** They run a 200-sample 1D grid + inner SPx per
+sample and benchmark at 100s-of-ms to seconds per IK; the production tier-2
+path (Raghavan-Roth + AE-3) handles the same chains in ~5 ms. Tier-1
+solvers remain importable for users who want them explicitly, but they're
+strictly slower than tier-2 RR on every measured workload.
+
+Concretely: JACO 2 has ``axes[1] || axes[2]`` (parallel shoulder) but no
+spherical wrist (60-degree non-orthogonal twist at joints 4-5). The naive
+ordering would route it through ``two_parallel`` at ~261 ms median; instead
+we route it through ``general_6r`` at ~5 ms median (#85). The 50x-200x
+difference is consistent across non-Pieper geometries.
+
+This dispatcher will eventually be shared with
+:mod:`ssik.solvers.jointlock.seven_r` (which still routes its tier-2 fallback
+through the slower ``gen_six_dof`` oracle); that consolidation is tracked as
+a follow-up to #110.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+
+from ssik._kinbody import KinBody
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.predicates import (
+    axis_parallel,
+    three_consecutive_intersecting,
+    three_consecutive_parallel,
+)
+
+__all__ = ["DispatchPlan", "dispatch"]
+
+_LOG = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class DispatchPlan:
+    """Result of solver-classification on a POE-normalized KinBody.
+
+    Returned by :func:`dispatch`. The ``reason`` is the canonical user-facing
+    explanation; tests assert on the structured fields, the CLI renders the
+    ``reason`` text. Numeric fields are rough estimates from the #93 speed
+    pass on Apple M3 single-thread; treat as "expect this order of
+    magnitude," not a contract.
+    """
+
+    solver_name: str
+    """Dotted path under :mod:`ssik.solvers` (e.g. ``ikgeo.three_parallel``)."""
+
+    tier: int
+    """0 closed-form, 1 univariate-search, 2 numeric Raghavan-Roth."""
+
+    reason: str
+    """Multi-line human-readable explanation. Suitable for printing as-is."""
+
+    expected_ms_median: float
+    """Approximate median wall-clock per IK on commodity x86 / Apple M3."""
+
+    flop_budget: int
+    """Approximate machine-invariant FLOPs per IK (#93)."""
+
+    needs_symbolic_precompute: bool
+    """True iff the solver runs sympy preprocessing during build/first call."""
+
+    estimated_precompute_seconds: float | None
+    """Rough cold-cache time when ``needs_symbolic_precompute=True``."""
+
+
+# Per-solver order-of-magnitude estimates measured on Apple M3 single-thread,
+# Python+numpy, post-#93 speed pass. These are the user-facing "expect ~Xms"
+# numbers; codegen also bakes them into the emitted artifact's docstring.
+_SOLVER_ESTIMATES: dict[str, tuple[int, float, int]] = {
+    # solver_name -> (tier, expected_ms_median, flop_budget)
+    "ikgeo.three_parallel": (0, 1.6, 2_519),
+    "ikgeo.spherical_two_parallel": (0, 1.2, 1_316),
+    "ikgeo.spherical_two_intersecting": (0, 1.3, 1_476),
+    "ikgeo.spherical": (0, 7.5, 10_312),
+    "ikgeo.two_parallel": (1, 261.0, 141_569),
+    "ikgeo.two_intersecting": (1, 1184.0, 2_650_681),
+    "ikgeo.general_6r": (2, 5.0, 30_000_000),
+    "ikgeo.gen_six_dof": (2, 26_800.0, 31_478_656),
+}
+
+
+def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) -> DispatchPlan:
+    """Classify a 6R or 7R chain and pick the best ssik solver.
+
+    :param kb: a POE-normalized :class:`KinBody`. Pass the result of
+        :func:`ssik._urdf.load_urdf_kinbody_normalized` (or your MJCF/DH
+        equivalent). Non-normalized inputs produce undefined results.
+    :param policy: tolerance policy controlling the predicates' axis-parallel
+        / axis-intersect thresholds. Defaults to
+        :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+    :returns: a :class:`DispatchPlan` describing the chosen solver, the
+        topology evidence, expected speed, and FLOP budget.
+    :raises ValueError: if the chain is not 6R (this iteration). 7R support
+        via :mod:`ssik.solvers.jointlock.seven_r` is a follow-up.
+    """
+    if len(kb.joints) != 6:
+        raise ValueError(
+            f"dispatch currently supports 6-DOF chains only; "
+            f"got {len(kb.joints)} joints. (7R support via jointlock.seven_r "
+            "lands in a follow-up to #110.)"
+        )
+
+    parallel_triple = three_consecutive_parallel(kb.joints, policy)
+    intersecting_triple = three_consecutive_intersecting(kb.joints, policy)
+    j12_parallel = axis_parallel(kb.joints[1].axis, kb.joints[2].axis, policy)
+    p1_norm = float(np.linalg.norm(kb.joints[1].T_left[:3, 3]))
+    p1_on_axis = p1_norm < policy.axis_intersect
+
+    # Tier 0 -- three consecutive parallel (UR class).
+    if parallel_triple == (1, 2, 3):
+        plan = _make_plan(
+            "ikgeo.three_parallel",
+            reason=(
+                "Three consecutive parallel axes at joints (1, 2, 3) -- the "
+                "UR-class structure (UR3 / UR5 / UR10).\n"
+                "Closed-form via SP6 (joints 0+4) + SP1 + SP3."
+            ),
+            needs_symbolic_precompute=False,
+        )
+        _LOG.info("dispatch: chose %s (tier 0)", plan.solver_name)
+        return plan
+
+    # Tier 0 -- spherical wrist (Pieper class).
+    if intersecting_triple == (3, 4, 5):
+        if j12_parallel and p1_on_axis:
+            # Both shoulder specializations match (Puma-560 case). Prefer the
+            # parallel-shoulder solver -- typically smaller IK set and slightly
+            # tighter conditioning on the SP3 elbow constraint.
+            plan = _make_plan(
+                "ikgeo.spherical_two_parallel",
+                reason=(
+                    "Spherical wrist at joints (3, 4, 5) AND axes[1] parallel "
+                    "to axes[2] AND ||p[1]|| ~= 0.\n"
+                    "Both Pieper specialisations apply (e.g. Puma 560); the "
+                    "parallel-shoulder solver is preferred for slightly tighter "
+                    "elbow conditioning."
+                ),
+                needs_symbolic_precompute=False,
+            )
+        elif j12_parallel:
+            plan = _make_plan(
+                "ikgeo.spherical_two_parallel",
+                reason=(
+                    "Spherical wrist at joints (3, 4, 5) AND axes[1] parallel "
+                    "to axes[2].\n"
+                    "Closed-form via SP4 (shoulder) + SP3 (elbow) + SP1 (wrist). "
+                    "Covers most industrial 6R arms (Puma, Fanuc LR/CR, KUKA KR)."
+                ),
+                needs_symbolic_precompute=False,
+            )
+        elif p1_on_axis:
+            plan = _make_plan(
+                "ikgeo.spherical_two_intersecting",
+                reason=(
+                    "Spherical wrist at joints (3, 4, 5) AND ||p[1]|| ~= 0 "
+                    "(joints 0 and 1 share an origin).\n"
+                    "Closed-form via SP3 + SP2 + SP4 + SP1. Compact-base arms "
+                    "(IRB120-class, lite6/xArm6 subfamilies)."
+                ),
+                needs_symbolic_precompute=False,
+            )
+        else:
+            plan = _make_plan(
+                "ikgeo.spherical",
+                reason=(
+                    "Spherical wrist at joints (3, 4, 5), no shoulder "
+                    "specialisation.\n"
+                    "Closed-form via SP5 (shoulder) + SP4 (wrist) + SP1. "
+                    "Generic spherical-wrist fallback; rarely matches "
+                    "commercial geometry."
+                ),
+                needs_symbolic_precompute=False,
+            )
+        _LOG.info("dispatch: chose %s (tier 0)", plan.solver_name)
+        return plan
+
+    # Tier 2 -- production Raghavan-Roth path. The EAIK gap.
+    #
+    # Skips tier-1 univariate-search solvers: those run a 200-sample 1D grid
+    # plus an inner SP5/SP6 call per sample and benchmark at 100s-of-ms to
+    # seconds, while RR handles the same chains at ~5ms. See module docstring
+    # for the JACO 2 example and the speed comparison.
+    weak_match_notes = []
+    if j12_parallel:
+        weak_match_notes.append(
+            "axes[1] parallel to axes[2] (would match tier-1 `two_parallel`, "
+            "but tier-2 RR is ~50x faster)"
+        )
+    if float(np.linalg.norm(kb.joints[5].T_left[:3, 3])) < policy.axis_intersect:
+        weak_match_notes.append(
+            "||p[5]|| ~= 0 (would match tier-1 `two_intersecting`, but tier-2 RR is ~200x faster)"
+        )
+    weak_block = (
+        "\nWeaker structural matches (not used):\n  - " + "\n  - ".join(weak_match_notes)
+        if weak_match_notes
+        else ""
+    )
+    plan = _make_plan(
+        "ikgeo.general_6r",
+        reason=(
+            "No tier-0 (Pieper-class) match.\n"
+            "Tier-2 numeric Raghavan-Roth + Manocha-Canny pipeline with AE-3 "
+            "leftvar selection. Closes the EAIK coverage gap (Kinova JACO 2 "
+            "classical, Agilex Piper, custom non-Pieper 6R)." + weak_block
+        ),
+        needs_symbolic_precompute=True,
+    )
+    _LOG.info("dispatch: chose %s (tier 2)", plan.solver_name)
+    return plan
+
+
+def _make_plan(solver_name: str, *, reason: str, needs_symbolic_precompute: bool) -> DispatchPlan:
+    """Assemble a :class:`DispatchPlan` from per-solver estimates + caller fields."""
+    tier, ms, flops = _SOLVER_ESTIMATES[solver_name]
+    # Symbolic precompute time estimate -- only applies to tier-2 RR currently.
+    # 150-300 s on JACO 2 today; report a single midpoint estimate for the
+    # build CLI's ETA. Real per-arm time depends on linearity-joint search
+    # hits and sympy version; the build pass measures it precisely.
+    precompute_s = 240.0 if needs_symbolic_precompute else None
+    return DispatchPlan(
+        solver_name=solver_name,
+        tier=tier,
+        reason=reason,
+        expected_ms_median=ms,
+        flop_budget=flops,
+        needs_symbolic_precompute=needs_symbolic_precompute,
+        estimated_precompute_seconds=precompute_s,
+    )

--- a/src/ssik/solvers/ikgeo/gen_six_dof.py
+++ b/src/ssik/solvers/ikgeo/gen_six_dof.py
@@ -35,6 +35,8 @@ arms that match no specialisation.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -50,6 +52,7 @@ __all__ = ["solve"]
 
 _GRID_N = 100
 _SOLVER_NAME = "ikgeo.gen_six_dof"
+_LOG = logging.getLogger(__name__)
 
 
 def solve(
@@ -137,6 +140,14 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates from %d 2D-grid minima -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(minima),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/general_6r.py
+++ b/src/ssik/solvers/ikgeo/general_6r.py
@@ -34,6 +34,8 @@ back-substitute typically ~ms, vs. minutes for the 100x100 grid).
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -42,6 +44,8 @@ from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_to_dh import poe_to_dh
 from ssik.solvers.ikgeo._raghavan_roth import solve_all_ik
+
+_LOG = logging.getLogger(__name__)
 
 __all__ = ["solve"]
 
@@ -119,4 +123,11 @@ def solve(
             )
         )
 
+    _LOG.info(
+        "%s: %d inner candidates -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(inner_solutions),
+        len(solutions),
+        len(solutions) == 0,
+    )
     return solutions, len(solutions) == 0

--- a/src/ssik/solvers/ikgeo/spherical.py
+++ b/src/ssik/solvers/ikgeo/spherical.py
@@ -50,6 +50,8 @@ docstring for the POE + ``R_home`` + wrist-consolidation convention.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -64,6 +66,7 @@ from ssik.subproblems._rotation import rotation_matrix
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical"
+_LOG = logging.getLogger(__name__)
 
 
 def solve(
@@ -178,6 +181,13 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
@@ -46,6 +46,8 @@ uses the same.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -60,6 +62,7 @@ from ssik.subproblems._rotation import rotation_matrix
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical_two_intersecting"
+_LOG = logging.getLogger(__name__)
 
 
 def solve(
@@ -182,6 +185,13 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/spherical_two_parallel.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_parallel.py
@@ -51,6 +51,8 @@ IK-Geo reference expects a single consolidated offset there). We sum them.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -65,6 +67,7 @@ from ssik.subproblems._rotation import rotation_matrix
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.spherical_two_parallel"
+_LOG = logging.getLogger(__name__)
 
 
 def solve(
@@ -207,6 +210,13 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -37,6 +37,8 @@ Up to 8 IK solutions per target pose (2 shoulder-pan x 2 wrist-pitch x
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -51,6 +53,7 @@ from ssik.subproblems._rotation import rotate, rotation_matrix
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.three_parallel"
+_LOG = logging.getLogger(__name__)
 
 
 def _wrap_to_pi(angle: float) -> float:
@@ -173,6 +176,13 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/two_intersecting.py
@@ -40,6 +40,8 @@ spherical-wrist siblings don't match.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -55,6 +57,7 @@ __all__ = ["solve"]
 
 _SEARCH_SAMPLES = 200
 _SOLVER_NAME = "ikgeo.two_intersecting"
+_LOG = logging.getLogger(__name__)
 
 
 def solve(
@@ -150,6 +153,14 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates from %d q4-search branches -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(q4_branches),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/ikgeo/two_parallel.py
+++ b/src/ssik/solvers/ikgeo/two_parallel.py
@@ -14,6 +14,8 @@ Algorithm: port of the BSD-3 [ik-geo Rust reference][ikgeo]'s
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -30,6 +32,7 @@ __all__ = ["solve"]
 
 _SEARCH_SAMPLES = 200
 _SOLVER_NAME = "ikgeo.two_parallel"
+_LOG = logging.getLogger(__name__)
 
 
 def _wrap_to_pi(angle: float) -> float:
@@ -139,6 +142,14 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+    )
+    _LOG.info(
+        "%s: %d candidates from %d q1-search branches -> %d solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        len(candidates),
+        len(q1_and_branch),
+        len(solutions),
+        len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
 

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -30,6 +30,7 @@ is the "works now, works everywhere" fallback.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from dataclasses import replace
 
@@ -60,6 +61,7 @@ __all__ = ["choose_lock_joint", "solve"]
 
 _DEFAULT_SAMPLES = 16
 _SOLVER_NAME = "jointlock.seven_r"
+_LOG = logging.getLogger(__name__)
 
 
 def _lock_joint(kb: KinBody, lock_idx: int, q_lock: float) -> KinBody:
@@ -315,4 +317,13 @@ def solve(
             )
 
     solutions = dedup_by_wrap_close(candidates, dedup_tol)
+    _LOG.info(
+        "%s: lock_idx=%d, %d samples -> %d candidates -> %d unique solutions (is_ls=%s)",
+        _SOLVER_NAME,
+        lock_idx,
+        len(samples),
+        len(candidates),
+        len(solutions),
+        len(solutions) == 0,
+    )
     return solutions, len(solutions) == 0

--- a/tests/artifacts/jaco2_ik.py
+++ b/tests/artifacts/jaco2_ik.py
@@ -1,0 +1,160 @@
+"""Generated IK module for Kinova JACO 2 (j2n6s200).
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Solver: ``ikgeo.general_6r`` (tier 2)
+Expected median IK time: ~5.0 ms on commodity
+single-thread hardware. FLOP budget: 30,000,000 per solve.
+
+Usage:
+
+    import jaco2_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions, is_ls = jaco2_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
+signals that no solution closed within the solver's FK tolerance,
+and the returned list is the best-LS approximation (or empty).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.solvers.ikgeo.general_6r import solve as _solver_solve
+
+SOLVER_NAME = "ikgeo.general_6r"
+SOLVER_TIER = 2
+EXPECTED_MS_MEDIAN = 5.0
+FLOP_BUDGET = 30000000
+DISPATCH_REASON = 'No tier-0 (Pieper-class) match.\nTier-2 numeric Raghavan-Roth + Manocha-Canny pipeline with AE-3 leftvar selection. Closes the EAIK coverage gap (Kinova JACO 2 classical, Agilex Piper, custom non-Pieper 6R).\nWeaker structural matches (not used):\n  - axes[1] parallel to axes[2] (would match tier-1 `two_parallel`, but tier-2 RR is ~50x faster)'
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['base_link', 'link_1', 'link_2', 'link_3', 'link_4', 'link_5', 'ee_link']
+
+_JOINT_NAMES = [
+    'j2n6s200_joint_1',
+    'j2n6s200_joint_2',
+    'j2n6s200_joint_3',
+    'j2n6s200_joint_4',
+    'j2n6s200_joint_5',
+    'j2n6s200_joint_6',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[-1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, -1.0, 0.15675], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-0.9999999999999996, -0.0, 0.0, 0.0], [0.0, 2.220446049250313e-16, -0.9999999999999998, 0.0016], [0.0, -0.9999999999999998, 2.220446049250313e-16, -0.11875], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -0.41], [0.0, 0.0, -1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-0.9999999999999996, -0.0, 0.0, 0.0], [0.0, 2.220446049250313e-16, -0.9999999999999998, 0.2073], [0.0, -0.9999999999999998, 2.220446049250313e-16, -0.0114], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-1.0, 0.0, 0.0, 0.0], [0.0, -0.49999965031225546, 0.866025605676658, -0.03703], [0.0, 0.866025605676658, 0.49999965031225535, -0.06414], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-1.0, 0.0, 0.0, 0.0], [0.0, -0.49999965031225546, 0.866025605676658, -0.03703], [0.0, 0.866025605676658, 0.49999965031225535, -0.06414], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[2.220446049250313e-16, 0.9999999999999998, 0.0, 0.0], [0.9999999999999998, 2.220446049250313e-16, 0.0, 0.0], [0.0, 0.0, -0.9999999999999996, -0.16], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+def solve(
+    T_target,
+    *,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+):
+    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+    :param policy: tolerance policy. Pass a custom
+        :class:`ssik.TolerancePolicy` to tighten or relax the
+        FK-closure threshold (``subproblem_numerical``), the
+        axis-parallel / axis-intersect predicates, etc. Defaults to
+        :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss algebraic candidates. Default ``False``;
+        turn on to recover candidates that don't quite meet
+        ``policy.subproblem_numerical`` on their own (e.g. near
+        kinematic singularities).
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
+        vector matching the source URDF's joint ordering;
+        ``solution.fk_residual`` reports closure against
+        ``T_target``. ``is_ls=True`` iff the algebraic path produced
+        no candidate meeting the FK tolerance -- callers wanting
+        only "exact" solutions check ``is_ls`` and discard.
+
+    Solver: general_6r.
+    """
+    return _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
+    )
+
+
+__all__ = [
+    "DISPATCH_REASON",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "solve",
+]

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -1,0 +1,160 @@
+"""Generated IK module for Puma 560.
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Solver: ``ikgeo.spherical_two_parallel`` (tier 0)
+Expected median IK time: ~1.2 ms on commodity
+single-thread hardware. FLOP budget: 1,316 per solve.
+
+Usage:
+
+    import puma560_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions, is_ls = puma560_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
+signals that no solution closed within the solver's FK tolerance,
+and the returned list is the best-LS approximation (or empty).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.solvers.ikgeo.spherical_two_parallel import solve as _solver_solve
+
+SOLVER_NAME = "ikgeo.spherical_two_parallel"
+SOLVER_TIER = 0
+EXPECTED_MS_MEDIAN = 1.2
+FLOP_BUDGET = 1316
+DISPATCH_REASON = 'Spherical wrist at joints (3, 4, 5) AND axes[1] parallel to axes[2] AND ||p[1]|| ~= 0.\nBoth Pieper specialisations apply (e.g. Puma 560); the parallel-shoulder solver is preferred for slightly tighter elbow conditioning.'
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['base_link', '_poe_link_1', '_poe_link_2', '_poe_link_3', '_poe_link_4', '_poe_link_5', 'wrist_3_link']
+
+_JOINT_NAMES = [
+    'joint_1',
+    'joint_2',
+    'joint_3',
+    'joint_4',
+    'joint_5',
+    'joint_6',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.4318], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.020299999999999985], [0.0, 1.0, 0.0, -0.15005], [0.0, 0.0, 1.0, 9.187912610603016e-18], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.4318], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+def solve(
+    T_target,
+    *,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+):
+    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+    :param policy: tolerance policy. Pass a custom
+        :class:`ssik.TolerancePolicy` to tighten or relax the
+        FK-closure threshold (``subproblem_numerical``), the
+        axis-parallel / axis-intersect predicates, etc. Defaults to
+        :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss algebraic candidates. Default ``False``;
+        turn on to recover candidates that don't quite meet
+        ``policy.subproblem_numerical`` on their own (e.g. near
+        kinematic singularities).
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
+        vector matching the source URDF's joint ordering;
+        ``solution.fk_residual`` reports closure against
+        ``T_target``. ``is_ls=True`` iff the algebraic path produced
+        no candidate meeting the FK tolerance -- callers wanting
+        only "exact" solutions check ``is_ls`` and discard.
+
+    Solver: spherical_two_parallel.
+    """
+    return _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
+    )
+
+
+__all__ = [
+    "DISPATCH_REASON",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "solve",
+]

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -1,0 +1,160 @@
+"""Generated IK module for UR5.
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Solver: ``ikgeo.three_parallel`` (tier 0)
+Expected median IK time: ~1.6 ms on commodity
+single-thread hardware. FLOP budget: 2,519 per solve.
+
+Usage:
+
+    import ur5_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions, is_ls = ur5_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
+signals that no solution closed within the solver's FK tolerance,
+and the returned list is the best-LS approximation (or empty).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.solvers.ikgeo.three_parallel import solve as _solver_solve
+
+SOLVER_NAME = "ikgeo.three_parallel"
+SOLVER_TIER = 0
+EXPECTED_MS_MEDIAN = 1.6
+FLOP_BUDGET = 2519
+DISPATCH_REASON = 'Three consecutive parallel axes at joints (1, 2, 3) -- the UR-class structure (UR3 / UR5 / UR10).\nClosed-form via SP6 (joints 0+4) + SP1 + SP3.'
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['base_link', '_poe_link_1', '_poe_link_2', '_poe_link_3', '_poe_link_4', '_poe_link_5', 'ee_link']
+
+_JOINT_NAMES = [
+    'shoulder_pan_joint',
+    'shoulder_lift_joint',
+    'elbow_joint',
+    'wrist_1_joint',
+    'wrist_2_joint',
+    'wrist_3_joint',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([0.0, -1.2246467991473532e-16, -1.0], dtype=np.float64),
+    np.array([0.0, -1.0, 6.123233995736766e-17], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.089159], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -0.425], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -0.39225000000000004], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -0.10915], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -1.3877787807814457e-17], [0.0, 0.0, 1.0, -0.09465], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 6.123233995736766e-17, -1.0, -0.0823], [0.0, 1.0, 6.123233995736766e-17, 5.204170427930421e-18], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+def solve(
+    T_target,
+    *,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+):
+    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+    :param policy: tolerance policy. Pass a custom
+        :class:`ssik.TolerancePolicy` to tighten or relax the
+        FK-closure threshold (``subproblem_numerical``), the
+        axis-parallel / axis-intersect predicates, etc. Defaults to
+        :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss algebraic candidates. Default ``False``;
+        turn on to recover candidates that don't quite meet
+        ``policy.subproblem_numerical`` on their own (e.g. near
+        kinematic singularities).
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
+        vector matching the source URDF's joint ordering;
+        ``solution.fk_residual`` reports closure against
+        ``T_target``. ``is_ls=True`` iff the algebraic path produced
+        no candidate meeting the FK tolerance -- callers wanting
+        only "exact" solutions check ``is_ls`` and discard.
+
+    Solver: three_parallel.
+    """
+    return _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
+    )
+
+
+__all__ = [
+    "DISPATCH_REASON",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "solve",
+]

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -1,0 +1,100 @@
+"""Snapshot tests for committed reference artifacts under tests/artifacts/.
+
+Each fixture arm has a committed ``<arm>_ik.py`` artifact. This test re-emits
+each one in-memory and asserts byte-equal against the committed file.
+
+If you change :mod:`ssik.core.codegen` or :mod:`ssik.core.dispatcher` in a
+way that affects rendered output (e.g. tweak the dispatch ``reason`` text),
+this test fails until you regenerate:
+
+    uv run python scripts/regen_artifacts.py
+
+Then commit the updated ``tests/artifacts/*.py`` files alongside your codegen
+change. The artifact diff is signal, not noise: it shows reviewers exactly
+what user-facing output the change produces.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from ssik._kinbody import build_kinbody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.codegen import emit_artifact
+from ssik.core.dispatcher import dispatch
+
+FIXTURES = Path(__file__).parent / "fixtures"
+ARTIFACTS = Path(__file__).parent / "artifacts"
+
+sys.path.insert(0, str(FIXTURES))
+from jaco2 import jaco2_specs  # noqa: E402
+
+
+def _emit_urdf(urdf: str, base: str, ee: str, module_name: str, arm_label: str) -> str:
+    kb = load_urdf_kinbody_normalized(FIXTURES / urdf, base, ee)
+    plan = dispatch(kb)
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name=module_name,
+        output_path=None,
+        arm_label=arm_label,
+    )
+    return result.source
+
+
+def _emit_jaco2() -> str:
+    kb = build_kinbody(jaco2_specs())
+    plan = dispatch(kb)
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="jaco2_ik",
+        output_path=None,
+        arm_label="Kinova JACO 2 (j2n6s200)",
+    )
+    return result.source
+
+
+@pytest.mark.parametrize(
+    ("module_name", "emit_fn"),
+    [
+        (
+            "ur5_ik",
+            lambda: _emit_urdf("ur5.urdf", "base_link", "ee_link", "ur5_ik", "UR5"),
+        ),
+        (
+            "puma560_ik",
+            lambda: _emit_urdf(
+                "puma560.urdf",
+                "base_link",
+                "wrist_3_link",
+                "puma560_ik",
+                "Puma 560",
+            ),
+        ),
+        ("jaco2_ik", _emit_jaco2),
+    ],
+)
+def test_committed_artifact_matches_regeneration(module_name: str, emit_fn: object) -> None:
+    """Re-emit + byte-compare. Any drift fails the test with a clear pointer
+    to the regen script."""
+    rendered = emit_fn()  # type: ignore[operator]
+    committed_path = ARTIFACTS / f"{module_name}.py"
+    assert committed_path.exists(), (
+        f"committed artifact {committed_path.relative_to(Path(__file__).parent.parent)} "
+        f"is missing -- run `uv run python scripts/regen_artifacts.py` to create it."
+    )
+    committed = committed_path.read_text()
+    if rendered != committed:
+        pytest.fail(
+            f"committed artifact {committed_path.name} differs from regenerated "
+            f"output. The codegen module produced different bytes -- this is "
+            f"likely an intentional codegen change. Regenerate with:\n"
+            f"    uv run python scripts/regen_artifacts.py\n"
+            f"and commit the updated tests/artifacts/*.py alongside your codegen "
+            f"change so reviewers can see the user-facing impact."
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,136 @@
+"""End-to-end tests for :mod:`ssik.cli` -- the ``ssik`` console script.
+
+Exercises both ``ssik classify`` and ``ssik build`` via the in-process
+``main()`` entry point so we get a fast loop without spawning subprocesses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ssik.cli import main as cli_main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_classify_ur5(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli_main(
+        [
+            "classify",
+            str(FIXTURES / "ur5.urdf"),
+            "--base",
+            "base_link",
+            "--ee",
+            "ee_link",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ikgeo.three_parallel" in out
+    assert "tier 0" in out
+    assert "Three consecutive parallel" in out
+
+
+def test_classify_puma(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli_main(
+        [
+            "classify",
+            str(FIXTURES / "puma560.urdf"),
+            "--base",
+            "base_link",
+            "--ee",
+            "wrist_3_link",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ikgeo.spherical_two_parallel" in out
+    assert "tier 0" in out
+
+
+def test_build_ur5_emits_and_validates(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    artifact = tmp_path / "ur5_ik_cli.py"
+    rc = cli_main(
+        [
+            "build",
+            str(FIXTURES / "ur5.urdf"),
+            "--base",
+            "base_link",
+            "--ee",
+            "ee_link",
+            "--out",
+            str(artifact),
+            "--module-name",
+            "ur5_ik_cli",
+            "--validate-poses",
+            "10",
+        ]
+    )
+    assert rc == 0
+    assert artifact.exists()
+    out = capsys.readouterr().out
+    assert "Wrote" in out
+    assert "0 failures" in out
+    assert "ikgeo.three_parallel" in out
+
+    # Import + smoke-solve to confirm the artifact is functional from disk.
+    spec = importlib.util.spec_from_file_location("ur5_ik_cli", artifact)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ur5_ik_cli"] = mod
+    spec.loader.exec_module(mod)
+    T = np.eye(4)
+    T[:3, 3] = [0.5, 0.1, 0.3]
+    sols, is_ls = mod.solve(T)
+    # Random free pose may or may not have a solution; just assert callable.
+    assert isinstance(sols, list)
+    assert isinstance(is_ls, bool)
+
+
+def test_build_no_validate(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    artifact = tmp_path / "ur5_skipval.py"
+    rc = cli_main(
+        [
+            "build",
+            str(FIXTURES / "ur5.urdf"),
+            "--base",
+            "base_link",
+            "--ee",
+            "ee_link",
+            "--out",
+            str(artifact),
+            "--module-name",
+            "ur5_skipval",
+            "--no-validate",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Validation skipped" in out
+    assert artifact.exists()
+
+
+def test_build_default_module_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``--module-name`` is omitted, the artifact is named after the
+    URDF stem (e.g. ``ur5.urdf`` → ``ur5_ik``)."""
+    monkeypatch.chdir(tmp_path)
+    rc = cli_main(
+        [
+            "build",
+            str(FIXTURES / "ur5.urdf"),
+            "--base",
+            "base_link",
+            "--ee",
+            "ee_link",
+            "--validate-poses",
+            "5",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "ur5_ik.py").exists()

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,191 @@
+"""End-to-end correctness for :mod:`ssik.core.codegen`.
+
+Builds the artifact for each shipped fixture, imports it as a Python
+module, and verifies that ``solve(T)`` produces the same solutions as
+calling the underlying ssik solver directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import KinBody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.codegen import emit_artifact
+from ssik.core.dispatcher import dispatch
+from ssik.core.tolerances import TolerancePolicy
+from ssik.solvers.ikgeo import spherical_two_parallel, three_parallel
+from ssik.subproblems._rotation import rotation_matrix
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fk_poe(kb: KinBody, q: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q, strict=True):
+        rot = np.eye(4)
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
+        T = T @ j.T_left @ rot @ j.T_right
+    return T
+
+
+def _import_artifact(source: str, module_name: str, tmp_path: Path) -> object:
+    """Write ``source`` to ``tmp_path/<module_name>.py`` and import it."""
+    artifact_path = tmp_path / f"{module_name}.py"
+    artifact_path.write_text(source)
+    spec = importlib.util.spec_from_file_location(module_name, artifact_path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_emit_ur5_artifact_in_memory(tmp_path: Path) -> None:
+    """Render the artifact for UR5 and check the rendered source has the
+    public surface we promised."""
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+    plan = dispatch(kb)
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="ur5_ik_test",
+        output_path=None,
+        arm_label="UR5",
+    )
+    # Public-API surface check.
+    for needle in (
+        "def solve(",
+        'SOLVER_NAME = "ikgeo.three_parallel"',
+        "SOLVER_TIER = 0",
+        "EXPECTED_MS_MEDIAN =",
+        "FLOP_BUDGET =",
+        "DISPATCH_REASON =",
+        "_KB = _build_kb()",
+        "from ssik.solvers.ikgeo.three_parallel import solve as _solver_solve",
+    ):
+        assert needle in result.source, f"missing {needle!r}"
+    assert result.module_name == "ur5_ik_test"
+    assert result.output_path is None
+
+
+@pytest.mark.parametrize(
+    ("urdf", "base", "ee", "module_name", "label", "direct_solver"),
+    [
+        ("ur5.urdf", "base_link", "ee_link", "ur5_ik_emit", "UR5", three_parallel),
+        (
+            "puma560.urdf",
+            "base_link",
+            "wrist_3_link",
+            "puma560_ik_emit",
+            "Puma 560",
+            spherical_two_parallel,
+        ),
+    ],
+)
+def test_emit_then_import_then_roundtrip(
+    tmp_path: Path,
+    urdf: str,
+    base: str,
+    ee: str,
+    module_name: str,
+    label: str,
+    direct_solver: object,
+) -> None:
+    """Full pipeline: dispatch -> emit -> import -> solve -> compare with the
+    direct solver call. The artifact must produce the same solutions as the
+    direct path on identical inputs.
+    """
+    kb = load_urdf_kinbody_normalized(FIXTURES / urdf, base, ee)
+    plan = dispatch(kb)
+    artifact_path = tmp_path / f"{module_name}.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name=module_name,
+        output_path=str(artifact_path),
+        arm_label=label,
+    )
+    assert artifact_path.exists()
+
+    spec = importlib.util.spec_from_file_location(module_name, artifact_path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+
+    # Sanity: artifact exports the documented public constants.
+    assert plan.solver_name == mod.SOLVER_NAME
+    assert plan.tier == mod.SOLVER_TIER
+    assert isinstance(mod.DISPATCH_REASON, str)
+
+    # Roundtrip: pick a random seeded q, FK it, solve, verify all returned
+    # solutions FK-close on the target. Then check the artifact's output
+    # matches the direct solver's output (same #solutions; q-vectors agree
+    # set-wise within machine precision).
+    rng = np.random.default_rng(seed=42)
+    for trial in range(5):
+        q_star = rng.uniform(-1.0, 1.0, size=6)
+        T_star = _fk_poe(kb, q_star)
+        sols_artifact, is_ls_artifact = mod.solve(T_star)
+        sols_direct, is_ls_direct = direct_solver.solve(kb, T_star)  # type: ignore[attr-defined]
+        assert is_ls_artifact == is_ls_direct, f"trial {trial}: is_ls disagrees"
+        assert len(sols_artifact) == len(sols_direct), f"trial {trial}: solution count disagrees"
+        for sol in sols_artifact:
+            T_check = _fk_poe(kb, sol.q)
+            assert np.allclose(T_check, T_star, atol=1e-9), (
+                f"trial {trial}: artifact q={sol.q.tolist()} fails FK"
+            )
+
+
+def test_artifact_solve_accepts_policy_and_refinement_kwargs(tmp_path: Path) -> None:
+    """The emitted ``solve()`` exposes the underlying solver's kwargs:
+    ``policy``, ``allow_refinement``, ``refinement_max_iters``. This is
+    the rich-API contract the artifact must preserve.
+    """
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+    plan = dispatch(kb)
+    artifact_path = tmp_path / "ur5_ik_kwargs.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="ur5_ik_kwargs",
+        output_path=str(artifact_path),
+        arm_label="UR5",
+    )
+    spec = importlib.util.spec_from_file_location("ur5_ik_kwargs", artifact_path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ur5_ik_kwargs"] = mod
+    spec.loader.exec_module(mod)
+
+    rng = np.random.default_rng(seed=11)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    T_star = _fk_poe(kb, q_star)
+
+    # Default call: defaults match the underlying solver's defaults.
+    _sols_default, is_ls_default = mod.solve(T_star)
+    assert not is_ls_default
+
+    # Custom policy: tighter FK-closure threshold; result still closes.
+    strict = TolerancePolicy(subproblem_numerical=1e-9)
+    sols_strict, is_ls_strict = mod.solve(T_star, policy=strict)
+    assert not is_ls_strict
+    for sol in sols_strict:
+        T_check = _fk_poe(kb, sol.q)
+        assert np.allclose(T_check, T_star, atol=1e-8), "strict-policy result fails FK"
+
+    # Newton refinement: opt-in path with cap on iterations.
+    sols_refined, is_ls_refined = mod.solve(T_star, allow_refinement=True, refinement_max_iters=8)
+    assert not is_ls_refined
+    for sol in sols_refined:
+        T_check = _fk_poe(kb, sol.q)
+        assert np.allclose(T_check, T_star, atol=1e-9)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,150 @@
+"""End-to-end correctness for :mod:`ssik.core.dispatcher`.
+
+Asserts that ``dispatch(kb)`` picks the right solver for every real URDF /
+MJCF fixture we ship, plus a synthetic non-Pieper 6R for the EAIK-gap case.
+The numeric estimate fields (``expected_ms_median``, ``flop_budget``) are
+checked for plausible orders of magnitude, not exact values -- they're
+order-of-magnitude estimates, not contracts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import Joint, KinBody, Link, build_kinbody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import DispatchPlan, dispatch
+
+FIXTURES = Path(__file__).parent / "fixtures"
+sys.path.insert(0, str(FIXTURES))
+from jaco2 import jaco2_specs  # noqa: E402
+
+
+def _build_synth_non_pieper() -> KinBody:
+    """Random-axis 6R chain with no parallel/intersecting structure -- the
+    classic EAIK-gap shape that should land on ``ikgeo.general_6r``.
+    """
+    rng = np.random.default_rng(seed=1234)
+
+    def _rnorm() -> np.ndarray:
+        v = rng.standard_normal(3)
+        return v / float(np.linalg.norm(v))
+
+    axes = [_rnorm() for _ in range(6)]
+    t_lefts = [rng.standard_normal(3) for _ in range(6)]
+    tool_p = rng.standard_normal(3)
+    link_names = ["base_link", *(f"link_{i}" for i in range(1, 6)), "ee_link"]
+    links = [Link(name=n) for n in link_names]
+    joints: list[Joint] = []
+    for i in range(6):
+        T_l = np.eye(4)
+        T_l[:3, 3] = t_lefts[i]
+        T_r = np.eye(4)
+        if i == 5:
+            T_r[:3, 3] = tool_p
+        joints.append(
+            Joint(
+                name=f"joint_{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=T_r,
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    return KinBody(links=links, joints=joints)
+
+
+@pytest.mark.parametrize(
+    ("urdf", "base", "ee", "expected_solver", "expected_tier"),
+    [
+        ("ur5.urdf", "base_link", "ee_link", "ikgeo.three_parallel", 0),
+        (
+            "puma560.urdf",
+            "base_link",
+            "wrist_3_link",
+            "ikgeo.spherical_two_parallel",
+            0,
+        ),
+    ],
+)
+def test_real_urdf_dispatch(
+    urdf: str, base: str, ee: str, expected_solver: str, expected_tier: int
+) -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / urdf, base, ee)
+    plan = dispatch(kb)
+    assert plan.solver_name == expected_solver
+    assert plan.tier == expected_tier
+    assert plan.expected_ms_median > 0
+    assert plan.flop_budget > 0
+    # Tier 0/1 should not need symbolic precompute.
+    assert plan.needs_symbolic_precompute is False
+    assert plan.estimated_precompute_seconds is None
+    # Reason is a multi-line user-facing string.
+    assert "\n" in plan.reason
+    assert len(plan.reason) > 50
+
+
+def test_jaco2_dispatch_to_general_6r() -> None:
+    """JACO 2 (real MJCF, 60-degree non-orthogonal twists) is the canonical
+    non-Pieper 6R fixture; it must land on the production tier-2 path."""
+    kb = build_kinbody(jaco2_specs())
+    plan = dispatch(kb)
+    assert plan.solver_name == "ikgeo.general_6r"
+    assert plan.tier == 2
+    assert plan.needs_symbolic_precompute is True
+
+
+def test_synth_non_pieper_dispatch_to_general_6r() -> None:
+    """The defining EAIK-gap test: a chain with no Pieper specialisation
+    must dispatch to the production tier-2 path (``general_6r``), not the
+    grid-search oracle (``gen_six_dof``)."""
+    kb = _build_synth_non_pieper()
+    plan = dispatch(kb)
+    assert plan.solver_name == "ikgeo.general_6r"
+    assert plan.tier == 2
+    assert plan.needs_symbolic_precompute is True
+    assert plan.estimated_precompute_seconds is not None
+    assert plan.estimated_precompute_seconds > 0
+    # Reason mentions the EAIK-gap framing.
+    assert "EAIK" in plan.reason or "Raghavan" in plan.reason
+
+
+def test_dispatch_rejects_non_6dof() -> None:
+    """7R chains aren't supported by this dispatcher iteration -- they
+    route through ``jointlock.seven_r``. The error message should say so."""
+    rng = np.random.default_rng(0)
+    links = [Link(name=f"l{i}") for i in range(8)]
+    joints = []
+    for i in range(7):
+        T_l = np.eye(4)
+        T_l[:3, 3] = rng.standard_normal(3)
+        ax = rng.standard_normal(3)
+        ax = ax / float(np.linalg.norm(ax))
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=ax,
+                joint_type="revolute",
+            )
+        )
+    kb = KinBody(links=links, joints=joints)
+    with pytest.raises(ValueError, match="7R support"):
+        dispatch(kb)
+
+
+def test_dispatch_plan_is_immutable() -> None:
+    kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+    plan = dispatch(kb)
+    assert isinstance(plan, DispatchPlan)
+    with pytest.raises((AttributeError, Exception)):  # frozen dataclass
+        plan.solver_name = "ikgeo.spherical"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
End-to-end UX for the per-arm artifact builder (#110 Phase 1). User submits a URDF; `ssik build` classifies the topology, picks the best solver, emits a self-contained Python module, and validates it on random poses.

```bash
$ ssik build path/to/ur5.urdf --base base_link --ee ee_link
[ssik] Loading path/to/ur5.urdf
[ssik]   6 joints, 7 links — POE-normalized OK
[ssik] Classifying topology
[ssik]   → Best solver: ikgeo.three_parallel (tier 0)
[ssik]   → Expected median IK time: ~1.6 ms
[ssik]   → FLOP budget: ~2,519 FLOPs / solve
[ssik]   → Reasoning:
[ssik]       Three consecutive parallel axes at joints (1, 2, 3) — the UR-class structure.
[ssik]       Closed-form via SP6 (joints 0+4) + SP1 + SP3.
[ssik] No build-time precompute needed (tier-0 closed-form)
[ssik] Emitting ./ur5_ik.py
[ssik]   Wrote 5,004 bytes
[ssik] Validating (100 random poses)
[ssik]   ✓ 100 poses, median 0.78 ms, max FK error 6e-09, 0 failures
```

The emitted artifact wraps the dispatched solver around baked KinBody constants and exposes the full underlying API:

```python
import ur5_ik
from ssik import TolerancePolicy

sols, is_ls = ur5_ik.solve(T_target)
sols, is_ls = ur5_ik.solve(T_target, policy=TolerancePolicy(subproblem_numerical=1e-9))
sols, is_ls = ur5_ik.solve(T_target, allow_refinement=True, refinement_max_iters=8)
```

## What changed

**New modules:**
- `src/ssik/core/dispatcher.py` — `dispatch(kb) -> DispatchPlan`. Structured solver pick + reason + speed/FLOP estimates + symbolic-precompute flag. Tier-1 univariate-search solvers no longer auto-dispatch (tier-2 RR is 50×–200× faster on the same chains; JACO 2 motivates this — see module docstring).
- `src/ssik/core/codegen.py` — `emit_artifact(...)` renders a self-contained Python module. Transparent `solve(T, *, policy=..., allow_refinement=..., refinement_max_iters=...)` wrapper around the chosen solver.
- `src/ssik/cli.py` — argparse entrypoint with `build` and `classify` subcommands, `--verbose` flag installing a stderr logging handler.
- `scripts/regen_artifacts.py` — regenerates the reference artifacts under `tests/artifacts/`.

**Library logging (per the conversation about \"rich explanatory output\"):**
- `ssik/__init__.py` installs a `NullHandler` on the ssik namespace — importing ssik never produces unsolicited stderr.
- Each of the 9 solver modules gets `_LOG = logging.getLogger(__name__)` and one INFO log per `solve()` exit reporting candidate count, solution count, is_ls flag.
- `ssik build -v` installs a stderr handler at INFO; `-vv` at DEBUG. Library users hook in via standard `logging.getLogger(\"ssik\").setLevel(...)`.

**Reference artifacts (committed):**
- `tests/artifacts/ur5_ik.py` (5 KB), `tests/artifacts/puma560_ik.py` (5 KB), `tests/artifacts/jaco2_ik.py` (6 KB)
- Snapshot test (`test_artifact_snapshots.py`) re-emits each one in-memory and asserts byte-equal against the committed file. Codegen drift fails the test with a pointer to `scripts/regen_artifacts.py`.

**README:**
- New \"Per-arm artifact builder (`ssik build`)\" section with the user flow + rich-API example.
- Distribution-model paragraph updated to reference the CLI.

## Validation

- 18 new tests pass (dispatcher 6 + codegen 4 + CLI 5 + artifact-snapshots 3)
- 330 existing tests pass (1 xfailed + 3 xpassed are the known #82 platform variance)
- `ruff check`, `ruff format --check`, `mypy` all clean

## Test plan

- [x] `uv run pytest tests/test_dispatcher.py tests/test_codegen.py tests/test_cli.py tests/test_artifact_snapshots.py` — 18 passed
- [x] Full fast suite green
- [x] `ssik classify tests/fixtures/ur5.urdf --base base_link --ee ee_link` produces the explanatory output above
- [x] `ssik build tests/fixtures/ur5.urdf --base base_link --ee ee_link --out /tmp/ur5_ik.py` emits + validates at median 0.78 ms
- [x] Generated artifact accepts `policy`, `allow_refinement`, `refinement_max_iters` kwargs (covered by `test_artifact_solve_accepts_policy_and_refinement_kwargs`)
- [x] Snapshot regen script: `uv run python scripts/regen_artifacts.py` produces byte-identical artifacts

## What's next

Per [#110](https://github.com/siddhss5/ikfastpy/issues/110):

- **Phase 2:** bake tier-2 RR's symbolic preprocessing into the artifact at build time (eliminates the ~150–300s first-call latency for non-Pieper arms).
- **Phase 3:** progress + ETA instrumentation on the symbolic stage so the build doesn't go silent for minutes.
- **Phase 4:** Cython codegen sibling — same artifact API, native speed, closes the FLOP-budget gap.