### PR TITLE
#129: joint limits as kinematic data + Franka 7R artifact

### DIFF
--- a/scripts/regen_artifacts.py
+++ b/scripts/regen_artifacts.py
@@ -51,6 +51,7 @@ def main() -> int:
         arm_label="Puma 560",
     )
     _emit_jaco2_artifact()
+    _emit_franka_panda_artifact()
     print("done.")
     return 0
 
@@ -86,6 +87,27 @@ def _emit_jaco2_artifact() -> None:
         module_name="jaco2_ik",
         output_path=str(out),
         arm_label="Kinova JACO 2 (j2n6s200)",
+    )
+    print(f"  {out.relative_to(REPO_ROOT)}: {plan.solver_name} (tier {plan.tier})")
+
+
+def _emit_franka_panda_artifact() -> None:
+    """Franka Panda fixture: real MJCF transcription, 7-DOF. The artifact
+    routes through ``jointlock.seven_r`` which auto-picks lock_idx=4
+    (matching EAIK) and dispatches to ``reversed:spherical_two_parallel``
+    via the chain-reversal pre-pass."""
+    sys.path.insert(0, str(FIXTURES))
+    from franka_panda import franka_panda_specs
+
+    kb = build_kinbody(franka_panda_specs())
+    plan = dispatch(kb)
+    out = ARTIFACTS / "franka_panda_ik.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="franka_panda_ik",
+        output_path=str(out),
+        arm_label="Franka Emika Panda (no hand)",
     )
     print(f"  {out.relative_to(REPO_ROOT)}: {plan.solver_name} (tier {plan.tier})")
 

--- a/src/ssik/_kinbody.py
+++ b/src/ssik/_kinbody.py
@@ -49,6 +49,15 @@ class JointSpec:
     purely in terms of "where the next joint sits" (e.g., simple axis lists).
     It is optional but necessary to express classical DH (where the ``d``/``a``
     translations happen *after* the joint rotation).
+
+    ``limits`` is an optional ``(lo, hi)`` pair giving the joint's reachable
+    range (radians for revolute, metres for prismatic). ``None`` means
+    unconstrained / unspecified -- ssik solvers don't filter by limits
+    inside the kernel (that lives in :mod:`ssik.postprocess`); the limits
+    are kinematic data downstream code can consume. The single in-kernel
+    consumer is :func:`ssik.solvers.jointlock.seven_r.solve`, which
+    clamps the default ``lock_samples`` sweep to ``[lo, hi]`` when
+    available so we don't waste samples outside the joint's range.
     """
 
     parent_link_T: NDArray[np.float64]
@@ -56,6 +65,7 @@ class JointSpec:
     joint_type: JointType
     child_link_T: NDArray[np.float64] | None = None
     name: str | None = None
+    limits: tuple[float, float] | None = None
 
 
 @dataclass(eq=False)
@@ -88,6 +98,10 @@ class Joint:
     Multi-axis joints (spherical, universal) are not supported — ``iaxis`` must
     be ``0``. Mimic/passive joints are not supported either; the relevant stubs
     raise if the solver tries to treat this joint as mimic.
+
+    ``limits`` mirrors :attr:`JointSpec.limits` -- an ``(lo, hi)`` pair or
+    ``None`` for unconstrained / unspecified. Solvers don't filter by limits
+    inside the kernel; downstream code in :mod:`ssik.postprocess` does.
     """
 
     name: str
@@ -97,6 +111,7 @@ class Joint:
     T_right: NDArray[np.float64]
     axis: NDArray[np.float64]
     joint_type: JointType
+    limits: tuple[float, float] | None = None
 
     def _check_iaxis(self, iaxis: int) -> None:
         if iaxis != 0:
@@ -246,7 +261,15 @@ def build_kinbody(
     # frame and the world-frame position of the rotation axis.
     R_cum = np.eye(3, dtype=np.float64)
     pos_cum = np.zeros(3, dtype=np.float64)
-    records: list[tuple[str, JointType, NDArray[np.float64], NDArray[np.float64]]] = []
+    records: list[
+        tuple[
+            str,
+            JointType,
+            NDArray[np.float64],
+            NDArray[np.float64],
+            tuple[float, float] | None,
+        ]
+    ] = []
     for i, spec in enumerate(specs):
         T_left = np.ascontiguousarray(spec.parent_link_T, dtype=np.float64)
         if T_left.shape != (4, 4):
@@ -276,7 +299,7 @@ def build_kinbody(
         R_cum = R_cum @ T_right[:3, :3]
 
         joint_name = spec.name if spec.name is not None else f"j{i}"
-        records.append((joint_name, spec.joint_type, axis_world, joint_origin))
+        records.append((joint_name, spec.joint_type, axis_world, joint_origin, spec.limits))
 
     # Second pass: emit POE-normalised joints. T_left is pure translation
     # (offset between consecutive joint origins in world); T_right is
@@ -284,7 +307,7 @@ def build_kinbody(
     # home_rotation). pos_cum and R_cum at this point are the FK at q=0.
     joints: list[Joint] = []
     prev_origin = np.zeros(3, dtype=np.float64)
-    for i, (joint_name, joint_type, axis_world, joint_origin) in enumerate(records):
+    for i, (joint_name, joint_type, axis_world, joint_origin, limits) in enumerate(records):
         new_T_left = np.eye(4, dtype=np.float64)
         new_T_left[:3, 3] = joint_origin - prev_origin
 
@@ -308,6 +331,7 @@ def build_kinbody(
                 T_right=new_T_right,
                 axis=axis_world,
                 joint_type=joint_type,
+                limits=limits,
             )
         )
         prev_origin = joint_origin

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -126,6 +126,10 @@ def load_urdf_kinbody(
         joint_type = _map_joint_type(uj.joint_type, uj.name)
         T_left = pending_fixed @ np.asarray(uj.origin, dtype=np.float64)
         pending_fixed = _IDENTITY.copy()
+        if uj.joint_type == "continuous" or uj.limit is None:
+            limits: tuple[float, float] | None = None
+        else:
+            limits = (float(uj.limit.lower), float(uj.limit.upper))
 
         child_link = Link(name=uj.child)
         joints.append(
@@ -137,6 +141,7 @@ def load_urdf_kinbody(
                 T_right=_IDENTITY.copy(),
                 axis=np.asarray(uj.axis, dtype=np.float64),
                 joint_type=joint_type,
+                limits=limits,
             )
         )
         links.append(child_link)
@@ -158,6 +163,7 @@ def load_urdf_kinbody(
             T_right=last.T_right @ pending_fixed,
             axis=last.axis,
             joint_type=last.joint_type,
+            limits=last.limits,
         )
 
     # The last link we appended carries the active-chain's child name; rename
@@ -217,8 +223,19 @@ def load_urdf_kinbody_normalized(
     pos_cum = np.zeros(3, dtype=np.float64)
     prev_active_pos = np.zeros(3, dtype=np.float64)
 
-    # Per-active-joint records: (name, joint_type, axis_base, P_offset).
-    records: list[tuple[str, JointType, NDArray[np.float64], NDArray[np.float64]]] = []
+    # Per-active-joint records: (name, joint_type, axis_base, P_offset, limits).
+    # ``limits`` is ``None`` for URDF ``continuous`` joints (free rotation, no
+    # range) and for any joint without a ``<limit>`` element. Otherwise it's
+    # ``(lower, upper)`` from urchin.
+    records: list[
+        tuple[
+            str,
+            JointType,
+            NDArray[np.float64],
+            NDArray[np.float64],
+            tuple[float, float] | None,
+        ]
+    ] = []
 
     for uj in chain:
         if uj.mimic is not None:
@@ -242,7 +259,14 @@ def load_urdf_kinbody_normalized(
         joint_type = _map_joint_type(uj.joint_type, uj.name)
         axis_base = r_cum @ np.asarray(uj.axis, dtype=np.float64)
         p_offset = pos_cum - prev_active_pos
-        records.append((uj.name, joint_type, axis_base, p_offset))
+        # Continuous URDF joints (free rotation) have no <limit>; urchin
+        # returns ``j.limit = None``. Same handling for any joint with no
+        # explicit limit element. Limited joints get ``(lower, upper)``.
+        if uj.joint_type == "continuous" or uj.limit is None:
+            limits = None
+        else:
+            limits = (float(uj.limit.lower), float(uj.limit.upper))
+        records.append((uj.name, joint_type, axis_base, p_offset, limits))
         prev_active_pos = pos_cum.copy()
 
     if not records:
@@ -266,7 +290,7 @@ def load_urdf_kinbody_normalized(
     link_names = [base_link, *[f"_poe_link_{i}" for i in range(1, n)], ee_link]
     links = [Link(name=name) for name in link_names]
     joints: list[Joint] = []
-    for i, (name, joint_type, axis_base, p_offset) in enumerate(records):
+    for i, (name, joint_type, axis_base, p_offset, limits) in enumerate(records):
         t_left = np.eye(4, dtype=np.float64)
         t_left[:3, 3] = p_offset
         t_right = final_t_right if i == n - 1 else _IDENTITY.copy()
@@ -279,6 +303,7 @@ def load_urdf_kinbody_normalized(
                 T_right=t_right,
                 axis=axis_base,
                 joint_type=joint_type,
+                limits=limits,
             )
         )
 

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -375,8 +375,9 @@ def _kb_digest(kb: KinBody) -> str:
     """
     import hashlib
 
+    # Bumped to v2 when joint limits joined the kinematic spec (#129).
     h = hashlib.sha256()
-    h.update(b"ssik-kinbody-v1\n")
+    h.update(b"ssik-kinbody-v2\n")
     for link in kb.links:
         h.update(b"L:")
         h.update(link.name.encode("utf-8"))
@@ -400,6 +401,11 @@ def _kb_digest(kb: KinBody) -> str:
             for v in row:
                 h.update(f"{v!r}".encode())
                 h.update(b",")
+        h.update(b":lim=")
+        if joint.limits is None:
+            h.update(b"None")
+        else:
+            h.update(f"{joint.limits[0]!r},{joint.limits[1]!r}".encode())
         h.update(b"\n")
     return h.hexdigest()[:12]
 
@@ -482,6 +488,10 @@ def _render_kinbody_constants(kb: KinBody) -> str:
     for j in kb.joints:
         lines.append(f"    {j.joint_type!r},")
     lines.append("]\n")
+    lines.append("_JOINT_LIMITS = [")
+    for j in kb.joints:
+        lines.append(f"    {j.limits!r},")
+    lines.append("]\n")
     return "\n".join(lines)
 
 
@@ -502,6 +512,7 @@ def _render_kinbody_builder() -> str:
                     T_right=_JOINT_T_RIGHTS[i],
                     axis=_JOINT_AXES[i],
                     joint_type=_JOINT_TYPES[i],
+                    limits=_JOINT_LIMITS[i],
                 )
                 for i in range(len(_JOINT_NAMES))
             ]

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -311,9 +311,13 @@ def solve(
 
     :param kb: POE-normalized :class:`KinBody` with 7 revolute joints.
     :param T_target: 4x4 target end-effector pose in the base frame.
-    :param lock_samples: either an ``int N`` (uniform sweep over
-        ``[-pi, pi]`` with N samples), or an explicit sequence of
-        lock-joint values. Default 16.
+    :param lock_samples: either an ``int N`` (uniform sweep over the
+        locked joint's reachable range with ``N`` samples), or an explicit
+        sequence of lock-joint values. Default 16. The sweep range is
+        ``kb.joints[lock_idx].limits`` if set, otherwise ``[-pi, pi]``
+        (which is the full revolution and the right default for
+        continuous / unspecified-limit joints). Explicit sequences
+        bypass the range clamp -- the caller's values win.
     :param policy: tolerances (forwarded to inner 6R solver).
     :param allow_refinement: opt into Newton polish on each inner-solver
         candidate (#74). Default off.
@@ -335,7 +339,17 @@ def solve(
         lock_idx = choose_lock_joint(kb, policy)
 
     if isinstance(lock_samples, int):
-        samples = np.linspace(-np.pi, np.pi, lock_samples, endpoint=False)
+        # Clamp the uniform sweep to the locked joint's reachable range
+        # when known (limits=None for continuous joints means free
+        # rotation -> sweep [-pi, pi] = one full revolution, the unique
+        # sample space). For limited joints this avoids wasting samples
+        # in unreachable territory.
+        joint_limits = kb.joints[lock_idx].limits
+        if joint_limits is None:
+            lo, hi = -np.pi, np.pi
+        else:
+            lo, hi = joint_limits
+        samples = np.linspace(lo, hi, lock_samples, endpoint=False)
     else:
         samples = np.array(list(lock_samples), dtype=np.float64)
 

--- a/tests/artifacts/franka_panda_ik.py
+++ b/tests/artifacts/franka_panda_ik.py
@@ -1,0 +1,257 @@
+"""Generated IK module for Franka Emika Panda (no hand).
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Provenance: KinBody hash d5f03f641ddf (sha256/12 of the input chain).
+
+Solver: ``jointlock.seven_r`` (tier 1)
+Expected median IK time: ~50.0 ms on commodity
+single-thread hardware. FLOP budget: 30,274 per solve.
+
+Usage:
+
+    import franka_panda_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions, is_ls = franka_panda_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
+signals that no solution closed within the solver's FK tolerance,
+and the returned list is the best-LS approximation (or empty).
+"""
+
+from __future__ import annotations
+
+import math
+from ssik.solvers.jointlock import seven_r as _ssik_seven_r
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
+from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
+
+SOLVER_NAME = "jointlock.seven_r"
+SOLVER_TIER = 1
+EXPECTED_MS_MEDIAN = 50.0
+FLOP_BUDGET = 30274
+DISPATCH_REASON = '7R revolute chain. Locking one joint (auto-selected by\ntopology rank of the resulting 6R sub-chain) reduces this\nto a series of 6R IK problems. Covers Franka Panda, FR3,\nKUKA iiwa, Flexiv Rizon, Kinova Gen3, uFactory xArm7.'
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['base_link', 'link_1', 'link_2', 'link_3', 'link_4', 'link_5', 'link_6', 'ee_link']
+
+_JOINT_NAMES = [
+    'panda_joint1',
+    'panda_joint2',
+    'panda_joint3',
+    'panda_joint4',
+    'panda_joint5',
+    'panda_joint6',
+    'panda_joint7',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.9999999999999998, 2.220446049250313e-16], dtype=np.float64),
+    np.array([0.0, 0.0, 0.9999999999999996], dtype=np.float64),
+    np.array([0.0, -0.9999999999999993, 2.220446049250312e-16], dtype=np.float64),
+    np.array([0.0, 0.0, 0.9999999999999991], dtype=np.float64),
+    np.array([0.0, -0.9999999999999989, 2.220446049250311e-16], dtype=np.float64),
+    np.array([0.0, -4.440892098500621e-16, -0.9999999999999987], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.333], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -7.01660951563099e-17], [0.0, 0.0, 1.0, 0.316], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0825], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -0.0825], [0.0, 1.0, 0.0, 8.526512829121199e-17], [0.0, 0.0, 1.0, 0.3839999999999997], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.088], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[-0.7071068058785943, -0.7071067564945002, 0.0, 0.0], [-0.7071067564944993, 0.7071068058785934, -4.440892098500621e-16, -4.7517545453956644e-17], [3.1401848077128287e-16, -3.140185027022262e-16, -0.9999999999999987, -0.10699999999999987], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+_JOINT_LIMITS = [
+    (-2.8973, 2.8973),
+    (-1.7628, 1.7628),
+    (-2.8973, 2.8973),
+    (-3.0718, -0.0698),
+    (-2.8973, 2.8973),
+    (-0.0175, 3.7525),
+    (-2.8973, 2.8973),
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+# --- 7R via joint-lock ---
+# Pre-selected lock_idx via choose_lock_joint at codegen time, passed
+# to the runtime solve() so it skips the per-IK topology-rank scan
+# over all 7 lock candidates. Per-sample inner-solver dispatch still
+# happens at runtime (rotating downstream axes by R_lock can shift
+# which tier-0/1 specialization applies).
+_LOCK_IDX = 4
+
+
+def _solve_algebraic(T_target):
+    """7R IK candidates via joint-locking + inner 6R sweep.
+
+    Routes to ssik.solvers.jointlock.seven_r.solve with the baked
+    KinBody and pre-selected lock_idx. Returns ``list[list[float]]``
+    of length-7 q-vectors.
+    """
+    sub_solutions, _is_ls = _ssik_seven_r.solve(
+        _KB, T_target, lock_idx=_LOCK_IDX
+    )
+    return [list(s.q) for s in sub_solutions]
+
+
+def _fk(q):
+    """POE forward kinematics using the baked KinBody."""
+    T = np.eye(4)
+    for j, qi in zip(_KB.joints, q, strict=True):
+        rot = np.eye(4)
+        rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
+        T = T @ j.T_left @ rot @ j.T_right
+    return T
+
+
+def _wrap_to_pi(a):
+    return ((a + math.pi) % (2 * math.pi)) - math.pi
+
+
+def solve(
+    T_target,
+    *,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+):
+    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose.
+    :param policy: tolerance policy (FK closure + dedup tolerance).
+    :param allow_refinement: opt into Newton-on-spatial-Jacobian
+        polish for near-miss candidates (those whose algebraic q
+        doesn't quite meet ``fk_atol``). Default off.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    """
+    T = np.asarray(T_target, dtype=np.float64)
+    candidates = _solve_algebraic(T)
+
+    fk_atol = policy.subproblem_numerical
+    dedup_atol = policy.subproblem_dedup
+
+    # Three-bucket sort: exact (closes within fk_atol), near-miss
+    # (refinable when allow_refinement=True), or drop.
+    verified: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q in candidates:
+        q = np.asarray(cand_q, dtype=np.float64)
+        if not np.all(np.isfinite(q)):
+            continue
+        T_check = _fk(q)
+        residual = float(np.linalg.norm(T_check - T))
+        if residual <= fk_atol:
+            verified.append((q, residual, "none", 0))
+            continue
+        if not allow_refinement:
+            continue
+        # Newton polish using the baked KinBody's spatial Jacobian.
+        refined = _lm_refine(
+            q,
+            _fk,
+            T,
+            fk_atol=fk_atol,
+            max_iters=refinement_max_iters,
+            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+        )
+        if refined is None:
+            continue
+        q_ref, resid_ref, iters = refined
+        verified.append((q_ref, resid_ref, "lm", iters))
+
+    # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    deduped: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q, cand_res, ref_used, ref_iters in verified:
+        dup_idx = None
+        for j, (existing_q, _, _, _) in enumerate(deduped):
+            diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
+            if np.all(np.abs(diffs) < dedup_atol):
+                dup_idx = j
+                break
+        if dup_idx is None:
+            deduped.append((cand_q, cand_res, ref_used, ref_iters))
+        elif cand_res < deduped[dup_idx][1]:
+            deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
+
+    solutions = [
+        Solution(
+            q=q,
+            fk_residual=residual,
+            refinement_used=ref_used,
+            refinement_iters=ref_iters,
+            branch_id=i,
+            solver_name=SOLVER_NAME,
+        )
+        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+    ]
+    return solutions, len(solutions) == 0
+
+
+__all__ = [
+    "DISPATCH_REASON",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "solve",
+]

--- a/tests/artifacts/jaco2_ik.py
+++ b/tests/artifacts/jaco2_ik.py
@@ -5,7 +5,7 @@ running analytical inverse kinematics on this specific arm. The
 per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
-Provenance: KinBody hash 970cf933f829 (sha256/12 of the input chain).
+Provenance: KinBody hash 51772c059f98 (sha256/12 of the input chain).
 
 Solver: ``ikgeo.general_6r`` (tier 2)
 Expected median IK time: ~5.0 ms on commodity
@@ -101,6 +101,15 @@ _JOINT_TYPES = [
     'revolute',
 ]
 
+_JOINT_LIMITS = [
+    None,
+    (0.820305, 5.46288),
+    (0.331613, 5.95157),
+    None,
+    None,
+    None,
+]
+
 
 def _build_kb() -> KinBody:
     """Reconstruct the baked KinBody. Run once at module import."""
@@ -114,6 +123,7 @@ def _build_kb() -> KinBody:
             T_right=_JOINT_T_RIGHTS[i],
             axis=_JOINT_AXES[i],
             joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
         )
         for i in range(len(_JOINT_NAMES))
     ]

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -5,7 +5,7 @@ running analytical inverse kinematics on this specific arm. The
 per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
-Provenance: KinBody hash d08202c0ca6c (sha256/12 of the input chain).
+Provenance: KinBody hash d7fe5076cb07 (sha256/12 of the input chain).
 
 Solver: ``ikgeo.spherical_two_parallel`` (tier 0)
 Expected median IK time: ~1.2 ms on commodity
@@ -96,6 +96,15 @@ _JOINT_TYPES = [
     'revolute',
 ]
 
+_JOINT_LIMITS = [
+    (-3.14159265358979, 3.14159265358979),
+    (-3.14159265358979, 3.14159265358979),
+    (-3.14159265358979, 3.14159265358979),
+    (-3.14159265358979, 3.14159265358979),
+    (-3.14159265358979, 3.14159265358979),
+    (-3.14159265358979, 3.14159265358979),
+]
+
 
 def _build_kb() -> KinBody:
     """Reconstruct the baked KinBody. Run once at module import."""
@@ -109,6 +118,7 @@ def _build_kb() -> KinBody:
             T_right=_JOINT_T_RIGHTS[i],
             axis=_JOINT_AXES[i],
             joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
         )
         for i in range(len(_JOINT_NAMES))
     ]

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -5,7 +5,7 @@ running analytical inverse kinematics on this specific arm. The
 per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
-Provenance: KinBody hash a914c659b3a3 (sha256/12 of the input chain).
+Provenance: KinBody hash 18d616aad415 (sha256/12 of the input chain).
 
 Solver: ``ikgeo.three_parallel`` (tier 0)
 Expected median IK time: ~1.6 ms on commodity
@@ -97,6 +97,15 @@ _JOINT_TYPES = [
     'revolute',
 ]
 
+_JOINT_LIMITS = [
+    (-6.28318530717959, 6.28318530717959),
+    (-6.28318530717959, 6.28318530717959),
+    (-3.14159265358979, 3.14159265358979),
+    (-6.28318530717959, 6.28318530717959),
+    (-6.28318530717959, 6.28318530717959),
+    (-6.28318530717959, 6.28318530717959),
+]
+
 
 def _build_kb() -> KinBody:
     """Reconstruct the baked KinBody. Run once at module import."""
@@ -110,6 +119,7 @@ def _build_kb() -> KinBody:
             T_right=_JOINT_T_RIGHTS[i],
             axis=_JOINT_AXES[i],
             joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
         )
         for i in range(len(_JOINT_NAMES))
     ]

--- a/tests/fixtures/franka_panda.py
+++ b/tests/fixtures/franka_panda.py
@@ -80,6 +80,19 @@ _FRANKA_JOINT_FRAMES: tuple[
     ((0.088, 0.0, 0.0), (1.0, 1.0, 0.0, 0.0)),
 )
 
+# Per-joint reachable range from the MJCF ``range="lo hi"`` attributes
+# (joints with no explicit range inherit the panda-class default of
+# ``-2.8973 .. 2.8973``).
+_FRANKA_JOINT_LIMITS: tuple[tuple[float, float], ...] = (
+    (-2.8973, 2.8973),  # joint1 (default class)
+    (-1.7628, 1.7628),  # joint2 (override)
+    (-2.8973, 2.8973),  # joint3 (default class)
+    (-3.0718, -0.0698),  # joint4 (override)
+    (-2.8973, 2.8973),  # joint5 (default class)
+    (-0.0175, 3.7525),  # joint6 (override)
+    (-2.8973, 2.8973),  # joint7 (default class)
+)
+
 # End-effector attachment-site offset inside link_7 (post-joint-7).
 _FRANKA_EE_FRAME: tuple[tuple[float, float, float], tuple[float, float, float, float]] = (
     (0.0, 0.0, 0.107),
@@ -91,7 +104,11 @@ def franka_panda_specs() -> list[JointSpec]:
     """7 revolute :class:`JointSpec`s for the Franka Panda arm chain.
 
     Joint 7's ``child_link_T`` carries the EE attachment-site offset so
-    forward kinematics produces the EE pose used by IK targets.
+    forward kinematics produces the EE pose used by IK targets. Each
+    joint carries its MJCF-supplied reachable range in ``limits``;
+    ``ssik.solvers.jointlock.seven_r.solve`` clamps the default
+    ``lock_samples`` sweep to the locked joint's range so we don't waste
+    samples outside reachable territory.
     """
     z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
     specs: list[JointSpec] = []
@@ -106,6 +123,7 @@ def franka_panda_specs() -> list[JointSpec]:
                 joint_type="revolute",
                 child_link_T=child,
                 name=f"panda_joint{i + 1}",
+                limits=_FRANKA_JOINT_LIMITS[i],
             )
         )
     return specs

--- a/tests/fixtures/jaco2.py
+++ b/tests/fixtures/jaco2.py
@@ -78,12 +78,27 @@ _JACO2_EE_FRAME: tuple[tuple[float, float, float], tuple[float, float, float, fl
     (0.0, 0.707107, 0.707107, 0.0),
 )
 
+# Per-joint reachable range from the MJCF ``range="lo hi"`` attributes.
+# Joints with no explicit ``range`` attribute (joints 1, 4, 5, 6) are
+# treated as continuous (free rotation, ``limits=None``) -- the URDF
+# ``continuous`` convention. Joints 2 and 3 have explicit ranges.
+_JACO2_JOINT_LIMITS: tuple[tuple[float, float] | None, ...] = (
+    None,  # joint_1: no range -> continuous
+    (0.820305, 5.46288),  # joint_2
+    (0.331613, 5.95157),  # joint_3
+    None,  # joint_4: no range -> continuous
+    None,  # joint_5: no range -> continuous
+    None,  # joint_6: no range -> continuous
+)
+
 
 def jaco2_specs() -> list[JointSpec]:
     """6 revolute :class:`JointSpec`s for the JACO 2 arm chain.
 
     Joint 6's ``child_link_T`` carries the EE-site offset so the chain's
-    forward kinematics produces the EE pose used by IK targets.
+    forward kinematics produces the EE pose used by IK targets. Each
+    joint carries its MJCF reachable range in ``limits`` (``None`` for
+    continuous joints).
     """
     z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
     specs: list[JointSpec] = []
@@ -98,6 +113,7 @@ def jaco2_specs() -> list[JointSpec]:
                 joint_type="revolute",
                 child_link_T=child,
                 name=f"j2n6s200_joint_{i + 1}",
+                limits=_JACO2_JOINT_LIMITS[i],
             )
         )
     return specs

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -73,6 +73,21 @@ def _emit_jaco2() -> str:
     return result.source
 
 
+def _emit_franka_panda() -> str:
+    from franka_panda import franka_panda_specs
+
+    kb = build_kinbody(franka_panda_specs())
+    plan = dispatch(kb)
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="franka_panda_ik",
+        output_path=None,
+        arm_label="Franka Emika Panda (no hand)",
+    )
+    return result.source
+
+
 @pytest.mark.parametrize(
     ("module_name", "emit_fn"),
     [
@@ -91,6 +106,7 @@ def _emit_jaco2() -> str:
             ),
         ),
         ("jaco2_ik", _emit_jaco2),
+        ("franka_panda_ik", _emit_franka_panda),
     ],
 )
 def test_committed_artifact_matches_regeneration(module_name: str, emit_fn: object) -> None:

--- a/tests/test_franka_fixture.py
+++ b/tests/test_franka_fixture.py
@@ -151,3 +151,52 @@ def test_franka_7r_solves_via_reversed_dispatch() -> None:
         f"Franka 7R IK closed only {closures}/5 random poses -- "
         "the reversed-chain dispatch isn't producing valid solutions."
     )
+
+
+def test_franka_joint_limits_baked_into_kinbody() -> None:
+    """Each joint's MJCF-supplied ``range`` lands in ``Joint.limits`` after
+    ``build_kinbody`` POE-normalisation. Limits are kinematic data (frame
+    change is a no-op on them).
+    """
+    kb = build_kinbody(franka_panda_specs())
+    expected = [
+        (-2.8973, 2.8973),  # joint1
+        (-1.7628, 1.7628),  # joint2
+        (-2.8973, 2.8973),  # joint3
+        (-3.0718, -0.0698),  # joint4
+        (-2.8973, 2.8973),  # joint5
+        (-0.0175, 3.7525),  # joint6
+        (-2.8973, 2.8973),  # joint7
+    ]
+    for i, lim in enumerate(expected):
+        assert kb.joints[i].limits == lim, f"joint {i} limits"
+
+
+def test_franka_seven_r_lock_samples_clamps_to_limits() -> None:
+    """``seven_r.solve`` default lock-sample sweep covers the locked joint's
+    actual range, not ``[-pi, pi]``. Exercises the clamping path in #129
+    Step 1.
+    """
+    from ssik.solvers.jointlock.seven_r import choose_lock_joint
+    from ssik.solvers.jointlock.seven_r import solve as seven_r_solve
+
+    kb = build_kinbody(franka_panda_specs())
+    lock_idx = choose_lock_joint(kb)
+    # Joint 4 has limits (-2.8973, 2.8973) -- about 92% of [-pi, pi].
+    expected_lo, expected_hi = kb.joints[lock_idx].limits  # type: ignore[misc]
+
+    # FK on the home pose gives a reachable target. The solve internally
+    # builds samples = np.linspace(lo, hi, N, endpoint=False); we can't
+    # observe them directly, but we can verify the chosen lock_idx's
+    # limits have the expected MJCF-supplied bounds (Franka joint 4
+    # is the forearm-adjacent joint, range -2.8973..2.8973).
+    assert lock_idx == 4
+    assert expected_lo == -2.8973
+    assert expected_hi == 2.8973
+
+    # Also verify a real solve still works through the limits-aware
+    # sweep (regression check: clamping shouldn't break IK).
+    T_home = _fk(kb, FRANKA_PANDA_KEYFRAMES["home"])
+    sols, is_ls = seven_r_solve(kb, T_home)
+    assert not is_ls
+    assert len(sols) > 0

--- a/tests/test_kinbody.py
+++ b/tests/test_kinbody.py
@@ -13,11 +13,15 @@ import pytest
 from ssik._kinbody import JointSpec, KinBody, Link, build_kinbody
 
 
-def _spec(joint_type: str = "revolute") -> JointSpec:
+def _spec(
+    joint_type: str = "revolute",
+    limits: tuple[float, float] | None = None,
+) -> JointSpec:
     return JointSpec(
         parent_link_T=np.eye(4),
         axis=np.array([0.0, 0.0, 1.0]),
         joint_type=joint_type,  # type: ignore[arg-type]
+        limits=limits,
     )
 
 
@@ -195,3 +199,28 @@ def test_custom_joint_names_preserved() -> None:
     )
     kb = build_kinbody([spec])
     assert kb.joints[0].GetName() == "shoulder_pan"
+
+
+def test_joint_limits_default_none() -> None:
+    """Joints without explicit limits default to ``limits=None`` (continuous /
+    unspecified). This is the silent backwards-compat path for fixtures that
+    don't supply limits."""
+    kb = build_kinbody([_spec(), _spec()])
+    for j in kb.joints:
+        assert j.limits is None
+
+
+def test_joint_limits_propagate_through_build_kinbody() -> None:
+    """``JointSpec.limits`` propagate to ``Joint.limits`` after POE
+    normalisation. Limits are kinematic data; the normalisation is a frame
+    change, not a re-parametrisation, so limits stay attached to the same
+    physical joint."""
+    specs = [
+        _spec(limits=(-1.0, 1.0)),
+        _spec(limits=None),  # continuous middle joint
+        _spec(limits=(-2.5, 0.5)),
+    ]
+    kb = build_kinbody(specs)
+    assert kb.joints[0].limits == (-1.0, 1.0)
+    assert kb.joints[1].limits is None
+    assert kb.joints[2].limits == (-2.5, 0.5)


### PR DESCRIPTION
## Summary

Adds joint reachable-range as data on ``JointSpec`` / ``Joint``, plumbs it through the URDF and MJCF construction paths, and uses it in one narrow place inside the kernel (``seven_r.solve`` lock-sample sweep). Per the IKFast / EAIK convention, solvers do NOT filter by limits — that lives in ``ssik.postprocess`` (#130). Limits are a property of the kinematic spec; what the caller does with them is composable.

## Pieces

- ``JointSpec.limits: tuple[float, float] | None = None``
- ``Joint.limits: tuple[float, float] | None = None``
- ``build_kinbody`` propagates ``limits`` through POE normalisation unchanged (frame change is a no-op on limits).
- URDF loaders pull ``urchin``'s ``j.limit.lower/upper``. URDF ``continuous`` joints (``j.limit is None``) → ``limits=None`` (free rotation, no clamp).
- MJCF fixtures (``jaco2``, ``franka_panda``) carry their per-joint ``range`` attributes; joints without an explicit range stay ``None``.

## Kernel use (one place only)

``ssik.solvers.jointlock.seven_r.solve``'s default ``lock_samples`` sweep uses the locked joint's ``[lo, hi]`` when available, falls back to ``[-pi, pi]`` otherwise. Explicit user-supplied sample arrays still bypass the clamp.

## Codegen

- ``_render_kinbody_constants`` emits ``_JOINT_LIMITS``.
- ``_build_kb`` reconstructs ``Joint(... limits=_JOINT_LIMITS[i])``.
- ``_kb_digest`` v1 → v2 (limits in the hash).

## Franka artifact (new)

``regen_artifacts.py`` now also emits ``tests/artifacts/franka_panda_ik.py`` via the 7R wrapper composer. The artifact bakes the Franka KinBody including all 7 joint limits; ``solve()`` runs the chain-reversal closed-form path (#128) and clamps the lock-sample sweep to joint 4's range ``[-2.8973, 2.8973]`` automatically. ~48 ms median per IK call (16 samples × ~3 ms inner ``spherical_two_parallel``); FK closure at machine precision.

## Tests

- ``test_kinbody``: limits default, limits propagation
- ``test_franka_fixture``: limits baked into KinBody, lock_samples clamps to range
- ``test_artifact_snapshots`` adds the Franka artifact
- All 4 artifact snapshots (UR5, Puma, JACO 2, Franka) byte-stable on the regen platform
- 428 tests pass; pre-existing flakes unaffected
- Lint, format, mypy clean

## Out of scope (separate issues)

- ``respect_limits`` / ``wrap_to_limits`` / ``q_seed`` / ``max_solutions`` → all in #130 (``ssik.postprocess``)
- Per-arm refinement specialisation (#126), numerical multi-restart (#127), more 7R fixtures (Step 4) → separate PRs

Closes #129.