### PR TITLE
#112: wire allow_refinement=True through specialised artifact orchestrator

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -206,6 +206,10 @@ def _render_specialised(
     buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
     buf.write("from ssik.core.solution import Solution\n")
     buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
+    buf.write(
+        "from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, "
+        "lm_refine as _lm_refine\n"
+    )
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -260,10 +264,11 @@ def _render_specialised_solve_orchestrator() -> str:
 
             :param T_target: 4x4 SE(3) target end-effector pose.
             :param policy: tolerance policy (FK closure + dedup tolerance).
-            :param allow_refinement: opt into Newton polish for near-miss
-                algebraic candidates. Currently a no-op in the specialised
-                emitter; a follow-up adds the inlined Newton loop.
-            :param refinement_max_iters: cap when refinement is added.
+            :param allow_refinement: opt into Newton-on-spatial-Jacobian
+                polish for near-miss candidates (those whose algebraic q
+                doesn't quite meet ``fk_atol``). Default off.
+            :param refinement_max_iters: cap on Newton iterations per
+                candidate when ``allow_refinement=True``.
             """
             T = np.asarray(T_target, dtype=np.float64)
             candidates = _solve_algebraic(T)
@@ -271,8 +276,9 @@ def _render_specialised_solve_orchestrator() -> str:
             fk_atol = policy.subproblem_numerical
             dedup_atol = policy.subproblem_dedup
 
-            # Verify each candidate via FK closure.
-            verified = []
+            # Three-bucket sort: exact (closes within fk_atol), near-miss
+            # (refinable when allow_refinement=True), or drop.
+            verified: list[tuple[np.ndarray, float, str, int]] = []
             for cand_q in candidates:
                 q = np.asarray(cand_q, dtype=np.float64)
                 if not np.all(np.isfinite(q)):
@@ -280,32 +286,48 @@ def _render_specialised_solve_orchestrator() -> str:
                 T_check = _fk(q)
                 residual = float(np.linalg.norm(T_check - T))
                 if residual <= fk_atol:
-                    verified.append((q, residual))
+                    verified.append((q, residual, "none", 0))
+                    continue
+                if not allow_refinement:
+                    continue
+                # Newton polish using the baked KinBody's spatial Jacobian.
+                refined = _lm_refine(
+                    q,
+                    _fk,
+                    T,
+                    fk_atol=fk_atol,
+                    max_iters=refinement_max_iters,
+                    jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+                )
+                if refined is None:
+                    continue
+                q_ref, resid_ref, iters = refined
+                verified.append((q_ref, resid_ref, "lm", iters))
 
             # Wrap-to-pi dedup; keep lowest fk_residual on collision.
-            deduped = []
-            for cand_q, cand_res in verified:
+            deduped: list[tuple[np.ndarray, float, str, int]] = []
+            for cand_q, cand_res, ref_used, ref_iters in verified:
                 dup_idx = None
-                for j, (existing_q, _) in enumerate(deduped):
+                for j, (existing_q, _, _, _) in enumerate(deduped):
                     diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
                     if np.all(np.abs(diffs) < dedup_atol):
                         dup_idx = j
                         break
                 if dup_idx is None:
-                    deduped.append((cand_q, cand_res))
+                    deduped.append((cand_q, cand_res, ref_used, ref_iters))
                 elif cand_res < deduped[dup_idx][1]:
-                    deduped[dup_idx] = (cand_q, cand_res)
+                    deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
             solutions = [
                 Solution(
                     q=q,
                     fk_residual=residual,
-                    refinement_used="none",
-                    refinement_iters=0,
+                    refinement_used=ref_used,
+                    refinement_iters=ref_iters,
                     branch_id=i,
                     solver_name=SOLVER_NAME,
                 )
-                for i, (q, residual) in enumerate(deduped)
+                for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
             ]
             return solutions, len(solutions) == 0
         '''

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -36,6 +36,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -315,10 +316,11 @@ def solve(
 
     :param T_target: 4x4 SE(3) target end-effector pose.
     :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton polish for near-miss
-        algebraic candidates. Currently a no-op in the specialised
-        emitter; a follow-up adds the inlined Newton loop.
-    :param refinement_max_iters: cap when refinement is added.
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss candidates (those whose algebraic q
+        doesn't quite meet ``fk_atol``). Default off.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -326,8 +328,9 @@ def solve(
     fk_atol = policy.subproblem_numerical
     dedup_atol = policy.subproblem_dedup
 
-    # Verify each candidate via FK closure.
-    verified = []
+    # Three-bucket sort: exact (closes within fk_atol), near-miss
+    # (refinable when allow_refinement=True), or drop.
+    verified: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q in candidates:
         q = np.asarray(cand_q, dtype=np.float64)
         if not np.all(np.isfinite(q)):
@@ -335,32 +338,48 @@ def solve(
         T_check = _fk(q)
         residual = float(np.linalg.norm(T_check - T))
         if residual <= fk_atol:
-            verified.append((q, residual))
+            verified.append((q, residual, "none", 0))
+            continue
+        if not allow_refinement:
+            continue
+        # Newton polish using the baked KinBody's spatial Jacobian.
+        refined = _lm_refine(
+            q,
+            _fk,
+            T,
+            fk_atol=fk_atol,
+            max_iters=refinement_max_iters,
+            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+        )
+        if refined is None:
+            continue
+        q_ref, resid_ref, iters = refined
+        verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
-    deduped = []
-    for cand_q, cand_res in verified:
+    deduped: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
-        for j, (existing_q, _) in enumerate(deduped):
+        for j, (existing_q, _, _, _) in enumerate(deduped):
             diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
             if np.all(np.abs(diffs) < dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:
-            deduped.append((cand_q, cand_res))
+            deduped.append((cand_q, cand_res, ref_used, ref_iters))
         elif cand_res < deduped[dup_idx][1]:
-            deduped[dup_idx] = (cand_q, cand_res)
+            deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
     solutions = [
         Solution(
             q=q,
             fk_residual=residual,
-            refinement_used="none",
-            refinement_iters=0,
+            refinement_used=ref_used,
+            refinement_iters=ref_iters,
             branch_id=i,
             solver_name=SOLVER_NAME,
         )
-        for i, (q, residual) in enumerate(deduped)
+        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
     return solutions, len(solutions) == 0
 

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -37,6 +37,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -275,10 +276,11 @@ def solve(
 
     :param T_target: 4x4 SE(3) target end-effector pose.
     :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton polish for near-miss
-        algebraic candidates. Currently a no-op in the specialised
-        emitter; a follow-up adds the inlined Newton loop.
-    :param refinement_max_iters: cap when refinement is added.
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss candidates (those whose algebraic q
+        doesn't quite meet ``fk_atol``). Default off.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -286,8 +288,9 @@ def solve(
     fk_atol = policy.subproblem_numerical
     dedup_atol = policy.subproblem_dedup
 
-    # Verify each candidate via FK closure.
-    verified = []
+    # Three-bucket sort: exact (closes within fk_atol), near-miss
+    # (refinable when allow_refinement=True), or drop.
+    verified: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q in candidates:
         q = np.asarray(cand_q, dtype=np.float64)
         if not np.all(np.isfinite(q)):
@@ -295,32 +298,48 @@ def solve(
         T_check = _fk(q)
         residual = float(np.linalg.norm(T_check - T))
         if residual <= fk_atol:
-            verified.append((q, residual))
+            verified.append((q, residual, "none", 0))
+            continue
+        if not allow_refinement:
+            continue
+        # Newton polish using the baked KinBody's spatial Jacobian.
+        refined = _lm_refine(
+            q,
+            _fk,
+            T,
+            fk_atol=fk_atol,
+            max_iters=refinement_max_iters,
+            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+        )
+        if refined is None:
+            continue
+        q_ref, resid_ref, iters = refined
+        verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
-    deduped = []
-    for cand_q, cand_res in verified:
+    deduped: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
-        for j, (existing_q, _) in enumerate(deduped):
+        for j, (existing_q, _, _, _) in enumerate(deduped):
             diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
             if np.all(np.abs(diffs) < dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:
-            deduped.append((cand_q, cand_res))
+            deduped.append((cand_q, cand_res, ref_used, ref_iters))
         elif cand_res < deduped[dup_idx][1]:
-            deduped[dup_idx] = (cand_q, cand_res)
+            deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
     solutions = [
         Solution(
             q=q,
             fk_residual=residual,
-            refinement_used="none",
-            refinement_iters=0,
+            refinement_used=ref_used,
+            refinement_iters=ref_iters,
             branch_id=i,
             solver_name=SOLVER_NAME,
         )
-        for i, (q, residual) in enumerate(deduped)
+        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
     return solutions, len(solutions) == 0
 

--- a/tests/test_specialised_bulletproof.py
+++ b/tests/test_specialised_bulletproof.py
@@ -139,3 +139,41 @@ def test_bulletproof_ur5_specialised(tmp_path: Path) -> None:
     kb = load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
     artifact = _build_specialised(kb, "ur5_bp", tmp_path)
     _bulletproof_check(kb, artifact, n_poses=100, fk_atol=1e-8)
+
+
+def test_specialised_artifact_refinement_path_works(tmp_path: Path) -> None:
+    """The specialised artifact's ``allow_refinement=True`` path must wire
+    through to ``ssik.refinement.lm_refine`` correctly.
+
+    Strategy: use a tightened ``subproblem_numerical`` so some algebraic
+    candidates fall into the near-miss bucket. Without refinement, those
+    get dropped (fewer solutions). With refinement, the Newton polish
+    recovers them (same or more solutions). At minimum, refinement must
+    return non-empty results without raising and report
+    ``refinement_used == "lm"`` for any polished candidate.
+    """
+    from ssik.core.tolerances import TolerancePolicy
+
+    kb = load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+    artifact = _build_specialised(kb, "puma560_refine", tmp_path)
+
+    rng = np.random.default_rng(seed=11)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    T_star = _fk(kb, q_star)
+
+    # Tight policy that triggers the near-miss path on at least some poses.
+    tight_policy = TolerancePolicy(subproblem_numerical=1e-13)
+
+    sols_off, _ = artifact.solve(T_star, policy=tight_policy, allow_refinement=False)  # type: ignore[attr-defined]
+    sols_on, _ = artifact.solve(T_star, policy=tight_policy, allow_refinement=True)  # type: ignore[attr-defined]
+
+    # Refinement should recover at least as many candidates as the no-refine path.
+    assert len(sols_on) >= len(sols_off), (
+        f"refinement reduced solution count: {len(sols_off)} (off) -> {len(sols_on)} (on)"
+    )
+
+    # If refinement helped, at least one solution should report it.
+    if len(sols_on) > len(sols_off):
+        assert any(s.refinement_used == "lm" for s in sols_on), (
+            "refinement added solutions but no Solution.refinement_used == 'lm'"
+        )


### PR DESCRIPTION
## Summary

The specialised codegen orchestrator's ``allow_refinement`` path was a no-op (docstring even said so). This PR wires it through to ``ssik.refinement.lm_refine`` + ``kinbody_jacobian`` so the kwarg actually works on specialised artifacts.

The artifact's ``solve()`` now correctly:

1. Computes algebraic candidates via ``_solve_algebraic``.
2. Per candidate: FK closure check.
   - residual ≤ fk_atol → exact (``refinement_used=\"none\"``)
   - else if ``allow_refinement=True``: ``lm_refine`` using ``_fk`` + ``kinbody_jacobian(_KB)``. Converges → ``refinement_used=\"lm\"``; diverges → drop.
   - else (refinement off): drop.
3. Wrap-to-pi dedup keeping lowest fk_residual + correct refinement metadata.

This is the contract from PR #111's rich-API design — specialised artifacts must support the full ``solve(T, *, policy, allow_refinement, refinement_max_iters)`` surface, not just the algebraic-only path.

## Test added

``tests/test_specialised_bulletproof.py::test_specialised_artifact_refinement_path_works``: tight TolerancePolicy pushes candidates into the near-miss bucket, asserts:

- ``len(sols_on) >= len(sols_off)`` — refinement never reduces count
- ``any(s.refinement_used == \"lm\" for s in sols_on)`` — when refinement helps, it's reported

## Validation

- 420 fast tests pass (1 known failure is #115 pre-existing UR5 hypothesis flake, filed)
- ruff + mypy clean
- Snapshot artifacts regenerated; byte-equal regen still works

## What's next

Per #112's plan, follow-up PRs:

- Tier-1 composers (two_parallel, two_intersecting) — search-loop pattern
- Tier-2 RR composer (general_6r) + build-time symbolic precompute baking → JACO 2 specialised (the EAIK-gap differentiator)
- gen_six_dof oracle composer + jointlock.seven_r composer
- Phase 4 Cython compile of the specialised source