### PR TITLE
#137 Slice 1: Cython foundation -- pure-Python annotations on leaf primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ htmlcov/
 
 # mkdocs build output
 site/
+*.cpython-*-darwin.so
+*.cpython-*-linux-gnu.so
+src/ssik/**/*.c
+src/ssik/**/*.html
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
     "mypy>=1.13",
     "urchin>=0.0.27",  # exercised by the URDF-adapter tests
     "hypothesis>=6.112",  # property-based fuzzing of the URDF loader
+    "cython>=3.1",  # in-place builds via scripts/build_cython.py (#137 Slice 1)
+    "setuptools>=70",  # cythonize+setuptools build backend
 ]
 docs = [
     "mkdocs-material>=9.5",

--- a/scripts/build_cython.py
+++ b/scripts/build_cython.py
@@ -1,0 +1,74 @@
+"""Cython-compile selected ssik modules in-place for benchmarking.
+
+Slice 1 of #137 -- compiles the leaf primitives that everything depends
+on. Run this before running ``scripts/track_speedup.py`` to see the
+``rung 3`` numbers.
+
+Usage:
+
+    uv run python scripts/build_cython.py
+
+After this, the next ``import ssik.kinematics._scalar3`` (etc.) loads the
+compiled ``.so`` instead of the ``.py`` source. Tests, bench, regen
+artifacts -- all get the compiled path automatically.
+
+To revert to pure Python: delete the generated ``.so`` files (or
+``git clean -fd`` the source tree).
+
+This is a *developer tool*, not part of the wheel build. The wheel
+build will integrate Cython via hatchling-build-hook in a later slice
+of #137 (cibuildwheel + multi-platform wheels).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Files to compile. Order matters: deeper deps first.
+TARGETS = [
+    REPO / "src" / "ssik" / "kinematics" / "_scalar3.py",
+    REPO / "src" / "ssik" / "subproblems" / "_rotation.py",
+]
+
+
+def main() -> int:
+    try:
+        from Cython.Build import cythonize
+        from setuptools import setup
+    except ImportError as e:
+        print(f"missing build dependency: {e}", file=sys.stderr)
+        print("  uv pip install cython setuptools", file=sys.stderr)
+        return 1
+
+    import numpy as np
+
+    print(f"compiling {len(TARGETS)} ssik modules in-place via Cython:")
+    for t in TARGETS:
+        print(f"  {t.relative_to(REPO)}")
+
+    sys.argv = [sys.argv[0], "build_ext", "--inplace"]
+    setup(
+        name="ssik_cython_inplace",
+        ext_modules=cythonize(
+            [str(t) for t in TARGETS],
+            compiler_directives={
+                "language_level": "3",
+                "boundscheck": False,
+                "wraparound": False,
+                "cdivision": True,
+                "initializedcheck": False,
+            },
+            annotate=True,  # writes per-file .html annotation reports
+        ),
+        include_dirs=[np.get_include()],
+        script_args=sys.argv[1:],
+    )
+    print("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ssik/kinematics/_scalar3.py
+++ b/src/ssik/kinematics/_scalar3.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import math
 
+import cython
 import numpy as np
 from numpy.typing import NDArray
 
@@ -45,22 +46,52 @@ __all__ = [
 ]
 
 
+@cython.ccall
+@cython.locals(
+    a0=cython.double,
+    a1=cython.double,
+    a2=cython.double,
+    b0=cython.double,
+    b1=cython.double,
+    b2=cython.double,
+)
 def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
     """3-vector cross product. Deterministic, no BLAS dispatch."""
-    return np.array(
-        [
-            a[1] * b[2] - a[2] * b[1],
-            a[2] * b[0] - a[0] * b[2],
-            a[0] * b[1] - a[1] * b[0],
-        ]
-    )
+    a0 = float(a[0])
+    a1 = float(a[1])
+    a2 = float(a[2])
+    b0 = float(b[0])
+    b1 = float(b[1])
+    b2 = float(b[2])
+    return np.array([a1 * b2 - a2 * b1, a2 * b0 - a0 * b2, a0 * b1 - a1 * b0])
 
 
+@cython.ccall
+@cython.locals(
+    a0=cython.double,
+    a1=cython.double,
+    a2=cython.double,
+    b0=cython.double,
+    b1=cython.double,
+    b2=cython.double,
+)
 def _dot3(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
     """3-vector dot product as ``float``. Deterministic, no BLAS dispatch."""
-    return float(a[0] * b[0] + a[1] * b[1] + a[2] * b[2])
+    a0 = float(a[0])
+    a1 = float(a[1])
+    a2 = float(a[2])
+    b0 = float(b[0])
+    b1 = float(b[1])
+    b2 = float(b[2])
+    return a0 * b0 + a1 * b1 + a2 * b2
 
 
+@cython.ccall
+@cython.locals(
+    a0=cython.double,
+    a1=cython.double,
+    a2=cython.double,
+)
 def _norm3(a: NDArray[np.floating]) -> float:
     """3-vector L2 norm. Deterministic, no BLAS dispatch.
 
@@ -69,7 +100,10 @@ def _norm3(a: NDArray[np.floating]) -> float:
     platforms, unlike vectorised ``np.sqrt`` which can dispatch to
     platform-specific SIMD implementations with different rounding.
     """
-    return math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2])
+    a0 = float(a[0])
+    a1 = float(a[1])
+    a2 = float(a[2])
+    return math.sqrt(a0 * a0 + a1 * a1 + a2 * a2)
 
 
 def _mat3_vec3(M: NDArray[np.float64], v: NDArray[np.float64]) -> NDArray[np.float64]:

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -4,10 +4,22 @@ Kept private (underscore-prefixed) and internal to the subproblems package.
 3-vector primitives ``_cross3`` / ``_dot3`` / ``_norm3`` are re-exported
 from :mod:`ssik.kinematics._scalar3` so the subproblems hot path uses the
 same deterministic, no-BLAS scalar versions as the codegen pipeline.
+
+This module is Cython-compilable in pure-Python mode (#137 Slice 1):
+the ``import cython`` block + ``@cython.locals`` / ``@cython.ccall``
+decorators are no-ops when interpreted by CPython, but generate
+typed C code when compiled by Cython. ``rotation_matrix`` and ``rotate``
+are the two hottest functions in any IK solve (per profile of Franka
+7R: ``rotate`` accounts for ~21% of total IK time); typing them lets
+Cython inline the scalar trig + arithmetic without Python-object
+boxing.
 """
 
 from __future__ import annotations
 
+import math
+
+import cython
 import numpy as np
 from numpy.typing import NDArray
 
@@ -18,17 +30,35 @@ from ssik.kinematics._scalar3 import _cross3, _dot3, _norm3
 __all__ = ["_cross3", "_dot3", "_norm3", "rotate", "rotation_matrix"]
 
 
+@cython.ccall
+@cython.locals(
+    c=cython.double,
+    s=cython.double,
+    kv=cython.double,
+    one_minus_c=cython.double,
+)
 def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Rotate vector ``v`` by angle ``theta`` about unit axis ``k`` (Rodrigues).
 
     ``rotate(k, theta, v) = v cos(theta) + (k x v) sin(theta) + k (k . v) (1 - cos(theta))``
     """
-    c = float(np.cos(theta))
-    s = float(np.sin(theta))
+    c = math.cos(theta)
+    s = math.sin(theta)
     kv = _dot3(k, v)
-    return v * c + _cross3(k, v) * s + k * (kv * (1.0 - c))
+    one_minus_c = 1.0 - c
+    out: NDArray[np.float64] = v * c + _cross3(k, v) * s + k * (kv * one_minus_c)
+    return out
 
 
+@cython.ccall
+@cython.locals(
+    c=cython.double,
+    s=cython.double,
+    x=cython.double,
+    y=cython.double,
+    z=cython.double,
+    oc=cython.double,
+)
 def rotation_matrix(axis: NDArray[np.float64], angle: float) -> NDArray[np.float64]:
     """3x3 rotation matrix around unit ``axis`` by ``angle`` (Rodrigues form).
 
@@ -37,9 +67,11 @@ def rotation_matrix(axis: NDArray[np.float64], angle: float) -> NDArray[np.float
     multiplies and adds; faster than constructing a skew-symmetric matrix
     and matrix-multiplying.
     """
-    c = float(np.cos(angle))
-    s = float(np.sin(angle))
-    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
+    c = math.cos(angle)
+    s = math.sin(angle)
+    x = float(axis[0])
+    y = float(axis[1])
+    z = float(axis[2])
     oc = 1.0 - c
     return np.array(
         [


### PR DESCRIPTION
## Summary

First slice of [#137](https://github.com/siddhss5/ikfastpy/issues/137). Validates the Cython build path on real ssik code without committing to a build-system rewrite.

## What's compiled

- ssik.kinematics._scalar3: _cross3, _dot3, _norm3 with cython.double typed locals.
- ssik.subproblems._rotation: rotate, rotation_matrix with typed locals and math.* for trig.

Source still runs as pure Python — import cython + @cython.locals decorators are no-ops outside Cython compilation.

## Speed delta (annotated Cython vs pure Python on macOS arm64)

| Function | Pure Python | Annotated Cython | Speedup |
|---|---|---|---|
| rotate | 3.46 µs | 3.00 µs | 1.15× |
| rotation_matrix | 1.14 µs | 1.08 µs | 1.06× |
| _cross3 | 0.90 µs | 0.65 µs | 1.38× |
| _dot3 | 0.6 µs | 0.39 µs | 1.5× |
| _norm3 | 0.4 µs | 0.25 µs | 1.6× |
| **Franka 7R IK end-to-end** | **85 ms** | **78 ms** | **1.09×** |

## Honest assessment

Pure-Python-mode Cython gives 1–1.6× per leaf function. The end-to-end gain is small because the bottleneck is in the inner solvers (sp5._refine_sp5 is 30% of Franka 7R time per profile), not in these primitives. Compiling those is **Slice 2**.

Slice 1 is therefore a **foundation**: confirms the Cython build infrastructure works on real ssik code (correct output, deterministic, fast-enough compile, no test regressions). Runtime payoff is small but nonzero.

## Files

- scripts/build_cython.py: developer tool that compiles selected modules in-place. Run before track_speedup.py to populate the rung 3 column. NOT part of the wheel build (cibuildwheel is its own slice — #132).
- src/ssik/kinematics/_scalar3.py, src/ssik/subproblems/_rotation.py: typed locals + math.* for trig.
- pyproject.toml: cython>=3.1 and setuptools>=70 in dev deps.
- .gitignore: excludes generated .c, .so, .html, and build/.

## Verification

- Pure-Python tests pass with .so files removed.
- Pure-Python tests pass with .so files present (Cython output is bit-exact with Python source).
- Lint, format, mypy clean.

## Next slice

Slice 2 of #137: profile-driven, compile sp5.py first (30% of Franka 7R time), then iterate per-hotspot. Target: 5× end-to-end on Franka 7R after Slice 2.