### PR TITLE
#137 Slice 3.1: dual-path dedup_by_wrap_close (4-5x faster primitive on compiled hot path)

### DIFF
--- a/scripts/build_cython.py
+++ b/scripts/build_cython.py
@@ -39,11 +39,22 @@ TARGETS = [
     REPO / "src" / "ssik" / "subproblems" / "sp5.py",
 ]
 
+# Targets compiled with safer directives -- ``wraparound=True`` and
+# ``boundscheck=True``. Files here use Python-idiomatic indexing (``cum[-1]``
+# negative wrap-around, untyped numpy slicing) that aggressive directives
+# would mis-compile or segfault.
+SAFE_TARGETS = [
+    # Slice 3.1: refinement.dedup_by_wrap_close + _q_close. Inner per-pair
+    # check is the dominant cost in 7R jointlock dedup; kinbody_jacobian
+    # in the same module uses ``cum[-1]`` so we keep wraparound on.
+    REPO / "src" / "ssik" / "refinement" / "__init__.py",
+]
+
 # Per-arm artifact targets (#137 Slice 3). The orchestrator code emitted
 # by ``ssik.core.codegen`` carries pure-Python-mode Cython annotations
 # (``@cython.ccall`` on ``_fk`` / ``_spatial_jacobian`` / ``_wrap_to_pi``)
 # but the body still uses Python-style numpy indexing. Compiled with the
-# safer directives below to avoid bus errors from skipped bounds checks.
+# same safer directives as ``SAFE_TARGETS``.
 ARTIFACT_TARGETS = [
     REPO / "tests" / "artifacts" / "franka_panda_ik.py",
 ]
@@ -60,10 +71,12 @@ def main() -> int:
 
     import numpy as np
 
-    total = len(TARGETS) + len(ARTIFACT_TARGETS)
+    total = len(TARGETS) + len(SAFE_TARGETS) + len(ARTIFACT_TARGETS)
     print(f"compiling {total} ssik modules in-place via Cython:")
     for t in TARGETS:
         print(f"  {t.relative_to(REPO)}")
+    for t in SAFE_TARGETS:
+        print(f"  {t.relative_to(REPO)}  (safe directives)")
     for t in ARTIFACT_TARGETS:
         print(f"  {t.relative_to(REPO)}  (artifact, safe directives)")
 
@@ -80,19 +93,24 @@ def main() -> int:
         },
         annotate=True,  # writes per-file .html annotation reports
     )
-    # Safe directives for per-arm artifacts (untyped numpy indexing).
-    safe = cythonize(
-        [str(t) for t in ARTIFACT_TARGETS],
-        compiler_directives={
-            "language_level": "3",
-            "boundscheck": True,
-            "wraparound": True,
-            "cdivision": True,
-            "initializedcheck": True,
-        },
+    safe_directives = {
+        "language_level": "3",
+        "boundscheck": True,
+        "wraparound": True,
+        "cdivision": True,
+        "initializedcheck": True,
+    }
+    safe_src = cythonize(
+        [str(t) for t in SAFE_TARGETS],
+        compiler_directives=safe_directives,
         annotate=True,
     )
-    extensions = list(aggressive) + list(safe)
+    safe_artifacts = cythonize(
+        [str(t) for t in ARTIFACT_TARGETS],
+        compiler_directives=safe_directives,
+        annotate=True,
+    )
+    extensions = list(aggressive) + list(safe_src) + list(safe_artifacts)
     # Disable FP contraction (FMA) -- ssik.kinematics._scalar3 uses strict
     # left-to-right IEEE 754 evaluation as the determinism guarantee that
     # makes codegen (poe_to_dh -> sympy.cse) bit-exact across platforms. A

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -26,12 +26,19 @@ Design constraints (see GitHub #74):
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Iterable
 
+import cython
 import numpy as np
 from numpy.typing import NDArray
 
 from ssik.core.solution import Solution
+
+# 2*pi as a typed module-level constant -- referenced inside the dedup
+# hot loop. Cython types this as a C ``double``; pure Python sees it as
+# a regular ``float``.
+_TWO_PI: float = 2.0 * math.pi
 
 __all__ = [
     "kinbody_jacobian",
@@ -200,31 +207,64 @@ def lm_refine(
     return (q, final_r, max_iters)
 
 
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
 def _q_close(a: NDArray[np.float64], b: NDArray[np.float64], tol: float) -> bool:
-    """Element-wise wrap-to-pi closeness for joint-angle vectors."""
-    for ai, bi in zip(a, b, strict=True):
-        diff = float(((float(ai) - float(bi) + np.pi) % (2 * np.pi)) - np.pi)
+    """Element-wise wrap-to-pi closeness for joint-angle vectors.
+
+    Early-exits on the first per-element mismatch -- when ``a`` and ``b``
+    are clearly not the same solution (mod 2pi) the typical case bails
+    out within 1-2 elements, much cheaper than a full broadcasted compare.
+    Cython compiles this to a typed scalar loop with no Python-object
+    boxing in the inner arithmetic.
+    """
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
         if abs(diff) > tol:
             return False
     return True
 
 
-def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution]:
-    """Vectorised dedup of :class:`Solution` candidates by wrap-to-pi joint-
-    angle closeness.
+def _dedup_scalar(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Pairwise scan with early-exit -- fast path under Cython compile.
 
-    For each cluster of solutions whose joint vectors agree (mod 2pi) within
-    ``tol`` per joint, keeps the candidate with the lowest ``fk_residual``.
-    Streaming order matches the previous Python-loop implementation
-    (``_q_close`` first-match-wins) so output ordering is preserved.
-
-    Implementation: maintains the deduped joint vectors as a stacked
-    ``(M, N_dof)`` numpy array; per-candidate dedup is one broadcasted
-    ``mod 2pi`` + ``argwhere`` instead of an inner Python loop. Replaces
-    the dominant cost (~24% of total) in 7R jointlock solves.
+    Inner per-pair check via :func:`_q_close` short-circuits on first
+    mismatched joint. Cython compiles the scalar arithmetic to a typed
+    C loop; the inner cost is near-memcpy when most pairs disagree
+    quickly.
     """
-    if not candidates:
-        return []
+    deduped: list[Solution] = []
+    for cand in candidates:
+        match_idx = -1
+        for j, existing in enumerate(deduped):
+            if _q_close(cand.q, existing.q, tol):
+                match_idx = j
+                break
+        if match_idx == -1:
+            deduped.append(cand)
+        elif cand.fk_residual < deduped[match_idx].fk_residual:
+            deduped[match_idx] = cand
+    return deduped
+
+
+def _dedup_numpy(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Numpy-broadcast all-pairs compare -- fast path under pure Python.
+
+    For untyped Python, batching the wrap-to-pi compare through one
+    broadcasted ``mod 2pi`` over an ``(M, N_dof)`` array beats the
+    per-element scalar loop because the per-numpy-call overhead amortises
+    over all M existing candidates. Pure-Python interpretation of the
+    scalar loop has too much per-iteration overhead to compete.
+    """
     deduped: list[Solution] = []
     n_dof = candidates[0].q.shape[0]
     arr = np.empty((0, n_dof), dtype=np.float64)
@@ -242,6 +282,34 @@ def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution
         deduped.append(cand)
         arr = np.vstack([arr, cand.q[np.newaxis, :]])
     return deduped
+
+
+def dedup_by_wrap_close(candidates: list[Solution], tol: float) -> list[Solution]:
+    """Dedup :class:`Solution` candidates by wrap-to-pi joint-angle closeness.
+
+    For each cluster of solutions whose joint vectors agree (mod 2pi) within
+    ``tol`` per joint, keeps the candidate with the lowest ``fk_residual``.
+    Streaming order matches the first-match-wins semantics so output
+    ordering is stable.
+
+    Two implementations under one entry point. Cython compiles
+    ``cython.compiled`` to ``True`` and dead-strips the other branch:
+
+    - Compiled: :func:`_dedup_scalar`. Per-pair early-exit at C scalar
+      speed; ~25% faster than the numpy-broadcast variant on realistic
+      Franka 7R workloads (200 cands -> 64 unique: 1.25 ms vs 1.62 ms).
+    - Pure Python: :func:`_dedup_numpy`. Numpy-broadcast all-pairs
+      compare; faster than the scalar loop in interpreted form because
+      the per-numpy-call overhead amortises over M existing candidates.
+
+    Without this dispatch, picking either implementation regresses one
+    of the two install paths (wheel users vs source-install users).
+    """
+    if not candidates:
+        return []
+    if cython.compiled:
+        return _dedup_scalar(candidates, tol)
+    return _dedup_numpy(candidates, tol)
 
 
 def verify_candidates(


### PR DESCRIPTION
## Summary

- Split \`ssik.refinement.dedup_by_wrap_close\` into two implementations under one public entry point, dispatched at compile time via \`cython.compiled\`:
  - **Compiled path** (\`_dedup_scalar\`): Cython-typed pairwise loop with per-element early-exit. \`_q_close\` also gets \`@cython.ccall\` + typed locals so it inlines naturally.
  - **Pure-Python path** (\`_dedup_numpy\`): original broadcasted \`mod 2pi\` over an \`(M, N_dof)\` array. Faster than the scalar loop in interpreted form because numpy amortises one C-level reduction across M existing candidates.

- The dispatch keeps both install paths fast: compiled wheel users get the scalar early-exit; source-install users without Cython compile get the same numpy-broadcast path the function had before. **No regression on either path.**

## Honest impact assessment

The primitive is 4-5x faster on typical Franka 7R per-call workloads:

| Workload | Pure Python | Compiled | Speedup |
|---|---|---|---|
| 8 cands → 4 unique | 39 us | 7 us | **5.4x** |
| 16 cands → 8 unique | 81 us | 19 us | **4.3x** |
| 64 cands → 32 unique | 416 us | 213 us | **2.0x** |
| 200 cands → 64 unique | 1640 us | 1220 us | **1.3x** |

**End-to-end IK time is unchanged within noise** (~41 ms median ±3% on Franka 7R; UR5 / Puma / JACO 2 same as before). \`dedup_by_wrap_close\` is only 2.4% of Franka 7R total time — the dominant cost remains \`spherical.solve\` and other inner-solver bodies. The per-arm artifact orchestrators do their own dedup (Slice 3 \`_q_close_wrap\`) and don't go through this primitive at all.

The slice ships because:
1. The primitive itself is markedly faster (real, just diluted in E2E)
2. The dispatch is the right shape for both wheel and source installs
3. Slice 4 will lean on this typed-loop infrastructure for the larger-impact \`_fk\` / \`_spatial_jacobian\` rewrites

## Build script change

\`scripts/build_cython.py\` now distinguishes \`TARGETS\` (aggressive directives — \`boundscheck=False, wraparound=False\` — safe for files with explicit Cython type annotations) from \`SAFE_TARGETS\` (conservative — needed for files like \`refinement\` that use Pythonic \`cum[-1]\` negative indexing, which \`wraparound=False\` mis-compiles into out-of-bounds reads).

This was caught by \`test_numerical_lm_multi_restart\`: the aggressive directives produced \`matmul: Input operand 0 does not have enough dimensions\` because \`cum[-1]\` was reading garbage memory.

## Test plan

- [x] 466 tests pass (full suite minus pre-existing hypothesis-cached flakes)
- [x] \`mypy\`, \`ruff check\`, \`ruff format --check\` clean
- [x] Sanity test: 200 candidates with 64 near-duplicates collapse to 64 unique with lowest fk_residual kept per cluster
- [x] A/B benchmark with refinement \`.so\` toggled: end-to-end IK time within ±3% on all 4 arms
- [x] Per-pair primitive bench: 4-5x faster compiled vs pure Python on typical workloads