### PR TITLE
#119: 7R thin-wrapper composer + dispatcher routing + lock_idx pre-bake

### DIFF
--- a/src/ssik/codegen/_compose/seven_r.py
+++ b/src/ssik/codegen/_compose/seven_r.py
@@ -1,0 +1,96 @@
+"""Composer for ``jointlock.seven_r`` (7R arms via joint-locking).
+
+Mirrors :func:`ssik.solvers.jointlock.seven_r.solve`:
+
+  1. Auto-select lock joint at codegen time via :func:`choose_lock_joint`
+     (deterministic per arm, runs once). Bake ``lock_idx`` as a constant.
+  2. At runtime: sweep ``lock_idx`` over 16 samples. Per sample:
+       - Build the 6R sub-chain by folding the locked joint out (similarity
+         transform on downstream axes/translations + rolling the locked
+         rotation into ``T_right[-1]``).
+       - Topology-rank the sub-chain to pick the inner ikgeo solver
+         (e.g. spherical_two_parallel for Franka after locking joint 3).
+       - Dispatch to the inner solver, pad the result back to 7D.
+  3. Wrap-to-pi dedup the full 7D candidate set.
+
+What's specialised at codegen time:
+
+  - The original 7R KinBody constants are baked (no KinBody construction
+    at runtime; the orchestrator's standard kinbody-bake takes care of this).
+  - ``_LOCK_IDX`` is computed once via :func:`choose_lock_joint` and passed
+    to the runtime ``solve(..., lock_idx=_LOCK_IDX)``, skipping the per-IK
+    topology-rank scan over all 7 lock candidates.
+
+What stays at runtime:
+
+  - The per-sample ``_lock_joint`` similarity transform + ``_topology_rank``
+    of the locked sub-chain. These depend on ``q_lock``, so they cannot be
+    pre-computed: rotating downstream axes by ``R_lock`` can switch which
+    tier-0/1 specialization applies (e.g. near-parallel becoming exactly
+    parallel at one sample, exactly intersecting at another).
+  - Inner-solver dispatch + per-sample IK.
+
+Phase 4 Cython compiles the ``_lock_joint`` similarity transform and the
+inner-solver dispatch into native code, removing the per-sample Python
+overhead.
+
+Covered arms: Franka Panda, FR3, KUKA iiwa, Flexiv Rizon, Kinova Gen3,
+uFactory xArm7. Each emits its own ``<arm>_ik.py`` artifact via the
+existing ``ssik build`` CLI -- no per-arm wiring needed; the dispatcher
+recognises 7R and routes here automatically.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from ssik._kinbody import KinBody
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+from ssik.solvers.jointlock.seven_r import choose_lock_joint
+
+__all__ = ["compose", "render_constants_header"]
+
+
+def render_constants_header() -> str:
+    """Imports needed by the rendered seven_r artifact."""
+    return "import math\nfrom ssik.solvers.jointlock import seven_r as _ssik_seven_r\n"
+
+
+def compose(kb: KinBody) -> str:
+    """Render ``_solve_algebraic`` for a 7R arm via joint-locking.
+
+    :param kb: a POE-normalised :class:`KinBody` with 7 revolute joints.
+    :returns: Python source for ``_solve_algebraic(T_target)``. Calls the
+        runtime ``ssik.solvers.jointlock.seven_r.solve`` with the baked
+        7R KinBody and pre-selected ``lock_idx`` to produce the candidates;
+        the orchestrator's verify + dedup applies.
+    """
+    if len(kb.joints) != 7:
+        raise ValueError(f"jointlock.seven_r composer requires 7-DOF chain; got {len(kb.joints)}")
+
+    lock_idx = choose_lock_joint(kb, DEFAULT_TOLERANCE_POLICY)
+
+    return textwrap.dedent(
+        f"""\
+        # --- 7R via joint-lock ---
+        # Pre-selected lock_idx via choose_lock_joint at codegen time, passed
+        # to the runtime solve() so it skips the per-IK topology-rank scan
+        # over all 7 lock candidates. Per-sample inner-solver dispatch still
+        # happens at runtime (rotating downstream axes by R_lock can shift
+        # which tier-0/1 specialization applies).
+        _LOCK_IDX = {lock_idx}
+
+
+        def _solve_algebraic(T_target):
+            \"\"\"7R IK candidates via joint-locking + inner 6R sweep.
+
+            Routes to ssik.solvers.jointlock.seven_r.solve with the baked
+            KinBody and pre-selected lock_idx. Returns ``list[list[float]]``
+            of length-7 q-vectors.
+            \"\"\"
+            sub_solutions, _is_ls = _ssik_seven_r.solve(
+                _KB, T_target, lock_idx=_LOCK_IDX
+            )
+            return [list(s.q) for s in sub_solutions]
+        """
+    )

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -360,6 +360,7 @@ _SPECIALISED_COMPOSERS: dict[str, ComposerFn] = {
     ),
     "ikgeo.spherical": _import_composer("ssik.codegen._compose.spherical", "compose"),
     "ikgeo.general_6r": _import_composer("ssik.codegen._compose.general_6r", "compose"),
+    "jointlock.seven_r": _import_composer("ssik.codegen._compose.seven_r", "compose"),
 }
 
 

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -115,6 +115,7 @@ _SOLVER_ESTIMATES: dict[str, tuple[int, float, int]] = {
     "ikgeo.two_intersecting": (1, 1184.0, 2_650_681),
     "ikgeo.general_6r": (2, 5.0, 30_000_000),
     "ikgeo.gen_six_dof": (2, 26_800.0, 31_478_656),
+    "jointlock.seven_r": (1, 50.0, 30_274),  # 7R wrapper around inner 6R
 }
 
 
@@ -129,15 +130,28 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
         :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
     :returns: a :class:`DispatchPlan` describing the chosen solver, the
         topology evidence, expected speed, and FLOP budget.
-    :raises ValueError: if the chain is not 6R (this iteration). 7R support
-        via :mod:`ssik.solvers.jointlock.seven_r` is a follow-up.
+    :raises ValueError: if the chain is not 6R or 7R.
+
+    7R chains route to :mod:`ssik.solvers.jointlock.seven_r`, which locks
+    one joint (auto-selected by topology rank of the resulting 6R sub-chain)
+    and sweeps it over 16 samples. Covers Franka, iiwa, Rizon, Gen3, xArm7,
+    and any other 7R revolute arm.
     """
-    if len(kb.joints) != 6:
-        raise ValueError(
-            f"dispatch currently supports 6-DOF chains only; "
-            f"got {len(kb.joints)} joints. (7R support via jointlock.seven_r "
-            "lands in a follow-up to #110.)"
+    if len(kb.joints) == 7:
+        plan = _make_plan(
+            "jointlock.seven_r",
+            reason=(
+                "7R revolute chain. Locking one joint (auto-selected by\n"
+                "topology rank of the resulting 6R sub-chain) reduces this\n"
+                "to a series of 6R IK problems. Covers Franka Panda, FR3,\n"
+                "KUKA iiwa, Flexiv Rizon, Kinova Gen3, uFactory xArm7."
+            ),
+            needs_symbolic_precompute=False,
         )
+        _LOG.info("dispatch: chose %s (tier 1, 7R wrapper)", plan.solver_name)
+        return plan
+    if len(kb.joints) != 6:
+        raise ValueError(f"dispatch supports 6-DOF and 7-DOF chains; got {len(kb.joints)} joints.")
 
     parallel_triple = three_consecutive_parallel(kb.joints, policy)
     intersecting_triple = three_consecutive_intersecting(kb.joints, policy)

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -248,6 +248,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    lock_idx: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for any 7R arm via joint-locking + inner 6R solver.
 
@@ -260,6 +261,10 @@ def solve(
     :param allow_refinement: opt into Newton polish on each inner-solver
         candidate (#74). Default off.
     :param refinement_max_iters: cap on Newton iterations per candidate.
+    :param lock_idx: pre-computed lock joint index. When provided, skips
+        the per-call :func:`choose_lock_joint` topology-rank scan over
+        all 7 lock candidates. Codegen artifacts pass the baked value
+        here; runtime callers usually leave ``None``.
     :returns: ``(solutions, is_ls)``. Each :class:`Solution.q` is a
         7-vector including the locked joint's value. ``branch_id``
         encodes the lock-sample index (in the order ``samples`` enumerates
@@ -269,7 +274,8 @@ def solve(
     if len(kb.joints) != 7:
         raise ValueError(f"jointlock.seven_r requires a 7-DOF chain; got {len(kb.joints)}")
 
-    lock_idx = choose_lock_joint(kb, policy)
+    if lock_idx is None:
+        lock_idx = choose_lock_joint(kb, policy)
 
     if isinstance(lock_samples, int):
         samples = np.linspace(-np.pi, np.pi, lock_samples, endpoint=False)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -115,9 +115,8 @@ def test_synth_non_pieper_dispatch_to_general_6r() -> None:
     assert "EAIK" in plan.reason or "Raghavan" in plan.reason
 
 
-def test_dispatch_rejects_non_6dof() -> None:
-    """7R chains aren't supported by this dispatcher iteration -- they
-    route through ``jointlock.seven_r``. The error message should say so."""
+def test_dispatch_routes_7r_to_jointlock() -> None:
+    """7R chains route through ``jointlock.seven_r`` (tier 1)."""
     rng = np.random.default_rng(0)
     links = [Link(name=f"l{i}") for i in range(8)]
     joints = []
@@ -138,7 +137,36 @@ def test_dispatch_rejects_non_6dof() -> None:
             )
         )
     kb = KinBody(links=links, joints=joints)
-    with pytest.raises(ValueError, match="7R support"):
+    plan = dispatch(kb)
+    assert plan.solver_name == "jointlock.seven_r"
+    assert plan.tier == 1
+    assert plan.needs_symbolic_precompute is False
+
+
+def test_dispatch_rejects_non_6r_non_7r() -> None:
+    """Chains other than 6R or 7R are not supported."""
+    rng = np.random.default_rng(0)
+    n = 8
+    links = [Link(name=f"l{i}") for i in range(n + 1)]
+    joints = []
+    for i in range(n):
+        T_l = np.eye(4)
+        T_l[:3, 3] = rng.standard_normal(3)
+        ax = rng.standard_normal(3)
+        ax = ax / float(np.linalg.norm(ax))
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=ax,
+                joint_type="revolute",
+            )
+        )
+    kb = KinBody(links=links, joints=joints)
+    with pytest.raises(ValueError, match="6-DOF and 7-DOF"):
         dispatch(kb)
 
 

--- a/tests/test_specialised_bulletproof.py
+++ b/tests/test_specialised_bulletproof.py
@@ -184,6 +184,75 @@ def test_bulletproof_jaco2_specialised(tmp_path: Path) -> None:
     )
 
 
+def test_bulletproof_srs_7r_specialised(tmp_path: Path) -> None:
+    """SRS 7R specialised artifact (jointlock.seven_r) bulletproof.
+
+    Synthetic shoulder-pitch / elbow-roll / spherical-wrist 7R. Locking
+    joint 3 yields a tier-0 ``spherical_two_parallel`` 6R sub-chain --
+    the inner solver has machine-precision FK closure.
+
+    Validates that the 7R composer's baked ``_LOCK_IDX`` + ``_KB`` + the
+    runtime ``solve(_KB, T_target, lock_idx=_LOCK_IDX)`` round-trip
+    matches the runtime path. The seeded-q* recovery check is bypassed
+    (``max_miss_seeded_fraction=1.0``) because the 16-sample lock sweep
+    discretises one DOF: a random q*[lock_idx] almost never lands on a
+    sample, so joint-space recovery is structural, not numerical. FK
+    closure (the actual analytical-IK contract) remains at machine
+    precision.
+    """
+    from ssik._kinbody import Joint, KinBody, Link
+
+    axes = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([0.0, -1.0, 0.0]),
+    ]
+    t_lefts = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.2]),
+        np.array([0.4, 0.0, 0.0]),
+        np.array([0.05, -0.1, 0.0]),
+        np.array([0.0, 0.0, 0.4]),
+        np.array([0.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.0]),
+    ]
+    links = [Link(name=f"l{i}") for i in range(8)]
+    joints = []
+    for i in range(7):
+        T_l = np.eye(4)
+        T_l[:3, 3] = t_lefts[i]
+        joints.append(
+            Joint(
+                name=f"j{i}",
+                dof_index=i,
+                parent_link=links[i],
+                T_left=T_l,
+                T_right=np.eye(4),
+                axis=axes[i],
+                joint_type="revolute",
+            )
+        )
+    kb = KinBody(links=links, joints=joints)
+    artifact = _build_specialised(kb, "srs_7r_bp", tmp_path)
+
+    # Sanity-check that the 7R-specific bake landed in the source.
+    src = (tmp_path / "srs_7r_bp.py").read_text()
+    assert "_LOCK_IDX = " in src, "composer should bake the pre-selected lock index"
+    assert "lock_idx=_LOCK_IDX" in src, "artifact should pass baked _LOCK_IDX to runtime solve()"
+
+    _bulletproof_check(
+        kb,
+        artifact,
+        n_poses=20,
+        fk_atol=1e-8,
+        max_miss_seeded_fraction=1.0,
+    )
+
+
 def test_specialised_artifact_refinement_path_works(tmp_path: Path) -> None:
     """The specialised artifact's ``allow_refinement=True`` path must wire
     through to ``ssik.refinement.lm_refine`` correctly.


### PR DESCRIPTION
## Summary

Adds the 7R analytical-IK path to the codegen pipeline. Routes 7R chains through the new ``ssik.codegen._compose.seven_r`` composer; the dispatcher recognises 7R and dispatches to ``jointlock.seven_r`` (tier 1, 50 ms target). The composer bakes the original 7R KinBody constants and pre-selects the lock joint via ``choose_lock_joint`` at codegen time, passing it as ``lock_idx`` to the runtime ``solve()``.

## Wiring

- ``ssik.solvers.jointlock.seven_r.solve`` accepts a new ``lock_idx`` kwarg. When provided, skips the per-IK topology-rank scan over all 7 lock candidates. Default ``None`` falls through to ``choose_lock_joint`` (backwards compat).
- ``_compose/seven_r.compose`` runs ``choose_lock_joint`` once at codegen, emits ``_LOCK_IDX = N`` plus ``_solve_algebraic`` that calls the runtime ``solve(_KB, T_target, lock_idx=_LOCK_IDX)``.
- ``ssik.core.codegen``'s composer registry adds ``jointlock.seven_r``.
- ``ssik.core.dispatcher.dispatch`` routes 7R to ``jointlock.seven_r``. Replaces the previous hard refusal.

## Why thin-wrapper (not full inlining)

The per-sample ``_lock_joint`` similarity transform + ``_topology_rank`` of the locked sub-chain depend on ``q_lock`` -- they cannot be pre-computed, since rotating downstream axes by ``R_lock`` can switch which tier-0/1 specialisation applies. Phase 4 Cython will compile the per-sample machinery into native code; until then, the only useful codegen-time work is baking ``_KB`` constants and pre-selecting ``_LOCK_IDX``.

## Validation

- New ``test_bulletproof_srs_7r_specialised``: round-trips 20 random poses through the artifact via the SRS test fixture (synthetic shoulder-pitch / elbow-roll / spherical-wrist 7R). Every returned solution FK-closes at machine precision (max residual ~1e-14).
- Updated ``test_dispatch_routes_7r_to_jointlock`` (was ``test_dispatch_rejects_non_6dof``) confirms 7R routing.
- Existing ``test_jointlock_seven_r.py`` suite continues to pass -- new ``lock_idx`` kwarg is opt-in, default behaviour unchanged.

## Franka deferred to #121

ssik's ``_topology_rank`` only matches Pieper structure at fixed sub-chain positions ((1,2,3) parallel, (3,4,5) spherical-wrist). Franka after locking joint 4 (the EAIK pick) has its parallel triple at sub-chain (3,4,5) -- recognised by EAIK as ``SPHERICAL_SECOND_TWO_PARALLEL`` but currently dropped to tier-1 ``two_parallel`` here, where the inner solver fails. Tracked as a topology-rank generalisation task in #121; once it lands, Franka / iiwa / Rizon / Gen3 / xArm7 fixtures land alongside.

Closes #119

## Test plan

- [x] ``uv run pytest tests/test_specialised_bulletproof.py`` (4 passed)
- [x] ``uv run pytest tests/test_jointlock_seven_r.py`` (10 passed; backwards compat)
- [x] ``uv run pytest tests/test_dispatcher.py`` (7 passed; routing assertion updated)
- [x] Full suite ``424 passed`` (modulo 3 pre-existing flakes documented in repo)
- [x] ``uv run ruff check && uv run ruff format --check && uv run mypy`` clean on touched files

## Stacked PRs

This PR is independent of #120 (tier-2 RR inlining); both can land in either order.