### PR TITLE
speedup tracker: jointlock.seven_r in _SOLVER_IMPORT_PATHS + Franka in ARMS

### DIFF
--- a/scripts/track_speedup.py
+++ b/scripts/track_speedup.py
@@ -66,6 +66,10 @@ ARMS = {
         "label": "Kinova JACO 2 (j2n6s200)",
         "loader": lambda: _load_jaco2(),
     },
+    "franka": {
+        "label": "Franka Emika Panda (no hand)",
+        "loader": lambda: _load_franka(),
+    },
 }
 
 
@@ -76,6 +80,15 @@ def _load_jaco2():
     from ssik._kinbody import build_kinbody
 
     return build_kinbody(jaco2_specs())
+
+
+def _load_franka():
+    """Franka 7R fixture, MJCF-transcribed."""
+    from franka_panda import franka_panda_specs
+
+    from ssik._kinbody import build_kinbody
+
+    return build_kinbody(franka_panda_specs())
 
 
 def _emit_module(kb, plan, module_name: str, label: str, output_path: Path):

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -123,6 +123,7 @@ _SOLVER_IMPORT_PATHS: dict[str, str] = {
     "ikgeo.two_intersecting": "ssik.solvers.ikgeo.two_intersecting",
     "ikgeo.general_6r": "ssik.solvers.ikgeo.general_6r",
     "ikgeo.gen_six_dof": "ssik.solvers.ikgeo.gen_six_dof",
+    "jointlock.seven_r": "ssik.solvers.jointlock.seven_r",
 }
 
 


### PR DESCRIPTION
Small fix unblocking the speedup tracker for 7R arms. Adds jointlock.seven_r to _SOLVER_IMPORT_PATHS so the tracker's rung-1 wrapper emission works on Franka, and adds Franka to the tracker's ARMS dict.

Run uv run python scripts/track_speedup.py --arm franka for current numbers (~48 ms median per IK; the structural cost of the 16-sample lock-joint sweep).