### PR TITLE
#130: ssik.postprocess (composable filters for IK solutions)

### DIFF
--- a/src/ssik/postprocess.py
+++ b/src/ssik/postprocess.py
@@ -1,0 +1,203 @@
+"""Composable post-processing filters for IK solutions.
+
+ssik's analytical IK kernel returns the full geometric solution set --
+every branch the math admits, regardless of joint limits, distance to a
+preferred configuration, or any other application-level concern. This
+module provides the building blocks the application layer composes on top.
+
+Convention follows IKFast (OpenRAVE wrapper handles limits + collision +
+nearest-to-seed in a separate Python layer above the generated kernel) and
+EAIK (``mj_manipulator/franka.py`` wraps EAIK's pure IK with limit /
+seed / collision logic on the Python side).
+
+Each function takes ``list[Solution]`` (and any extra args) and returns
+``list[Solution]`` -- pure transforms, easy to test, easy to compose.
+The four shipping with v0.1 cover ~95% of real-world post-processing:
+
+  * :func:`respect_limits` -- drop solutions outside any joint's range
+  * :func:`wrap_to_limits` -- try ``q ± 2*pi`` per joint to bring solutions in
+  * :func:`nearest_to_seed` -- sort by wrap-to-pi distance to a reference q
+  * :func:`max_solutions` -- truncate to the first ``k``
+
+Production pipeline pattern::
+
+    from franka_panda_ik import _KB, solve
+    from ssik.postprocess import (
+        respect_limits, wrap_to_limits, nearest_to_seed, max_solutions,
+    )
+
+    sols, _ = solve(T_target)
+    sols = wrap_to_limits(sols, _KB)
+    sols = respect_limits(sols, _KB)
+    sols = nearest_to_seed(sols, q_current)
+    sols = max_solutions(sols, k=4)
+
+Out of scope for v0.1 (separate issues / future work):
+
+  * Collision filtering (needs a collision backend such as FCL).
+  * Trajectory-context filters (continuous q-trajectory with smoothness).
+  * Reachability / dexterity scoring.
+
+These can be follow-ups; the four above cover the common case and form a
+self-contained module that compiles cleanly to a single shared ``.so``
+in Phase 4 (no per-arm specialisation, no symbolic precompute).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+from ssik.core.solution import Solution
+
+__all__ = [
+    "max_solutions",
+    "nearest_to_seed",
+    "respect_limits",
+    "wrap_to_limits",
+]
+
+
+def respect_limits(sols: list[Solution], kb: KinBody) -> list[Solution]:
+    """Drop solutions where any joint's q value is outside its reachable range.
+
+    Joints with ``limits=None`` are unconstrained (continuous joints, or
+    fixtures that don't supply limits) and never reject a solution. Joints
+    with ``limits=(lo, hi)`` reject any solution where ``q[i] < lo`` or
+    ``q[i] > hi`` strictly; values exactly on the boundary are accepted.
+
+    :param sols: candidate solutions (e.g. output of an ssik solver's
+        ``solve()``).
+    :param kb: the same :class:`KinBody` used for the IK call. Joint limits
+        come from ``kb.joints[i].limits``.
+    :returns: filtered solutions; preserves input order.
+    """
+    n_joints = len(kb.joints)
+    kept: list[Solution] = []
+    for sol in sols:
+        if len(sol.q) != n_joints:
+            raise ValueError(f"solution q-length {len(sol.q)} doesn't match kb DOF {n_joints}")
+        within = True
+        for i, joint in enumerate(kb.joints):
+            if joint.limits is None:
+                continue
+            lo, hi = joint.limits
+            if sol.q[i] < lo or sol.q[i] > hi:
+                within = False
+                break
+        if within:
+            kept.append(sol)
+    return kept
+
+
+def wrap_to_limits(sols: list[Solution], kb: KinBody) -> list[Solution]:
+    """Try wrapping each joint's q value by ``±2*pi`` integer multiples to
+    bring it into the joint's reachable range.
+
+    A revolute joint at ``q = 3.0`` with limits ``[-pi, pi]`` is FK-equivalent
+    to ``q - 2*pi ≈ -3.28``, which is *also* outside the range, so neither
+    wrap fits and the solution stays at ``q = 3.0`` (and would be dropped by
+    :func:`respect_limits` if called next). A joint at ``q = 4.0`` with
+    limits ``[-pi, pi]`` wraps to ``q - 2*pi ≈ -2.28`` which is in range:
+    we keep the wrapped value.
+
+    Joints with ``limits=None`` are left unchanged (no constraint to wrap
+    into). Prismatic joints are left unchanged (no rotational periodicity).
+
+    Search is over ``k ∈ {-2, -1, 0, +1, +2}`` integer multiples of ``2*pi``;
+    that covers any joint whose limits span up to ±5*pi (more than enough for
+    any commercial arm). The smallest-|k| wrap that lands in range wins,
+    biasing toward the original value.
+
+    :param sols: candidate solutions.
+    :param kb: the same :class:`KinBody` used for the IK call.
+    :returns: solutions with each q-vector adjusted joint-wise; preserves
+        input order; returns ``Solution`` instances with the wrapped q
+        and other fields unchanged.
+    """
+    n_joints = len(kb.joints)
+    out: list[Solution] = []
+    for sol in sols:
+        if len(sol.q) != n_joints:
+            raise ValueError(f"solution q-length {len(sol.q)} doesn't match kb DOF {n_joints}")
+        q_new = np.asarray(sol.q, dtype=np.float64).copy()
+        for i, joint in enumerate(kb.joints):
+            if joint.limits is None or joint.joint_type != "revolute":
+                continue
+            lo, hi = joint.limits
+            q_i = float(q_new[i])
+            if lo <= q_i <= hi:
+                continue
+            # Try wraps with smallest |k| first.
+            best = q_i
+            best_in_range = False
+            for k in (1, -1, 2, -2):
+                candidate = q_i + 2.0 * np.pi * k
+                if lo <= candidate <= hi:
+                    best = candidate
+                    best_in_range = True
+                    break
+            if best_in_range:
+                q_new[i] = best
+        out.append(replace(sol, q=q_new))
+    return out
+
+
+def _wrap_to_pi(angle: float) -> float:
+    """Wrap a single angle to the canonical ``[-pi, pi]`` representative."""
+    return float(((angle + np.pi) % (2.0 * np.pi)) - np.pi)
+
+
+def nearest_to_seed(
+    sols: list[Solution],
+    q_seed: NDArray[np.float64],
+    *,
+    metric: str = "wrap_l2",
+) -> list[Solution]:
+    """Sort solutions by joint-space distance to a reference configuration.
+
+    The "wrap-to-pi" distance treats angle differences modulo ``2*pi``, so
+    e.g. ``q=3.0`` and ``q_seed=-3.0`` are at distance
+    ``|wrap(3.0 - (-3.0))| = |wrap(6.0)| = |6.0 - 2*pi| ≈ 0.28``, not 6.0.
+    This is the right metric for revolute-joint similarity.
+
+    :param sols: candidate solutions.
+    :param q_seed: reference joint configuration (length matches the chain's
+        DOF).
+    :param metric: one of ``"wrap_l2"`` (default; sum-of-squares of
+        wrap-to-pi differences) or ``"wrap_linf"`` (max wrap-to-pi
+        difference). ``wrap_l2`` is smooth and prefers configurations that
+        are uniformly close; ``wrap_linf`` is hard-cap and prefers
+        configurations whose worst-joint deviation is small.
+    :returns: solutions sorted by ascending distance to ``q_seed``. Stable
+        sort: ties preserve input order.
+    """
+    if metric not in ("wrap_l2", "wrap_linf"):
+        raise ValueError(f"unknown metric {metric!r}; expected 'wrap_l2' or 'wrap_linf'")
+    seed = np.asarray(q_seed, dtype=np.float64)
+
+    def distance(sol: Solution) -> float:
+        diffs = [_wrap_to_pi(float(sol.q[i] - seed[i])) for i in range(len(seed))]
+        if metric == "wrap_l2":
+            return float(np.sqrt(sum(d * d for d in diffs)))
+        # wrap_linf
+        return float(max(abs(d) for d in diffs))
+
+    # Python's sort is stable, so ties preserve input order.
+    return sorted(sols, key=distance)
+
+
+def max_solutions(sols: list[Solution], k: int) -> list[Solution]:
+    """Truncate to the first ``k`` solutions.
+
+    Use after :func:`nearest_to_seed` (or any other ranking) to keep only
+    the top-``k`` matches. ``k <= 0`` returns an empty list.
+
+    :param sols: candidate solutions, typically already sorted.
+    :param k: maximum number of solutions to keep.
+    :returns: ``sols[:max(k, 0)]``.
+    """
+    return list(sols[: max(k, 0)])

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,372 @@
+"""Unit tests for :mod:`ssik.postprocess`.
+
+Operates on synthetic ``Solution`` lists -- no IK round-trip needed.
+Each function is tested for its core contract plus edge cases:
+
+* ``respect_limits``: drops out-of-range, keeps in-range, ignores
+  ``limits=None`` joints, preserves input order.
+* ``wrap_to_limits``: wraps ``q ± 2*pi`` when that lands in range,
+  leaves alone if neither wrap fits, no-op for prismatic and
+  ``limits=None`` joints, preserves order, preserves other ``Solution``
+  fields.
+* ``nearest_to_seed``: sorts by wrap-to-pi distance under ``wrap_l2``
+  / ``wrap_linf``; stable on ties.
+* ``max_solutions``: truncates correctly including edge cases.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import JointSpec, KinBody, build_kinbody
+from ssik.core.solution import Solution
+from ssik.postprocess import (
+    max_solutions,
+    nearest_to_seed,
+    respect_limits,
+    wrap_to_limits,
+)
+
+
+def _kb_with_limits(limits: list[tuple[float, float] | None]) -> KinBody:
+    """Build a small KinBody with one joint per entry in ``limits``."""
+    z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    specs = [
+        JointSpec(
+            parent_link_T=np.eye(4),
+            axis=z_axis,
+            joint_type="revolute",
+            limits=lim,
+        )
+        for lim in limits
+    ]
+    return build_kinbody(specs)
+
+
+def _sol(q: list[float]) -> Solution:
+    return Solution(
+        q=np.asarray(q, dtype=np.float64),
+        fk_residual=0.0,
+        solver_name="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# respect_limits
+# ---------------------------------------------------------------------------
+
+
+def test_respect_limits_keeps_in_range() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0), (-2.0, 2.0)])
+    sols = [_sol([0.5, 1.5]), _sol([-0.9, -1.9])]
+    out = respect_limits(sols, kb)
+    assert len(out) == 2
+
+
+def test_respect_limits_drops_out_of_range() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0), (-2.0, 2.0)])
+    sols = [_sol([0.5, 1.5]), _sol([1.5, 0.0])]  # second violates joint 0
+    out = respect_limits(sols, kb)
+    assert len(out) == 1
+    assert out[0].q[0] == 0.5
+
+
+def test_respect_limits_ignores_none_joints() -> None:
+    """``limits=None`` (continuous) joints don't constrain anything."""
+    kb = _kb_with_limits([None, (-1.0, 1.0)])
+    sols = [_sol([100.0, 0.5]), _sol([-100.0, 1.5])]
+    out = respect_limits(sols, kb)
+    # First survives (100.0 unconstrained, 0.5 in range);
+    # second drops (1.5 out of range on joint 1).
+    assert len(out) == 1
+    assert out[0].q[0] == 100.0
+
+
+def test_respect_limits_boundary_inclusive() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sols = [_sol([-1.0]), _sol([1.0])]
+    out = respect_limits(sols, kb)
+    assert len(out) == 2  # both boundaries accepted
+
+
+def test_respect_limits_preserves_order() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sols = [_sol([0.1]), _sol([0.2]), _sol([0.3])]
+    out = respect_limits(sols, kb)
+    assert [float(s.q[0]) for s in out] == pytest.approx([0.1, 0.2, 0.3])
+
+
+def test_respect_limits_rejects_wrong_q_length() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    bad = _sol([0.0, 0.0])  # 2-vector for 1-DOF kb
+    with pytest.raises(ValueError, match="q-length"):
+        respect_limits([bad], kb)
+
+
+# ---------------------------------------------------------------------------
+# wrap_to_limits
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_to_limits_brings_q_into_range() -> None:
+    """q=4.0 with limits [-pi, pi] wraps to ~ -2.283 which IS in range."""
+    kb = _kb_with_limits([(-np.pi, np.pi)])
+    sols = [_sol([4.0])]
+    out = wrap_to_limits(sols, kb)
+    assert len(out) == 1
+    assert -np.pi <= out[0].q[0] <= np.pi
+    # 4.0 - 2*pi ≈ -2.2832
+    assert abs(out[0].q[0] - (4.0 - 2 * np.pi)) < 1e-12
+
+
+def test_wrap_to_limits_leaves_in_range_alone() -> None:
+    kb = _kb_with_limits([(-np.pi, np.pi)])
+    sols = [_sol([1.5])]
+    out = wrap_to_limits(sols, kb)
+    assert out[0].q[0] == 1.5  # unchanged
+
+
+def test_wrap_to_limits_no_wrap_fits() -> None:
+    """q=3.0 with limits [0.5, 1.0] -- no integer 2*pi wrap lands in
+    that narrow range, so q stays at 3.0 (later filtered by respect_limits)."""
+    kb = _kb_with_limits([(0.5, 1.0)])
+    sols = [_sol([3.0])]
+    out = wrap_to_limits(sols, kb)
+    assert out[0].q[0] == 3.0  # unchanged; respect_limits would drop it
+
+
+def test_wrap_to_limits_skips_none_joints() -> None:
+    """Continuous joints (limits=None) are never wrapped."""
+    kb = _kb_with_limits([None])
+    sols = [_sol([10.0])]
+    out = wrap_to_limits(sols, kb)
+    assert out[0].q[0] == 10.0
+
+
+def test_wrap_to_limits_skips_prismatic() -> None:
+    """Prismatic joints have no rotational periodicity; never wrap."""
+    z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    specs = [
+        JointSpec(
+            parent_link_T=np.eye(4),
+            axis=z_axis,
+            joint_type="prismatic",
+            limits=(-1.0, 1.0),
+        )
+    ]
+    kb = build_kinbody(specs)
+    sols = [_sol([5.0])]  # out of range, but never wrapped
+    out = wrap_to_limits(sols, kb)
+    assert out[0].q[0] == 5.0
+
+
+def test_wrap_to_limits_preserves_other_fields() -> None:
+    kb = _kb_with_limits([(-np.pi, np.pi)])
+    original = Solution(
+        q=np.array([4.0]),
+        fk_residual=1.5e-9,
+        refinement_used="lm",
+        refinement_iters=3,
+        branch_id=2,
+        solver_name="test_solver",
+    )
+    out = wrap_to_limits([original], kb)
+    wrapped = out[0]
+    assert wrapped.fk_residual == 1.5e-9
+    assert wrapped.refinement_used == "lm"
+    assert wrapped.refinement_iters == 3
+    assert wrapped.branch_id == 2
+    assert wrapped.solver_name == "test_solver"
+
+
+def test_wrap_to_limits_prefers_smallest_k() -> None:
+    """When multiple wraps land in range, pick smallest |k| (closest to original)."""
+    # If limits are very wide, both q+2*pi and q-2*pi could fit. The smallest-k
+    # wrap is q itself (k=0), so an in-range value should never get wrapped.
+    kb = _kb_with_limits([(-3 * np.pi, 3 * np.pi)])
+    sols = [_sol([0.5])]
+    out = wrap_to_limits(sols, kb)
+    assert out[0].q[0] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# nearest_to_seed
+# ---------------------------------------------------------------------------
+
+
+def test_nearest_to_seed_sorts_l2() -> None:
+    sols = [_sol([0.0, 0.0]), _sol([0.5, 0.5]), _sol([0.1, 0.1])]
+    seed = np.array([0.0, 0.0])
+    out = nearest_to_seed(sols, seed)
+    # Order: [0,0] (dist 0), [0.1,0.1] (~0.14), [0.5,0.5] (~0.71)
+    assert [float(s.q[0]) for s in out] == pytest.approx([0.0, 0.1, 0.5])
+
+
+def test_nearest_to_seed_uses_wrap_metric() -> None:
+    """q=3.0 and seed=-3.0 are wrap-distance ~0.28, NOT 6.0."""
+    sols = [_sol([3.0]), _sol([0.5])]
+    seed = np.array([-3.0])
+    out = nearest_to_seed(sols, seed)
+    # Wrap dist for 3.0 vs -3.0: wrap(6.0) = 6.0 - 2*pi ≈ -0.28, |...| = 0.28
+    # Wrap dist for 0.5 vs -3.0: 3.5 (no wrap needed)
+    # So 3.0 wins despite "looking" farther on raw subtraction.
+    assert out[0].q[0] == 3.0
+    assert out[1].q[0] == 0.5
+
+
+def test_nearest_to_seed_linf_metric() -> None:
+    sols = [_sol([0.5, 0.0]), _sol([0.3, 0.3])]
+    seed = np.array([0.0, 0.0])
+    out = nearest_to_seed(sols, seed, metric="wrap_linf")
+    # linf: [0.5, 0] -> max(0.5, 0) = 0.5; [0.3, 0.3] -> 0.3
+    # So [0.3, 0.3] should come first.
+    assert out[0].q[0] == 0.3
+    assert out[1].q[0] == 0.5
+
+
+def test_nearest_to_seed_stable_sort() -> None:
+    # Two solutions at same distance -- stable sort preserves input order.
+    sols = [_sol([1.0, 0.0]), _sol([-1.0, 0.0])]
+    seed = np.array([0.0, 0.0])
+    out = nearest_to_seed(sols, seed)
+    # Both at distance 1.0; first one stays first.
+    assert out[0].q[0] == 1.0
+    assert out[1].q[0] == -1.0
+
+
+def test_nearest_to_seed_unknown_metric_raises() -> None:
+    sols = [_sol([0.0])]
+    seed = np.array([0.0])
+    with pytest.raises(ValueError, match="unknown metric"):
+        nearest_to_seed(sols, seed, metric="manhattan")
+
+
+# ---------------------------------------------------------------------------
+# max_solutions
+# ---------------------------------------------------------------------------
+
+
+def test_max_solutions_truncates() -> None:
+    sols = [_sol([float(i)]) for i in range(5)]
+    out = max_solutions(sols, k=3)
+    assert len(out) == 3
+    assert [float(s.q[0]) for s in out] == [0.0, 1.0, 2.0]
+
+
+def test_max_solutions_k_larger_than_input() -> None:
+    sols = [_sol([0.0]), _sol([1.0])]
+    out = max_solutions(sols, k=10)
+    assert len(out) == 2
+
+
+def test_max_solutions_k_zero() -> None:
+    sols = [_sol([0.0]), _sol([1.0])]
+    out = max_solutions(sols, k=0)
+    assert out == []
+
+
+def test_max_solutions_k_negative() -> None:
+    sols = [_sol([0.0]), _sol([1.0])]
+    out = max_solutions(sols, k=-3)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Pipeline composition (end-to-end recipe)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_compose_franka_recipe() -> None:
+    """The canonical pipeline: wrap into range -> drop violations ->
+    sort by distance -> top-k. Verifies the composition produces a
+    sensible output without any individual step swallowing the others."""
+    kb = _kb_with_limits([(-np.pi, np.pi), (-1.0, 1.0)])
+    sols = [
+        _sol([4.0, 0.0]),  # joint 0 wraps to ~-2.28 which is in range; joint 1 ok
+        _sol([0.5, 0.5]),  # both in range
+        _sol([0.0, 1.5]),  # joint 1 out of range -> drops
+        _sol([0.1, 0.1]),  # both in range
+        _sol([10.0, 0.0]),  # joint 0 wraps to ~3.72 (out of [-pi, pi]); drops
+    ]
+    seed = np.array([0.0, 0.0])
+
+    sols = wrap_to_limits(sols, kb)
+    sols = respect_limits(sols, kb)
+    sols = nearest_to_seed(sols, seed)
+    sols = max_solutions(sols, k=2)
+
+    assert len(sols) == 2
+    # Closest to seed should come first.
+    assert sols[0].q[0] == pytest.approx(0.1)
+    assert sols[0].q[1] == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real IK output -> postprocess pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_franka_pipeline_real_ik_output() -> None:
+    """Run real Franka 7R IK, then put the output through the canonical
+    pipeline. Verifies the postprocess helpers compose with actual solver
+    output (not just synthetic Solutions).
+
+    Acceptance: after `wrap_to_limits + respect_limits`, every surviving
+    solution lies inside every joint's range. After `nearest_to_seed`, the
+    first one is the closest to ``q_current``. After `max_solutions(k=1)`,
+    we have exactly one.
+    """
+    import sys
+    from pathlib import Path
+
+    fixtures = Path(__file__).parent / "fixtures"
+    sys.path.insert(0, str(fixtures))
+    from franka_panda import franka_panda_specs
+
+    from ssik.kinematics._scalar3 import _mat4_mat4
+    from ssik.solvers.jointlock.seven_r import solve as seven_r_solve
+    from ssik.subproblems._rotation import rotation_matrix
+
+    kb = build_kinbody(franka_panda_specs())
+
+    # FK on a known q gives a reachable target.
+    q_true = np.array([0.1, 0.2, -0.1, -1.5, 0.0, 1.7, -0.5], dtype=np.float64)
+    T = np.eye(4)
+    for j, qi in zip(kb.joints, q_true, strict=True):
+        R = np.eye(4)
+        R[:3, :3] = rotation_matrix(j.axis, float(qi))
+        T = _mat4_mat4(_mat4_mat4(T, _mat4_mat4(j.T_left, R)), j.T_right)
+
+    sols, is_ls = seven_r_solve(kb, T)
+    assert not is_ls
+    assert len(sols) > 0
+
+    # Run the canonical pipeline.
+    sols = wrap_to_limits(sols, kb)
+    sols = respect_limits(sols, kb)
+    assert len(sols) > 0, "all Franka solutions filtered out by limits"
+
+    # Every survivor strictly within every joint's limits.
+    for sol in sols:
+        for i, joint in enumerate(kb.joints):
+            if joint.limits is None:
+                continue
+            lo, hi = joint.limits
+            assert lo <= sol.q[i] <= hi, (
+                f"joint {i} q={sol.q[i]} outside [{lo}, {hi}] -- respect_limits failed"
+            )
+
+    # Sort by distance to seed; q_true is the seed so it should rank first.
+    sols = nearest_to_seed(sols, q_true)
+    # The closest should be very close (sub-radian on every joint, l2 < 1.0).
+    closest_diffs = [
+        abs(((sols[0].q[i] - q_true[i]) + np.pi) % (2 * np.pi) - np.pi) for i in range(7)
+    ]
+    assert max(closest_diffs) < 0.5, (
+        f"closest IK solution to seed has unexpectedly large diffs: {closest_diffs}"
+    )
+
+    # Truncate to top-1.
+    sols = max_solutions(sols, k=1)
+    assert len(sols) == 1


### PR DESCRIPTION
## Summary

Adds [ssik.postprocess](src/ssik/postprocess.py) — four composable building blocks the application layer uses to filter / order / cap analytical-IK solutions. Follows the IKFast / EAIK convention: kernel returns the full geometric solution set; application stitches its own pipeline.

## Functions

- ``respect_limits(sols, kb)`` — drop solutions outside any joint's reachable range (uses ``Joint.limits`` from #129; ``None`` = unconstrained).
- ``wrap_to_limits(sols, kb)`` — try ``q ± 2π`` integer multiples per revolute joint to bring out-of-range values back into the joint's range. Smallest ``|k|`` wins. Skips prismatic and ``limits=None`` joints.
- ``nearest_to_seed(sols, q_seed, *, metric=...)`` — sort by wrap-to-π distance to a reference. ``wrap_l2`` (default) for uniform closeness; ``wrap_linf`` for worst-joint cap. Stable sort.
- ``max_solutions(sols, k)`` — truncate to first ``k``.

Each is a pure transform on ``list[Solution]``. No per-arm specialisation. Compiles to a single shared ``.so`` in Phase 4 (orthogonal to per-arm artifacts).

## Canonical pipeline

```python
from franka_panda_ik import _KB, solve
from ssik.postprocess import (
    wrap_to_limits, respect_limits, nearest_to_seed, max_solutions,
)

sols, _ = solve(T_target)
sols = wrap_to_limits(sols, _KB)
sols = respect_limits(sols, _KB)
sols = nearest_to_seed(sols, q_current)
sols = max_solutions(sols, k=4)
```

## Tests (24 total)

- Unit tests per function: core contract + edge cases (boundary inclusivity, ``limits=None``, prismatic skip, stable sort, k=0/negative, ``wrap_metric`` variants).
- ``test_pipeline_compose_franka_recipe``: synthetic-Solution end-to-end through ``wrap → respect → nearest → max``.
- ``test_franka_pipeline_real_ik_output``: real Franka 7R IK output fed through the canonical pipeline — every survivor lies inside every joint's range; closest-to-seed is numerically close to the seed.

Lint, format, mypy clean.

## Out of scope (post-v0.1)

- Collision filtering (needs a collision backend e.g. FCL)
- Trajectory-context filters (continuous-q smoothness)
- Reachability / dexterity scoring

The four shipping cover ~95% of real-world post-processing.

Closes #130.