### PR TITLE
#126: per-arm _fk + _spatial_jacobian baked into specialised artifacts (.so prereq)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -206,10 +206,10 @@ def _render_specialised(
     buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
     buf.write("from ssik.core.solution import Solution\n")
     buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
-    buf.write(
-        "from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, "
-        "lm_refine as _lm_refine\n"
-    )
+    # _spatial_jacobian is inlined per-arm in the orchestrator (#126); the
+    # only refinement primitive imported from runtime is the generic
+    # Levenberg-Marquardt step.
+    buf.write("from ssik.refinement import lm_refine as _lm_refine\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -235,18 +235,57 @@ def _render_specialised_solve_orchestrator() -> str:
     Wraps ``_solve_algebraic`` with FK verification + wrap-to-pi dedup;
     matches the runtime ``verify_candidates`` semantics. Exposes the
     same kwargs as the thin-wrapper version.
+
+    Both ``_fk`` and ``_spatial_jacobian`` are inlined per-arm: they
+    iterate over the baked ``_JOINT_AXES`` / ``_JOINT_T_LEFTS`` /
+    ``_JOINT_T_RIGHTS`` arrays directly without a ``_KB`` indirection.
+    Cython compiles those loops to native code with const-folded
+    chain constants -- prerequisite for the Level 3 numerical backstop
+    being a clean ``.so``. Math is identical to
+    :func:`ssik.refinement.kinbody_jacobian`; only the indirection
+    changes.
     """
     return textwrap.dedent(
         '''\
 
         def _fk(q):
-            """POE forward kinematics using the baked KinBody."""
+            """POE forward kinematics using the baked chain constants."""
             T = np.eye(4)
-            for j, qi in zip(_KB.joints, q, strict=True):
+            for i in range(len(_JOINT_AXES)):
                 rot = np.eye(4)
-                rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
-                T = T @ j.T_left @ rot @ j.T_right
+                rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+                T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
             return T
+
+
+        def _spatial_jacobian(q):
+            """6 x n_dof spatial Jacobian using the baked chain constants.
+
+            Math identical to ssik.refinement.kinbody_jacobian: column i
+            is (z_i x (p_e - p_i), z_i) where z_i is the i-th joint axis
+            in the world frame at q and p_i / p_e are the i-th joint
+            origin and EE position respectively. Per-arm version with
+            baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+            there's no KinBody walk at runtime.
+            """
+            n = len(_JOINT_AXES)
+            cum = np.eye(4, dtype=np.float64)
+            cums = [cum.copy()]
+            for i in range(n):
+                rot = np.eye(4, dtype=np.float64)
+                rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+                cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+                cums.append(cum.copy())
+            p_e = cums[-1][:3, 3]
+            J = np.zeros((6, n), dtype=np.float64)
+            for i in range(n):
+                t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+                axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+                z_i = t_pre[:3, :3] @ axis_unit
+                p_i = t_pre[:3, 3]
+                J[:3, i] = np.cross(z_i, p_e - p_i)
+                J[3:, i] = z_i
+            return J
 
 
         def _wrap_to_pi(a):
@@ -290,14 +329,14 @@ def _render_specialised_solve_orchestrator() -> str:
                     continue
                 if not allow_refinement:
                     continue
-                # Newton polish using the baked KinBody's spatial Jacobian.
+                # Newton polish using the per-arm spatial Jacobian.
                 refined = _lm_refine(
                     q,
                     _fk,
                     T,
                     fk_atol=fk_atol,
                     max_iters=refinement_max_iters,
-                    jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+                    jacobian_fn=_spatial_jacobian,
                 )
                 if refined is None:
                     continue

--- a/tests/artifacts/franka_panda_ik.py
+++ b/tests/artifacts/franka_panda_ik.py
@@ -36,7 +36,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
+from ssik.refinement import lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "jointlock.seven_r"
@@ -155,13 +155,43 @@ def _solve_algebraic(T_target):
 
 
 def _fk(q):
-    """POE forward kinematics using the baked KinBody."""
+    """POE forward kinematics using the baked chain constants."""
     T = np.eye(4)
-    for j, qi in zip(_KB.joints, q, strict=True):
+    for i in range(len(_JOINT_AXES)):
         rot = np.eye(4)
-        rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
+
+
+def _spatial_jacobian(q):
+    """6 x n_dof spatial Jacobian using the baked chain constants.
+
+    Math identical to ssik.refinement.kinbody_jacobian: column i
+    is (z_i x (p_e - p_i), z_i) where z_i is the i-th joint axis
+    in the world frame at q and p_i / p_e are the i-th joint
+    origin and EE position respectively. Per-arm version with
+    baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+    there's no KinBody walk at runtime.
+    """
+    n = len(_JOINT_AXES)
+    cum = np.eye(4, dtype=np.float64)
+    cums = [cum.copy()]
+    for i in range(n):
+        rot = np.eye(4, dtype=np.float64)
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+        cums.append(cum.copy())
+    p_e = cums[-1][:3, 3]
+    J = np.zeros((6, n), dtype=np.float64)
+    for i in range(n):
+        t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+        axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+        z_i = t_pre[:3, :3] @ axis_unit
+        p_i = t_pre[:3, 3]
+        J[:3, i] = np.cross(z_i, p_e - p_i)
+        J[3:, i] = z_i
+    return J
 
 
 def _wrap_to_pi(a):
@@ -205,14 +235,14 @@ def solve(
             continue
         if not allow_refinement:
             continue
-        # Newton polish using the baked KinBody's spatial Jacobian.
+        # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(
             q,
             _fk,
             T,
             fk_atol=fk_atol,
             max_iters=refinement_max_iters,
-            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+            jacobian_fn=_spatial_jacobian,
         )
         if refined is None:
             continue

--- a/tests/artifacts/jaco2_ik.py
+++ b/tests/artifacts/jaco2_ik.py
@@ -43,7 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
+from ssik.refinement import lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -650,13 +650,43 @@ def _solve_algebraic(T_target):
 
 
 def _fk(q):
-    """POE forward kinematics using the baked KinBody."""
+    """POE forward kinematics using the baked chain constants."""
     T = np.eye(4)
-    for j, qi in zip(_KB.joints, q, strict=True):
+    for i in range(len(_JOINT_AXES)):
         rot = np.eye(4)
-        rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
+
+
+def _spatial_jacobian(q):
+    """6 x n_dof spatial Jacobian using the baked chain constants.
+
+    Math identical to ssik.refinement.kinbody_jacobian: column i
+    is (z_i x (p_e - p_i), z_i) where z_i is the i-th joint axis
+    in the world frame at q and p_i / p_e are the i-th joint
+    origin and EE position respectively. Per-arm version with
+    baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+    there's no KinBody walk at runtime.
+    """
+    n = len(_JOINT_AXES)
+    cum = np.eye(4, dtype=np.float64)
+    cums = [cum.copy()]
+    for i in range(n):
+        rot = np.eye(4, dtype=np.float64)
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+        cums.append(cum.copy())
+    p_e = cums[-1][:3, 3]
+    J = np.zeros((6, n), dtype=np.float64)
+    for i in range(n):
+        t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+        axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+        z_i = t_pre[:3, :3] @ axis_unit
+        p_i = t_pre[:3, 3]
+        J[:3, i] = np.cross(z_i, p_e - p_i)
+        J[3:, i] = z_i
+    return J
 
 
 def _wrap_to_pi(a):
@@ -700,14 +730,14 @@ def solve(
             continue
         if not allow_refinement:
             continue
-        # Newton polish using the baked KinBody's spatial Jacobian.
+        # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(
             q,
             _fk,
             T,
             fk_atol=fk_atol,
             max_iters=refinement_max_iters,
-            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+            jacobian_fn=_spatial_jacobian,
         )
         if refined is None:
             continue

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -38,7 +38,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
+from ssik.refinement import lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -304,13 +304,43 @@ def _solve_algebraic(T_target):
 
 
 def _fk(q):
-    """POE forward kinematics using the baked KinBody."""
+    """POE forward kinematics using the baked chain constants."""
     T = np.eye(4)
-    for j, qi in zip(_KB.joints, q, strict=True):
+    for i in range(len(_JOINT_AXES)):
         rot = np.eye(4)
-        rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
+
+
+def _spatial_jacobian(q):
+    """6 x n_dof spatial Jacobian using the baked chain constants.
+
+    Math identical to ssik.refinement.kinbody_jacobian: column i
+    is (z_i x (p_e - p_i), z_i) where z_i is the i-th joint axis
+    in the world frame at q and p_i / p_e are the i-th joint
+    origin and EE position respectively. Per-arm version with
+    baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+    there's no KinBody walk at runtime.
+    """
+    n = len(_JOINT_AXES)
+    cum = np.eye(4, dtype=np.float64)
+    cums = [cum.copy()]
+    for i in range(n):
+        rot = np.eye(4, dtype=np.float64)
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+        cums.append(cum.copy())
+    p_e = cums[-1][:3, 3]
+    J = np.zeros((6, n), dtype=np.float64)
+    for i in range(n):
+        t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+        axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+        z_i = t_pre[:3, :3] @ axis_unit
+        p_i = t_pre[:3, 3]
+        J[:3, i] = np.cross(z_i, p_e - p_i)
+        J[3:, i] = z_i
+    return J
 
 
 def _wrap_to_pi(a):
@@ -354,14 +384,14 @@ def solve(
             continue
         if not allow_refinement:
             continue
-        # Newton polish using the baked KinBody's spatial Jacobian.
+        # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(
             q,
             _fk,
             T,
             fk_atol=fk_atol,
             max_iters=refinement_max_iters,
-            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+            jacobian_fn=_spatial_jacobian,
         )
         if refined is None:
             continue

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -39,7 +39,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.refinement import kinbody_jacobian as _kinbody_jacobian, lm_refine as _lm_refine
+from ssik.refinement import lm_refine as _lm_refine
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -264,13 +264,43 @@ def _solve_algebraic(T_target):
 
 
 def _fk(q):
-    """POE forward kinematics using the baked KinBody."""
+    """POE forward kinematics using the baked chain constants."""
     T = np.eye(4)
-    for j, qi in zip(_KB.joints, q, strict=True):
+    for i in range(len(_JOINT_AXES)):
         rot = np.eye(4)
-        rot[:3, :3] = _rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
+
+
+def _spatial_jacobian(q):
+    """6 x n_dof spatial Jacobian using the baked chain constants.
+
+    Math identical to ssik.refinement.kinbody_jacobian: column i
+    is (z_i x (p_e - p_i), z_i) where z_i is the i-th joint axis
+    in the world frame at q and p_i / p_e are the i-th joint
+    origin and EE position respectively. Per-arm version with
+    baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+    there's no KinBody walk at runtime.
+    """
+    n = len(_JOINT_AXES)
+    cum = np.eye(4, dtype=np.float64)
+    cums = [cum.copy()]
+    for i in range(n):
+        rot = np.eye(4, dtype=np.float64)
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+        cums.append(cum.copy())
+    p_e = cums[-1][:3, 3]
+    J = np.zeros((6, n), dtype=np.float64)
+    for i in range(n):
+        t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+        axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+        z_i = t_pre[:3, :3] @ axis_unit
+        p_i = t_pre[:3, 3]
+        J[:3, i] = np.cross(z_i, p_e - p_i)
+        J[3:, i] = z_i
+    return J
 
 
 def _wrap_to_pi(a):
@@ -314,14 +344,14 @@ def solve(
             continue
         if not allow_refinement:
             continue
-        # Newton polish using the baked KinBody's spatial Jacobian.
+        # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(
             q,
             _fk,
             T,
             fk_atol=fk_atol,
             max_iters=refinement_max_iters,
-            jacobian_fn=lambda qq: _kinbody_jacobian(_KB, qq),
+            jacobian_fn=_spatial_jacobian,
         )
         if refined is None:
             continue


### PR DESCRIPTION
## Summary

Replaces the runtime ``ssik.refinement.kinbody_jacobian(_KB, q)`` call in every specialised artifact's ``solve()`` orchestrator with a per-arm ``_spatial_jacobian(q)`` defined inline. Same numerics (1.66e-15 max diff vs runtime); no ``_KB`` indirection — the orchestrator walks the baked ``_JOINT_AXES`` / ``_JOINT_T_LEFTS`` / ``_JOINT_T_RIGHTS`` arrays directly.

Same treatment for ``_fk``. Both the FK and the spatial Jacobian are now pure functions of (baked constants, q) with no Python attribute access on ``_KB`` per iteration.

## Why this matters (.so prereq)

Foundation for #127 (LM-multi-restart numerical backstop). Post-Cython compilation, the chain constants get const-folded into the JIT'd FK + Jacobian, and the LM iteration becomes straight-line BLAS calls. Without this baking, every refinement iteration would walk ``_KB`` via Python attribute access — Cython can't compile that to native code cleanly.

## Estimated post-Phase-4 perf

- Today (pure Python loop): ~150 µs per Jacobian call
- Post-Cython baseline: ~5 µs (30×)
- Post-Cython with full per-joint unrolling: ~1 µs (150×)

## Changes

- [codegen.py](src/ssik/core/codegen.py): ``_render_specialised_solve_orchestrator`` emits ``_fk`` and ``_spatial_jacobian`` inline; refinement uses ``jacobian_fn=_spatial_jacobian``.
- ``_render_specialised`` drops the ``_kinbody_jacobian`` import. Only ``lm_refine`` (the generic Newton step) stays imported from runtime.
- All four artifacts regenerated: ``ur5_ik.py``, ``puma560_ik.py``, ``jaco2_ik.py``, ``franka_panda_ik.py``. ``kb_digest`` unchanged (no kinematic-structure change).

## Verification

- Per-arm ``_spatial_jacobian`` matches runtime ``kinbody_jacobian`` at 1.66e-15 max diff (Franka random q).
- 456 tests pass; 4 artifact snapshots byte-stable on macOS.
- Refinement-path tests unchanged.
- Lint, format, mypy clean.

## Next

#127 builds directly on this — the multi-restart driver imports each artifact's ``_spatial_jacobian`` and runs LM with random seeds for universal correctness on arms with no analytical decomposition.

Closes #126.