### PR TITLE
#137 Slice 4 step 1b: extract shared poe_forward_kinematics (architectural prep for #147)

### DIFF
--- a/src/ssik/kinematics/poe_fk.py
+++ b/src/ssik/kinematics/poe_fk.py
@@ -1,0 +1,49 @@
+"""Forward kinematics for POE-normalized kinematic chains.
+
+The shared implementation used by every analytical solver's post-verify
+step. Before #137 Slice 4 step 1b this lived as seven byte-identical
+copies in ``ssik.solvers.ikgeo.*``; consolidating to a single module
+means the next-stage Cython source rewrite (#147) optimises it exactly
+once, and the same per-call ``np.eye(4)`` allocation fix applies to
+every solver simultaneously.
+
+The cached ``_FK_EYE4`` constant + reused ``rot`` buffer match the
+artifact orchestrator pattern from #146; the runtime hot path through
+the inner 6R solvers gets the same default-call speedup.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+from ssik.subproblems._rotation import rotation_matrix
+
+__all__ = ["poe_forward_kinematics"]
+
+
+# Cached read-only 4x4 identity. Hot-path callers do ``_FK_EYE4.copy()``
+# instead of ``np.eye(4)`` to avoid the per-call diagonal-init cost --
+# this matters under a 7R lock-sweep that calls back into the inner 6R
+# solver's verify pass 24x per IK.
+_FK_EYE4 = np.eye(4, dtype=np.float64)
+_FK_EYE4.flags.writeable = False
+
+
+def poe_forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """POE forward kinematics for a normalized :class:`KinBody` at config ``q``.
+
+    Walks the chain joint-by-joint, applying ``T_left @ Rot(axis, q) @ T_right``
+    in order. Returns the 4x4 base-to-end pose.
+
+    Performance: a single ``rot`` buffer is reused across joints; only its
+    3x3 rotation block is overwritten per iteration (the bottom row stays
+    ``[0, 0, 0, 1]``). One numpy 4x4 alloc total instead of one per joint.
+    """
+    T = _FK_EYE4.copy()
+    rot = _FK_EYE4.copy()
+    for j, qi in zip(kb.joints, q, strict=True):
+        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
+        T = T @ j.T_left @ rot @ j.T_right
+    return T

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -40,6 +40,12 @@ from ssik.core.solution import Solution
 # a regular ``float``.
 _TWO_PI: float = 2.0 * math.pi
 
+# Cached read-only 4x4 identity reused inside ``kinbody_jacobian``: each
+# call avoids ``len(joints)+1`` per-iteration ``np.eye(4)`` allocations.
+# Same pattern as the artifact orchestrator's ``_FK_EYE4`` (#146).
+_FK_EYE4 = np.eye(4, dtype=np.float64)
+_FK_EYE4.flags.writeable = False
+
 __all__ = [
     "kinbody_jacobian",
     "lm_refine",
@@ -121,9 +127,9 @@ def kinbody_jacobian(
     """
     joints = kb.joints  # type: ignore[attr-defined]
     n = len(joints)
-    cum: list[NDArray[np.float64]] = [np.eye(4, dtype=np.float64)]
+    cum: list[NDArray[np.float64]] = [_FK_EYE4.copy()]
+    rot = _FK_EYE4.copy()
     for joint, qi in zip(joints, q, strict=True):
-        rot = np.eye(4, dtype=np.float64)
         c = float(np.cos(float(qi)))
         s = float(np.sin(float(qi)))
         ax = joint.axis / np.linalg.norm(joint.axis)

--- a/src/ssik/solvers/ikgeo/gen_six_dof.py
+++ b/src/ssik/solvers/ikgeo/gen_six_dof.py
@@ -43,6 +43,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._bivariate import search_2d
 from ssik.subproblems import sp1, sp5
@@ -132,7 +133,7 @@ def solve(
 
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -150,13 +151,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/spherical.py
+++ b/src/ssik/solvers/ikgeo/spherical.py
@@ -58,6 +58,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp4, sp5
@@ -173,7 +174,7 @@ def solve(
     # three_parallel rationale.
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -190,13 +191,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
@@ -54,6 +54,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp2, sp3, sp4
@@ -177,7 +178,7 @@ def solve(
 
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -194,13 +195,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/spherical_two_parallel.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_parallel.py
@@ -59,6 +59,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import axis_parallel, three_consecutive_intersecting
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp3, sp4
@@ -202,7 +203,7 @@ def solve(
 
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -219,13 +220,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -45,6 +45,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import three_consecutive_parallel
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.subproblems import sp1, sp3, sp6
@@ -168,7 +169,7 @@ def solve(
     # specific ordering matters under cluster-root pathology.
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -185,13 +186,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/two_intersecting.py
@@ -48,6 +48,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._univariate import search_1d
 from ssik.subproblems import sp1, sp5
@@ -145,7 +146,7 @@ def solve(
 
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -163,13 +164,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    """POE forward kinematics for the composed IK post-verification."""
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T

--- a/src/ssik/solvers/ikgeo/two_parallel.py
+++ b/src/ssik/solvers/ikgeo/two_parallel.py
@@ -22,6 +22,7 @@ from numpy.typing import NDArray
 from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import axis_parallel
 from ssik.refinement import kinbody_jacobian, verify_candidates
 from ssik.solvers.ikgeo._univariate import search_1d_matched
@@ -134,7 +135,7 @@ def solve(
 
     solutions = verify_candidates(
         candidates,
-        fk_fn=lambda q: _forward_kinematics(kb, q),
+        fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
         fk_atol=policy.subproblem_numerical,
@@ -152,12 +153,3 @@ def solve(
         len(solutions) == 0,
     )
     return solutions, len(solutions) == 0
-
-
-def _forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
-    T = np.eye(4)
-    for j, qi in zip(kb.joints, q, strict=True):
-        rot = np.eye(4)
-        rot[:3, :3] = rotation_matrix(j.axis, float(qi))
-        T = T @ j.T_left @ rot @ j.T_right
-    return T


### PR DESCRIPTION
## Summary

The seven runtime ikgeo 6R solvers each carried a byte-identical local \`_forward_kinematics(kb, q)\` for their post-verify FK pass. This consolidates them into a single \`ssik.kinematics.poe_fk.poe_forward_kinematics\` with the \`_FK_EYE4\` cache + reused \`rot\` buffer pattern from PR #146 already applied. The same pattern lands on \`kinbody_jacobian\` in \`ssik.refinement.__init__\`.

## Honest framing

**This is architectural prep, not a measurable speedup.** A/B bench shows every arm within noise (<1%):

| Arm     | Baseline | + this PR | Δ |
|---------|----------|-----------|---|
| UR5     | 0.52 ms  | 0.53 ms   | noise |
| Puma    | 0.24 ms  | 0.25 ms   | noise |
| JACO 2  | 0.90 ms  | 0.89 ms   | noise |
| Franka  | 38.74 ms | 38.61 ms  | noise (-0.3%) |

Why it doesn't show up in the bench:

- 6R artifacts (UR5, Puma 560, JACO 2) **bypass the runtime inner-6R solvers entirely** — their composer inlines the algebraic body at codegen time. \`poe_forward_kinematics\` isn't on their hot path.
- Franka 7R does call it (~192× per default IK via the lock sweep) and saves ~6 \`np.eye(4)\` allocs per call (~5 µs), totalling ~1 ms out of ~38 ms. Sub-threshold for bench precision.

## Why ship it anyway

The value is the **DRY consolidation**: the next-stage Cython source rewrite (#147) now needs to optimize **one** place instead of seven to deliver real measurable speedups on the inner-6R hot path. Less code, lower review burden, no per-solver divergence risk.

Companion to #146 (which did the same \`_FK_EYE4\` trick for the artifact orchestrator's \`_fk\`).

## Test plan

- [x] 479 tests pass (no behaviour change)
- [x] \`mypy\`, \`ruff check\`, \`ruff format --check\` clean
- [x] FK closure preserved across all 4 artifacts (sanity-checked through artifact tests)