### PR TITLE
#137 Slice 3: per-arm artifact compilation + scalar dedup loop (Franka 7R 31% faster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,7 @@ site/
 *.cpython-*-linux-gnu.so
 src/ssik/**/*.c
 src/ssik/**/*.html
+# Cython artefacts from per-arm artifact compile (#137 Slice 3).
+tests/artifacts/*.c
+tests/artifacts/*.html
 build/

--- a/scripts/build_cython.py
+++ b/scripts/build_cython.py
@@ -22,17 +22,30 @@ of #137 (cibuildwheel + multi-platform wheels).
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
 # Files to compile. Order matters: deeper deps first.
+# These targets have explicit Cython type annotations on hot-path locals;
+# the aggressive directives (``boundscheck=False, wraparound=False``) are
+# safe because indices are typed and bounded.
 TARGETS = [
     REPO / "src" / "ssik" / "kinematics" / "_scalar3.py",
     REPO / "src" / "ssik" / "subproblems" / "_rotation.py",
     # Slice 2: sp5._refine_sp5 is 30% of Franka 7R IK time per profile.
     REPO / "src" / "ssik" / "subproblems" / "sp5.py",
+]
+
+# Per-arm artifact targets (#137 Slice 3). The orchestrator code emitted
+# by ``ssik.core.codegen`` carries pure-Python-mode Cython annotations
+# (``@cython.ccall`` on ``_fk`` / ``_spatial_jacobian`` / ``_wrap_to_pi``)
+# but the body still uses Python-style numpy indexing. Compiled with the
+# safer directives below to avoid bus errors from skipped bounds checks.
+ARTIFACT_TARGETS = [
+    REPO / "tests" / "artifacts" / "franka_panda_ik.py",
 ]
 
 
@@ -47,12 +60,16 @@ def main() -> int:
 
     import numpy as np
 
-    print(f"compiling {len(TARGETS)} ssik modules in-place via Cython:")
+    total = len(TARGETS) + len(ARTIFACT_TARGETS)
+    print(f"compiling {total} ssik modules in-place via Cython:")
     for t in TARGETS:
         print(f"  {t.relative_to(REPO)}")
+    for t in ARTIFACT_TARGETS:
+        print(f"  {t.relative_to(REPO)}  (artifact, safe directives)")
 
     sys.argv = [sys.argv[0], "build_ext", "--inplace"]
-    extensions = cythonize(
+    # Aggressive directives for src/ssik targets (manually typed).
+    aggressive = cythonize(
         [str(t) for t in TARGETS],
         compiler_directives={
             "language_level": "3",
@@ -63,6 +80,19 @@ def main() -> int:
         },
         annotate=True,  # writes per-file .html annotation reports
     )
+    # Safe directives for per-arm artifacts (untyped numpy indexing).
+    safe = cythonize(
+        [str(t) for t in ARTIFACT_TARGETS],
+        compiler_directives={
+            "language_level": "3",
+            "boundscheck": True,
+            "wraparound": True,
+            "cdivision": True,
+            "initializedcheck": True,
+        },
+        annotate=True,
+    )
+    extensions = list(aggressive) + list(safe)
     # Disable FP contraction (FMA) -- ssik.kinematics._scalar3 uses strict
     # left-to-right IEEE 754 evaluation as the determinism guarantee that
     # makes codegen (poe_to_dh -> sympy.cse) bit-exact across platforms. A
@@ -83,6 +113,17 @@ def main() -> int:
         include_dirs=[np.get_include()],
         script_args=sys.argv[1:],
     )
+    # ``cythonize`` puts artifact .so files at ``src/<module>.cpython-...so``
+    # (because the artifact source lives outside any registered package). Move
+    # each one next to its .py source so ``import tests.artifacts.<arm>_ik``
+    # picks up the compiled extension.
+    for source in ARTIFACT_TARGETS:
+        stem = source.stem  # e.g. "franka_panda_ik"
+        misplaced = list((REPO / "src").glob(f"{stem}.cpython-*.so"))
+        for so in misplaced:
+            dest = source.parent / so.name
+            shutil.move(str(so), str(dest))
+            print(f"  moved {so.relative_to(REPO)} -> {dest.relative_to(REPO)}")
     print("done.")
     return 0
 

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -203,7 +203,12 @@ def _render_specialised(
     buf.write(_render_header(module_name, arm_label, plan, kb))
     buf.write("\n\nfrom __future__ import annotations\n\n")
     buf.write(render_constants_header())
-    buf.write("\nimport numpy as np\n\n")
+    # ``import cython`` enables the pure-Python-mode Cython annotations
+    # in the orchestrator below (``@cython.ccall``, ``@cython.locals``).
+    # No-op when the artifact runs as plain Python; takes effect when
+    # the artifact is compiled to ``.so`` via ``scripts/build_cython.py``
+    # (#137 Slice 3).
+    buf.write("\nimport cython\nimport numpy as np\n\n")
     buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
     buf.write("from ssik.core.solution import Solution\n")
     buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
@@ -249,16 +254,26 @@ def _render_specialised_solve_orchestrator() -> str:
     return textwrap.dedent(
         '''\
 
+        # Module-scope ``2*pi`` constant referenced inside the dedup hot
+        # loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+        _TWO_PI: float = 2.0 * math.pi
+
+
+        @cython.ccall
+        @cython.locals(i=cython.int, n=cython.int)
         def _fk(q):
             """POE forward kinematics using the baked chain constants."""
+            n = len(_JOINT_AXES)
             T = np.eye(4)
-            for i in range(len(_JOINT_AXES)):
+            for i in range(n):
                 rot = np.eye(4)
                 rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
                 T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
             return T
 
 
+        @cython.ccall
+        @cython.locals(i=cython.int, n=cython.int)
         def _spatial_jacobian(q):
             """6 x n_dof spatial Jacobian using the baked chain constants.
 
@@ -289,8 +304,37 @@ def _render_specialised_solve_orchestrator() -> str:
             return J
 
 
-        def _wrap_to_pi(a):
-            return ((a + math.pi) % (2 * math.pi)) - math.pi
+        @cython.ccall
+        def _wrap_to_pi(a: float) -> float:
+            """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+            dedup hot loop (235k+ times on Franka 7R)."""
+            return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+        @cython.ccall
+        @cython.locals(
+            i=cython.int,
+            n=cython.int,
+            diff=cython.double,
+            ai=cython.double,
+            bi=cython.double,
+        )
+        def _q_close_wrap(a, b, tol: float) -> bool:
+            """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+            within ``tol`` per element. Replaces the
+            ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+            pipeline that allocated a numpy array per dedup-loop iteration --
+            a per-element scalar loop avoids the array creation and the
+            ``np.all`` reduction overhead, which together dominated the
+            artifact's ``solve()`` body at the per-IK level."""
+            n = len(a)
+            for i in range(n):
+                ai = float(a[i])
+                bi = float(b[i])
+                diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+                if abs(diff) > tol:
+                    return False
+            return True
 
 
         def solve(
@@ -345,12 +389,13 @@ def _render_specialised_solve_orchestrator() -> str:
                 verified.append((q_ref, resid_ref, "lm", iters))
 
             # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+            # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+            # iteration numpy allocation (#137 Slice 3).
             deduped: list[tuple[np.ndarray, float, str, int]] = []
             for cand_q, cand_res, ref_used, ref_iters in verified:
                 dup_idx = None
                 for j, (existing_q, _, _, _) in enumerate(deduped):
-                    diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
-                    if np.all(np.abs(diffs) < dedup_atol):
+                    if _q_close_wrap(cand_q, existing_q, dedup_atol):
                         dup_idx = j
                         break
                 if dup_idx is None:

--- a/tests/artifacts/franka_panda_ik.py
+++ b/tests/artifacts/franka_panda_ik.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import math
 from ssik.solvers.jointlock import seven_r as _ssik_seven_r
 
+import cython
 import numpy as np
 
 from ssik._kinbody import Joint, KinBody, Link
@@ -154,16 +155,26 @@ def _solve_algebraic(T_target):
     return [list(s.q) for s in sub_solutions]
 
 
+# Module-scope ``2*pi`` constant referenced inside the dedup hot
+# loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+_TWO_PI: float = 2.0 * math.pi
+
+
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _fk(q):
     """POE forward kinematics using the baked chain constants."""
+    n = len(_JOINT_AXES)
     T = np.eye(4)
-    for i in range(len(_JOINT_AXES)):
+    for i in range(n):
         rot = np.eye(4)
         rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
         T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
 
 
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _spatial_jacobian(q):
     """6 x n_dof spatial Jacobian using the baked chain constants.
 
@@ -194,8 +205,37 @@ def _spatial_jacobian(q):
     return J
 
 
-def _wrap_to_pi(a):
-    return ((a + math.pi) % (2 * math.pi)) - math.pi
+@cython.ccall
+def _wrap_to_pi(a: float) -> float:
+    """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+    dedup hot loop (235k+ times on Franka 7R)."""
+    return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
+def _q_close_wrap(a, b, tol: float) -> bool:
+    """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+    within ``tol`` per element. Replaces the
+    ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+    pipeline that allocated a numpy array per dedup-loop iteration --
+    a per-element scalar loop avoids the array creation and the
+    ``np.all`` reduction overhead, which together dominated the
+    artifact's ``solve()`` body at the per-IK level."""
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+        if abs(diff) > tol:
+            return False
+    return True
 
 
 def solve(
@@ -250,12 +290,13 @@ def solve(
         verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+    # iteration numpy allocation (#137 Slice 3).
     deduped: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
         for j, (existing_q, _, _, _) in enumerate(deduped):
-            diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
-            if np.all(np.abs(diffs) < dedup_atol):
+            if _q_close_wrap(cand_q, existing_q, dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:

--- a/tests/artifacts/jaco2_ik.py
+++ b/tests/artifacts/jaco2_ik.py
@@ -38,6 +38,7 @@ from ssik.solvers.ikgeo._raghavan_roth import (
     _fk_dh as _ssik_fk_dh,
 )
 
+import cython
 import numpy as np
 
 from ssik._kinbody import Joint, KinBody, Link
@@ -649,16 +650,26 @@ def _solve_algebraic(T_target):
     ]
 
 
+# Module-scope ``2*pi`` constant referenced inside the dedup hot
+# loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+_TWO_PI: float = 2.0 * math.pi
+
+
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _fk(q):
     """POE forward kinematics using the baked chain constants."""
+    n = len(_JOINT_AXES)
     T = np.eye(4)
-    for i in range(len(_JOINT_AXES)):
+    for i in range(n):
         rot = np.eye(4)
         rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
         T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
 
 
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _spatial_jacobian(q):
     """6 x n_dof spatial Jacobian using the baked chain constants.
 
@@ -689,8 +700,37 @@ def _spatial_jacobian(q):
     return J
 
 
-def _wrap_to_pi(a):
-    return ((a + math.pi) % (2 * math.pi)) - math.pi
+@cython.ccall
+def _wrap_to_pi(a: float) -> float:
+    """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+    dedup hot loop (235k+ times on Franka 7R)."""
+    return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
+def _q_close_wrap(a, b, tol: float) -> bool:
+    """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+    within ``tol`` per element. Replaces the
+    ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+    pipeline that allocated a numpy array per dedup-loop iteration --
+    a per-element scalar loop avoids the array creation and the
+    ``np.all`` reduction overhead, which together dominated the
+    artifact's ``solve()`` body at the per-IK level."""
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+        if abs(diff) > tol:
+            return False
+    return True
 
 
 def solve(
@@ -745,12 +785,13 @@ def solve(
         verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+    # iteration numpy allocation (#137 Slice 3).
     deduped: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
         for j, (existing_q, _, _, _) in enumerate(deduped):
-            diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
-            if np.all(np.abs(diffs) < dedup_atol):
+            if _q_close_wrap(cand_q, existing_q, dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -33,6 +33,7 @@ import math
 _DEG_SQ = 1e-16
 _FEAS_TOL = 1e-08
 
+import cython
 import numpy as np
 
 from ssik._kinbody import Joint, KinBody, Link
@@ -303,16 +304,26 @@ def _solve_algebraic(T_target):
     return candidates
 
 
+# Module-scope ``2*pi`` constant referenced inside the dedup hot
+# loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+_TWO_PI: float = 2.0 * math.pi
+
+
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _fk(q):
     """POE forward kinematics using the baked chain constants."""
+    n = len(_JOINT_AXES)
     T = np.eye(4)
-    for i in range(len(_JOINT_AXES)):
+    for i in range(n):
         rot = np.eye(4)
         rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
         T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
 
 
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _spatial_jacobian(q):
     """6 x n_dof spatial Jacobian using the baked chain constants.
 
@@ -343,8 +354,37 @@ def _spatial_jacobian(q):
     return J
 
 
-def _wrap_to_pi(a):
-    return ((a + math.pi) % (2 * math.pi)) - math.pi
+@cython.ccall
+def _wrap_to_pi(a: float) -> float:
+    """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+    dedup hot loop (235k+ times on Franka 7R)."""
+    return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
+def _q_close_wrap(a, b, tol: float) -> bool:
+    """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+    within ``tol`` per element. Replaces the
+    ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+    pipeline that allocated a numpy array per dedup-loop iteration --
+    a per-element scalar loop avoids the array creation and the
+    ``np.all`` reduction overhead, which together dominated the
+    artifact's ``solve()`` body at the per-IK level."""
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+        if abs(diff) > tol:
+            return False
+    return True
 
 
 def solve(
@@ -399,12 +439,13 @@ def solve(
         verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+    # iteration numpy allocation (#137 Slice 3).
     deduped: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
         for j, (existing_q, _, _, _) in enumerate(deduped):
-            diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
-            if np.all(np.abs(diffs) < dedup_atol):
+            if _q_close_wrap(cand_q, existing_q, dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -34,6 +34,7 @@ from ssik.subproblems import sp6 as _sp6_runtime
 _DEG_SQ = 1e-16
 _FEAS_TOL = 1e-08
 
+import cython
 import numpy as np
 
 from ssik._kinbody import Joint, KinBody, Link
@@ -263,16 +264,26 @@ def _solve_algebraic(T_target):
     return candidates
 
 
+# Module-scope ``2*pi`` constant referenced inside the dedup hot
+# loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+_TWO_PI: float = 2.0 * math.pi
+
+
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _fk(q):
     """POE forward kinematics using the baked chain constants."""
+    n = len(_JOINT_AXES)
     T = np.eye(4)
-    for i in range(len(_JOINT_AXES)):
+    for i in range(n):
         rot = np.eye(4)
         rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
         T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
     return T
 
 
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
 def _spatial_jacobian(q):
     """6 x n_dof spatial Jacobian using the baked chain constants.
 
@@ -303,8 +314,37 @@ def _spatial_jacobian(q):
     return J
 
 
-def _wrap_to_pi(a):
-    return ((a + math.pi) % (2 * math.pi)) - math.pi
+@cython.ccall
+def _wrap_to_pi(a: float) -> float:
+    """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+    dedup hot loop (235k+ times on Franka 7R)."""
+    return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
+def _q_close_wrap(a, b, tol: float) -> bool:
+    """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+    within ``tol`` per element. Replaces the
+    ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+    pipeline that allocated a numpy array per dedup-loop iteration --
+    a per-element scalar loop avoids the array creation and the
+    ``np.all`` reduction overhead, which together dominated the
+    artifact's ``solve()`` body at the per-IK level."""
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+        if abs(diff) > tol:
+            return False
+    return True
 
 
 def solve(
@@ -359,12 +399,13 @@ def solve(
         verified.append((q_ref, resid_ref, "lm", iters))
 
     # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+    # iteration numpy allocation (#137 Slice 3).
     deduped: list[tuple[np.ndarray, float, str, int]] = []
     for cand_q, cand_res, ref_used, ref_iters in verified:
         dup_idx = None
         for j, (existing_q, _, _, _) in enumerate(deduped):
-            diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
-            if np.all(np.abs(diffs) < dedup_atol):
+            if _q_close_wrap(cand_q, existing_q, dedup_atol):
                 dup_idx = j
                 break
         if dup_idx is None:


### PR DESCRIPTION
## Summary

- The composer (\`ssik.core.codegen\`) now emits the per-arm artifact orchestrator with pure-Python-mode Cython annotations (\`@cython.ccall\` on \`_fk\` / \`_spatial_jacobian\` / \`_wrap_to_pi\`, plus a new \`_q_close_wrap\` helper). The artifact still runs as plain Python; \`scripts/build_cython.py\` now optionally compiles the Franka artifact to a per-arm \`.so\` with safer compile directives (\`boundscheck=True\`, \`wraparound=True\`) appropriate for orchestrator code that isn't manually typed end-to-end.

- **The actual win comes from the dedup-loop rewrite, not the compile.** The old per-iteration body allocated a numpy array via list-comprehension over \`_wrap_to_pi\`:

  \`\`\`python
  diffs = np.array([_wrap_to_pi(a - b) for a, b in zip(cand_q, existing_q)])
  if np.all(np.abs(diffs) < dedup_atol): ...
  \`\`\`

  Replaced by a typed scalar loop in \`_q_close_wrap\` that early-exits on first per-element mismatch — no numpy allocation, no \`np.all\` reduction.

- Bench (Franka 7R, median of 80 solves × 5 runs):

  | Variant | ms/solve |
  |---|---|
  | Python orchestrator (old) | 60.85 |
  | Python orchestrator (typed scalar dedup) | 42.22 |
  | Compiled \`.so\` (typed scalar dedup) | 41.71 |

  31% win is purely from killing per-iteration numpy overhead. The Cython compile adds ~1% on top — it's infrastructure for Slice 4 (where typed memoryviews + cdef-arrays in \`_fk\` / \`_spatial_jacobian\` will move the needle), not the load-bearing optimisation here.

- Also fixes \`scripts/build_cython.py\` to drop the artifact \`.so\` next to its \`.py\` source (cythonize+setuptools default puts it at \`src/\` because the artifact lives outside any registered package). \`.gitignore\` extended to exclude \`tests/artifacts/*.c\` / \`*.html\` byproducts.

## Slice 2b note

Compiling \`spherical.py\` as-is was tried during this slice and reverted — 0% measurable speedup. Files without explicit Cython type annotations don't benefit from compilation; that's the diminishing-returns signal #137's Slice 2 plan describes. Slice 3 (this PR) and Slice 4 are the right shape from here.

## Test plan

- [x] \`uv run python scripts/regen_artifacts.py\` (4 artifacts re-emitted)
- [x] \`uv run pytest tests/test_artifact_snapshots.py\` (4 passed — snapshots match)
- [x] \`uv run pytest tests/test_franka_fixture.py tests/test_jointlock_seven_r.py tests/test_postprocess.py tests/test_numerical_lm_multi_restart.py\` (54 passed)
- [x] \`uv run pytest -q\` (466 passed; 3 pre-existing hypothesis-cached failures verified to pass with \`--hypothesis-seed=0\`)
- [x] \`uv run mypy\` (110 source files clean)
- [x] \`uv run ruff check && uv run ruff format --check\` (clean)
- [x] FK closure verified at 1e-9 max across 50 random Franka 7R poses (4168 solutions, median 2e-14)