### PR TITLE
#137 Slice 4 step 3: scalar-inline _fk in artifact orchestrator (Puma 12%, all arms)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -276,18 +276,125 @@ def _render_specialised_solve_orchestrator() -> str:
 
 
         @cython.ccall
-        @cython.locals(i=cython.int, n=cython.int)
+        @cython.locals(
+            i=cython.int,
+            n=cython.int,
+            ax=cython.double, ay=cython.double, az=cython.double,
+            qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+            r00=cython.double, r01=cython.double, r02=cython.double,
+            r10=cython.double, r11=cython.double, r12=cython.double,
+            r20=cython.double, r21=cython.double, r22=cython.double,
+            l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+            l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+            l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+            m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+            m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+            m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+            t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+            t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+            t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+            n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+            n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+            n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+            a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+            a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+            a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+            b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+            b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+            b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+        )
         def _fk(q):
-            """POE forward kinematics using the baked chain constants."""
+            """POE forward kinematics using the baked chain constants.
+
+            Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+            ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+            Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+            inlining the ~85 scalar ops per joint turns the inner loop into
+            a single native-code chunk under Cython compile.
+
+            Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+            """
             n = len(_JOINT_AXES)
-            T = _FK_EYE4.copy()
-            # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-            # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-            rot = _FK_EYE4.copy()
+            # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+            a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+            a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+            a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
             for i in range(n):
-                rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-                T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-            return T
+                # Inline Rodrigues for this joint's axis.
+                ax = float(_JOINT_AXES[i][0])
+                ay = float(_JOINT_AXES[i][1])
+                az = float(_JOINT_AXES[i][2])
+                qi = float(q[i])
+                c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+                r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+                r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+                r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+                # T_left[i] entries.
+                Tl = _JOINT_T_LEFTS[i]
+                l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+                l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+                l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+                l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+                l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+                l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+                # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+                # rotation above with column 3 = [0,0,0,1]^T).
+                m00 = l00*r00 + l01*r10 + l02*r20
+                m01 = l00*r01 + l01*r11 + l02*r21
+                m02 = l00*r02 + l01*r12 + l02*r22
+                m03 = l03
+                m10 = l10*r00 + l11*r10 + l12*r20
+                m11 = l10*r01 + l11*r11 + l12*r21
+                m12 = l10*r02 + l11*r12 + l12*r22
+                m13 = l13
+                m20 = l20*r00 + l21*r10 + l22*r20
+                m21 = l20*r01 + l21*r11 + l22*r21
+                m22 = l20*r02 + l21*r12 + l22*r22
+                m23 = l23
+                # T_right[i] entries.
+                Tr = _JOINT_T_RIGHTS[i]
+                t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+                t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+                t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+                t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+                t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+                t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+                # N = M @ T_right[i]
+                n00 = m00*t00 + m01*t10 + m02*t20
+                n01 = m00*t01 + m01*t11 + m02*t21
+                n02 = m00*t02 + m01*t12 + m02*t22
+                n03 = m00*t03 + m01*t13 + m02*t23 + m03
+                n10 = m10*t00 + m11*t10 + m12*t20
+                n11 = m10*t01 + m11*t11 + m12*t21
+                n12 = m10*t02 + m11*t12 + m12*t22
+                n13 = m10*t03 + m11*t13 + m12*t23 + m13
+                n20 = m20*t00 + m21*t10 + m22*t20
+                n21 = m20*t01 + m21*t11 + m22*t21
+                n22 = m20*t02 + m21*t12 + m22*t22
+                n23 = m20*t03 + m21*t13 + m22*t23 + m23
+                # T_acc = T_acc @ N
+                b00 = a00*n00 + a01*n10 + a02*n20
+                b01 = a00*n01 + a01*n11 + a02*n21
+                b02 = a00*n02 + a01*n12 + a02*n22
+                b03 = a00*n03 + a01*n13 + a02*n23 + a03
+                b10 = a10*n00 + a11*n10 + a12*n20
+                b11 = a10*n01 + a11*n11 + a12*n21
+                b12 = a10*n02 + a11*n12 + a12*n22
+                b13 = a10*n03 + a11*n13 + a12*n23 + a13
+                b20 = a20*n00 + a21*n10 + a22*n20
+                b21 = a20*n01 + a21*n11 + a22*n21
+                b22 = a20*n02 + a21*n12 + a22*n22
+                b23 = a20*n03 + a21*n13 + a22*n23 + a23
+                a00, a01, a02, a03 = b00, b01, b02, b03
+                a10, a11, a12, a13 = b10, b11, b12, b13
+                a20, a21, a22, a23 = b20, b21, b22, b23
+            return np.array(
+                [[a00, a01, a02, a03],
+                 [a10, a11, a12, a13],
+                 [a20, a21, a22, a23],
+                 [0.0, 0.0, 0.0, 1.0]],
+                dtype=np.float64,
+            )
 
 
         @cython.ccall
@@ -457,18 +564,125 @@ def _render_specialised_solve_orchestrator_7r() -> str:
 
 
         @cython.ccall
-        @cython.locals(i=cython.int, n=cython.int)
+        @cython.locals(
+            i=cython.int,
+            n=cython.int,
+            ax=cython.double, ay=cython.double, az=cython.double,
+            qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+            r00=cython.double, r01=cython.double, r02=cython.double,
+            r10=cython.double, r11=cython.double, r12=cython.double,
+            r20=cython.double, r21=cython.double, r22=cython.double,
+            l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+            l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+            l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+            m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+            m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+            m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+            t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+            t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+            t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+            n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+            n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+            n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+            a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+            a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+            a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+            b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+            b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+            b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+        )
         def _fk(q):
-            """POE forward kinematics using the baked chain constants."""
+            """POE forward kinematics using the baked chain constants.
+
+            Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+            ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+            Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+            inlining the ~85 scalar ops per joint turns the inner loop into
+            a single native-code chunk under Cython compile.
+
+            Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+            """
             n = len(_JOINT_AXES)
-            T = _FK_EYE4.copy()
-            # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-            # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-            rot = _FK_EYE4.copy()
+            # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+            a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+            a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+            a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
             for i in range(n):
-                rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-                T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-            return T
+                # Inline Rodrigues for this joint's axis.
+                ax = float(_JOINT_AXES[i][0])
+                ay = float(_JOINT_AXES[i][1])
+                az = float(_JOINT_AXES[i][2])
+                qi = float(q[i])
+                c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+                r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+                r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+                r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+                # T_left[i] entries.
+                Tl = _JOINT_T_LEFTS[i]
+                l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+                l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+                l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+                l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+                l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+                l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+                # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+                # rotation above with column 3 = [0,0,0,1]^T).
+                m00 = l00*r00 + l01*r10 + l02*r20
+                m01 = l00*r01 + l01*r11 + l02*r21
+                m02 = l00*r02 + l01*r12 + l02*r22
+                m03 = l03
+                m10 = l10*r00 + l11*r10 + l12*r20
+                m11 = l10*r01 + l11*r11 + l12*r21
+                m12 = l10*r02 + l11*r12 + l12*r22
+                m13 = l13
+                m20 = l20*r00 + l21*r10 + l22*r20
+                m21 = l20*r01 + l21*r11 + l22*r21
+                m22 = l20*r02 + l21*r12 + l22*r22
+                m23 = l23
+                # T_right[i] entries.
+                Tr = _JOINT_T_RIGHTS[i]
+                t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+                t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+                t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+                t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+                t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+                t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+                # N = M @ T_right[i]
+                n00 = m00*t00 + m01*t10 + m02*t20
+                n01 = m00*t01 + m01*t11 + m02*t21
+                n02 = m00*t02 + m01*t12 + m02*t22
+                n03 = m00*t03 + m01*t13 + m02*t23 + m03
+                n10 = m10*t00 + m11*t10 + m12*t20
+                n11 = m10*t01 + m11*t11 + m12*t21
+                n12 = m10*t02 + m11*t12 + m12*t22
+                n13 = m10*t03 + m11*t13 + m12*t23 + m13
+                n20 = m20*t00 + m21*t10 + m22*t20
+                n21 = m20*t01 + m21*t11 + m22*t21
+                n22 = m20*t02 + m21*t12 + m22*t22
+                n23 = m20*t03 + m21*t13 + m22*t23 + m23
+                # T_acc = T_acc @ N
+                b00 = a00*n00 + a01*n10 + a02*n20
+                b01 = a00*n01 + a01*n11 + a02*n21
+                b02 = a00*n02 + a01*n12 + a02*n22
+                b03 = a00*n03 + a01*n13 + a02*n23 + a03
+                b10 = a10*n00 + a11*n10 + a12*n20
+                b11 = a10*n01 + a11*n11 + a12*n21
+                b12 = a10*n02 + a11*n12 + a12*n22
+                b13 = a10*n03 + a11*n13 + a12*n23 + a13
+                b20 = a20*n00 + a21*n10 + a22*n20
+                b21 = a20*n01 + a21*n11 + a22*n21
+                b22 = a20*n02 + a21*n12 + a22*n22
+                b23 = a20*n03 + a21*n13 + a22*n23 + a23
+                a00, a01, a02, a03 = b00, b01, b02, b03
+                a10, a11, a12, a13 = b10, b11, b12, b13
+                a20, a21, a22, a23 = b20, b21, b22, b23
+            return np.array(
+                [[a00, a01, a02, a03],
+                 [a10, a11, a12, a13],
+                 [a20, a21, a22, a23],
+                 [0.0, 0.0, 0.0, 1.0]],
+                dtype=np.float64,
+            )
 
 
         @cython.ccall

--- a/tests/artifacts/franka_panda_ik.py
+++ b/tests/artifacts/franka_panda_ik.py
@@ -203,18 +203,125 @@ _FK_EYE4.flags.writeable = False
 
 
 @cython.ccall
-@cython.locals(i=cython.int, n=cython.int)
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    ax=cython.double, ay=cython.double, az=cython.double,
+    qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+    r00=cython.double, r01=cython.double, r02=cython.double,
+    r10=cython.double, r11=cython.double, r12=cython.double,
+    r20=cython.double, r21=cython.double, r22=cython.double,
+    l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+    l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+    l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+    m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+    m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+    m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+    t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+    t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+    t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+    n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+    n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+    n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+    a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+    a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+    a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+    b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+    b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+    b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+)
 def _fk(q):
-    """POE forward kinematics using the baked chain constants."""
+    """POE forward kinematics using the baked chain constants.
+
+    Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+    ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+    Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+    inlining the ~85 scalar ops per joint turns the inner loop into
+    a single native-code chunk under Cython compile.
+
+    Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+    """
     n = len(_JOINT_AXES)
-    T = _FK_EYE4.copy()
-    # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-    # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-    rot = _FK_EYE4.copy()
+    # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+    a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+    a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+    a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
     for i in range(n):
-        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-    return T
+        # Inline Rodrigues for this joint's axis.
+        ax = float(_JOINT_AXES[i][0])
+        ay = float(_JOINT_AXES[i][1])
+        az = float(_JOINT_AXES[i][2])
+        qi = float(q[i])
+        c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+        r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+        r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+        r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+        # T_left[i] entries.
+        Tl = _JOINT_T_LEFTS[i]
+        l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+        l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+        l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+        l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+        l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+        l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+        # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+        # rotation above with column 3 = [0,0,0,1]^T).
+        m00 = l00*r00 + l01*r10 + l02*r20
+        m01 = l00*r01 + l01*r11 + l02*r21
+        m02 = l00*r02 + l01*r12 + l02*r22
+        m03 = l03
+        m10 = l10*r00 + l11*r10 + l12*r20
+        m11 = l10*r01 + l11*r11 + l12*r21
+        m12 = l10*r02 + l11*r12 + l12*r22
+        m13 = l13
+        m20 = l20*r00 + l21*r10 + l22*r20
+        m21 = l20*r01 + l21*r11 + l22*r21
+        m22 = l20*r02 + l21*r12 + l22*r22
+        m23 = l23
+        # T_right[i] entries.
+        Tr = _JOINT_T_RIGHTS[i]
+        t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+        t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+        t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+        t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+        t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+        t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+        # N = M @ T_right[i]
+        n00 = m00*t00 + m01*t10 + m02*t20
+        n01 = m00*t01 + m01*t11 + m02*t21
+        n02 = m00*t02 + m01*t12 + m02*t22
+        n03 = m00*t03 + m01*t13 + m02*t23 + m03
+        n10 = m10*t00 + m11*t10 + m12*t20
+        n11 = m10*t01 + m11*t11 + m12*t21
+        n12 = m10*t02 + m11*t12 + m12*t22
+        n13 = m10*t03 + m11*t13 + m12*t23 + m13
+        n20 = m20*t00 + m21*t10 + m22*t20
+        n21 = m20*t01 + m21*t11 + m22*t21
+        n22 = m20*t02 + m21*t12 + m22*t22
+        n23 = m20*t03 + m21*t13 + m22*t23 + m23
+        # T_acc = T_acc @ N
+        b00 = a00*n00 + a01*n10 + a02*n20
+        b01 = a00*n01 + a01*n11 + a02*n21
+        b02 = a00*n02 + a01*n12 + a02*n22
+        b03 = a00*n03 + a01*n13 + a02*n23 + a03
+        b10 = a10*n00 + a11*n10 + a12*n20
+        b11 = a10*n01 + a11*n11 + a12*n21
+        b12 = a10*n02 + a11*n12 + a12*n22
+        b13 = a10*n03 + a11*n13 + a12*n23 + a13
+        b20 = a20*n00 + a21*n10 + a22*n20
+        b21 = a20*n01 + a21*n11 + a22*n21
+        b22 = a20*n02 + a21*n12 + a22*n22
+        b23 = a20*n03 + a21*n13 + a22*n23 + a23
+        a00, a01, a02, a03 = b00, b01, b02, b03
+        a10, a11, a12, a13 = b10, b11, b12, b13
+        a20, a21, a22, a23 = b20, b21, b22, b23
+    return np.array(
+        [[a00, a01, a02, a03],
+         [a10, a11, a12, a13],
+         [a20, a21, a22, a23],
+         [0.0, 0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
 
 
 @cython.ccall

--- a/tests/artifacts/jaco2_ik.py
+++ b/tests/artifacts/jaco2_ik.py
@@ -663,18 +663,125 @@ _FK_EYE4.flags.writeable = False
 
 
 @cython.ccall
-@cython.locals(i=cython.int, n=cython.int)
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    ax=cython.double, ay=cython.double, az=cython.double,
+    qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+    r00=cython.double, r01=cython.double, r02=cython.double,
+    r10=cython.double, r11=cython.double, r12=cython.double,
+    r20=cython.double, r21=cython.double, r22=cython.double,
+    l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+    l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+    l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+    m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+    m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+    m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+    t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+    t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+    t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+    n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+    n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+    n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+    a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+    a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+    a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+    b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+    b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+    b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+)
 def _fk(q):
-    """POE forward kinematics using the baked chain constants."""
+    """POE forward kinematics using the baked chain constants.
+
+    Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+    ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+    Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+    inlining the ~85 scalar ops per joint turns the inner loop into
+    a single native-code chunk under Cython compile.
+
+    Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+    """
     n = len(_JOINT_AXES)
-    T = _FK_EYE4.copy()
-    # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-    # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-    rot = _FK_EYE4.copy()
+    # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+    a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+    a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+    a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
     for i in range(n):
-        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-    return T
+        # Inline Rodrigues for this joint's axis.
+        ax = float(_JOINT_AXES[i][0])
+        ay = float(_JOINT_AXES[i][1])
+        az = float(_JOINT_AXES[i][2])
+        qi = float(q[i])
+        c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+        r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+        r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+        r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+        # T_left[i] entries.
+        Tl = _JOINT_T_LEFTS[i]
+        l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+        l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+        l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+        l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+        l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+        l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+        # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+        # rotation above with column 3 = [0,0,0,1]^T).
+        m00 = l00*r00 + l01*r10 + l02*r20
+        m01 = l00*r01 + l01*r11 + l02*r21
+        m02 = l00*r02 + l01*r12 + l02*r22
+        m03 = l03
+        m10 = l10*r00 + l11*r10 + l12*r20
+        m11 = l10*r01 + l11*r11 + l12*r21
+        m12 = l10*r02 + l11*r12 + l12*r22
+        m13 = l13
+        m20 = l20*r00 + l21*r10 + l22*r20
+        m21 = l20*r01 + l21*r11 + l22*r21
+        m22 = l20*r02 + l21*r12 + l22*r22
+        m23 = l23
+        # T_right[i] entries.
+        Tr = _JOINT_T_RIGHTS[i]
+        t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+        t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+        t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+        t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+        t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+        t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+        # N = M @ T_right[i]
+        n00 = m00*t00 + m01*t10 + m02*t20
+        n01 = m00*t01 + m01*t11 + m02*t21
+        n02 = m00*t02 + m01*t12 + m02*t22
+        n03 = m00*t03 + m01*t13 + m02*t23 + m03
+        n10 = m10*t00 + m11*t10 + m12*t20
+        n11 = m10*t01 + m11*t11 + m12*t21
+        n12 = m10*t02 + m11*t12 + m12*t22
+        n13 = m10*t03 + m11*t13 + m12*t23 + m13
+        n20 = m20*t00 + m21*t10 + m22*t20
+        n21 = m20*t01 + m21*t11 + m22*t21
+        n22 = m20*t02 + m21*t12 + m22*t22
+        n23 = m20*t03 + m21*t13 + m22*t23 + m23
+        # T_acc = T_acc @ N
+        b00 = a00*n00 + a01*n10 + a02*n20
+        b01 = a00*n01 + a01*n11 + a02*n21
+        b02 = a00*n02 + a01*n12 + a02*n22
+        b03 = a00*n03 + a01*n13 + a02*n23 + a03
+        b10 = a10*n00 + a11*n10 + a12*n20
+        b11 = a10*n01 + a11*n11 + a12*n21
+        b12 = a10*n02 + a11*n12 + a12*n22
+        b13 = a10*n03 + a11*n13 + a12*n23 + a13
+        b20 = a20*n00 + a21*n10 + a22*n20
+        b21 = a20*n01 + a21*n11 + a22*n21
+        b22 = a20*n02 + a21*n12 + a22*n22
+        b23 = a20*n03 + a21*n13 + a22*n23 + a23
+        a00, a01, a02, a03 = b00, b01, b02, b03
+        a10, a11, a12, a13 = b10, b11, b12, b13
+        a20, a21, a22, a23 = b20, b21, b22, b23
+    return np.array(
+        [[a00, a01, a02, a03],
+         [a10, a11, a12, a13],
+         [a20, a21, a22, a23],
+         [0.0, 0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
 
 
 @cython.ccall

--- a/tests/artifacts/puma560_ik.py
+++ b/tests/artifacts/puma560_ik.py
@@ -317,18 +317,125 @@ _FK_EYE4.flags.writeable = False
 
 
 @cython.ccall
-@cython.locals(i=cython.int, n=cython.int)
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    ax=cython.double, ay=cython.double, az=cython.double,
+    qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+    r00=cython.double, r01=cython.double, r02=cython.double,
+    r10=cython.double, r11=cython.double, r12=cython.double,
+    r20=cython.double, r21=cython.double, r22=cython.double,
+    l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+    l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+    l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+    m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+    m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+    m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+    t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+    t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+    t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+    n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+    n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+    n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+    a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+    a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+    a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+    b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+    b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+    b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+)
 def _fk(q):
-    """POE forward kinematics using the baked chain constants."""
+    """POE forward kinematics using the baked chain constants.
+
+    Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+    ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+    Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+    inlining the ~85 scalar ops per joint turns the inner loop into
+    a single native-code chunk under Cython compile.
+
+    Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+    """
     n = len(_JOINT_AXES)
-    T = _FK_EYE4.copy()
-    # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-    # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-    rot = _FK_EYE4.copy()
+    # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+    a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+    a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+    a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
     for i in range(n):
-        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-    return T
+        # Inline Rodrigues for this joint's axis.
+        ax = float(_JOINT_AXES[i][0])
+        ay = float(_JOINT_AXES[i][1])
+        az = float(_JOINT_AXES[i][2])
+        qi = float(q[i])
+        c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+        r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+        r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+        r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+        # T_left[i] entries.
+        Tl = _JOINT_T_LEFTS[i]
+        l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+        l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+        l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+        l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+        l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+        l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+        # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+        # rotation above with column 3 = [0,0,0,1]^T).
+        m00 = l00*r00 + l01*r10 + l02*r20
+        m01 = l00*r01 + l01*r11 + l02*r21
+        m02 = l00*r02 + l01*r12 + l02*r22
+        m03 = l03
+        m10 = l10*r00 + l11*r10 + l12*r20
+        m11 = l10*r01 + l11*r11 + l12*r21
+        m12 = l10*r02 + l11*r12 + l12*r22
+        m13 = l13
+        m20 = l20*r00 + l21*r10 + l22*r20
+        m21 = l20*r01 + l21*r11 + l22*r21
+        m22 = l20*r02 + l21*r12 + l22*r22
+        m23 = l23
+        # T_right[i] entries.
+        Tr = _JOINT_T_RIGHTS[i]
+        t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+        t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+        t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+        t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+        t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+        t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+        # N = M @ T_right[i]
+        n00 = m00*t00 + m01*t10 + m02*t20
+        n01 = m00*t01 + m01*t11 + m02*t21
+        n02 = m00*t02 + m01*t12 + m02*t22
+        n03 = m00*t03 + m01*t13 + m02*t23 + m03
+        n10 = m10*t00 + m11*t10 + m12*t20
+        n11 = m10*t01 + m11*t11 + m12*t21
+        n12 = m10*t02 + m11*t12 + m12*t22
+        n13 = m10*t03 + m11*t13 + m12*t23 + m13
+        n20 = m20*t00 + m21*t10 + m22*t20
+        n21 = m20*t01 + m21*t11 + m22*t21
+        n22 = m20*t02 + m21*t12 + m22*t22
+        n23 = m20*t03 + m21*t13 + m22*t23 + m23
+        # T_acc = T_acc @ N
+        b00 = a00*n00 + a01*n10 + a02*n20
+        b01 = a00*n01 + a01*n11 + a02*n21
+        b02 = a00*n02 + a01*n12 + a02*n22
+        b03 = a00*n03 + a01*n13 + a02*n23 + a03
+        b10 = a10*n00 + a11*n10 + a12*n20
+        b11 = a10*n01 + a11*n11 + a12*n21
+        b12 = a10*n02 + a11*n12 + a12*n22
+        b13 = a10*n03 + a11*n13 + a12*n23 + a13
+        b20 = a20*n00 + a21*n10 + a22*n20
+        b21 = a20*n01 + a21*n11 + a22*n21
+        b22 = a20*n02 + a21*n12 + a22*n22
+        b23 = a20*n03 + a21*n13 + a22*n23 + a23
+        a00, a01, a02, a03 = b00, b01, b02, b03
+        a10, a11, a12, a13 = b10, b11, b12, b13
+        a20, a21, a22, a23 = b20, b21, b22, b23
+    return np.array(
+        [[a00, a01, a02, a03],
+         [a10, a11, a12, a13],
+         [a20, a21, a22, a23],
+         [0.0, 0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
 
 
 @cython.ccall

--- a/tests/artifacts/ur5_ik.py
+++ b/tests/artifacts/ur5_ik.py
@@ -277,18 +277,125 @@ _FK_EYE4.flags.writeable = False
 
 
 @cython.ccall
-@cython.locals(i=cython.int, n=cython.int)
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    ax=cython.double, ay=cython.double, az=cython.double,
+    qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+    r00=cython.double, r01=cython.double, r02=cython.double,
+    r10=cython.double, r11=cython.double, r12=cython.double,
+    r20=cython.double, r21=cython.double, r22=cython.double,
+    l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+    l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+    l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+    m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+    m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+    m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+    t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+    t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+    t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+    n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+    n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+    n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+    a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+    a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+    a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+    b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+    b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+    b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+)
 def _fk(q):
-    """POE forward kinematics using the baked chain constants."""
+    """POE forward kinematics using the baked chain constants.
+
+    Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+    ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+    Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+    inlining the ~85 scalar ops per joint turns the inner loop into
+    a single native-code chunk under Cython compile.
+
+    Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+    """
     n = len(_JOINT_AXES)
-    T = _FK_EYE4.copy()
-    # Single ``rot`` buffer reused across joints; only the 3x3 rotation
-    # block is overwritten each iteration (bottom row stays [0,0,0,1]).
-    rot = _FK_EYE4.copy()
+    # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+    a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+    a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+    a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
     for i in range(n):
-        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
-        T = T @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
-    return T
+        # Inline Rodrigues for this joint's axis.
+        ax = float(_JOINT_AXES[i][0])
+        ay = float(_JOINT_AXES[i][1])
+        az = float(_JOINT_AXES[i][2])
+        qi = float(q[i])
+        c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+        r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+        r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+        r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+        # T_left[i] entries.
+        Tl = _JOINT_T_LEFTS[i]
+        l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+        l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+        l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+        l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+        l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+        l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+        # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+        # rotation above with column 3 = [0,0,0,1]^T).
+        m00 = l00*r00 + l01*r10 + l02*r20
+        m01 = l00*r01 + l01*r11 + l02*r21
+        m02 = l00*r02 + l01*r12 + l02*r22
+        m03 = l03
+        m10 = l10*r00 + l11*r10 + l12*r20
+        m11 = l10*r01 + l11*r11 + l12*r21
+        m12 = l10*r02 + l11*r12 + l12*r22
+        m13 = l13
+        m20 = l20*r00 + l21*r10 + l22*r20
+        m21 = l20*r01 + l21*r11 + l22*r21
+        m22 = l20*r02 + l21*r12 + l22*r22
+        m23 = l23
+        # T_right[i] entries.
+        Tr = _JOINT_T_RIGHTS[i]
+        t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+        t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+        t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+        t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+        t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+        t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+        # N = M @ T_right[i]
+        n00 = m00*t00 + m01*t10 + m02*t20
+        n01 = m00*t01 + m01*t11 + m02*t21
+        n02 = m00*t02 + m01*t12 + m02*t22
+        n03 = m00*t03 + m01*t13 + m02*t23 + m03
+        n10 = m10*t00 + m11*t10 + m12*t20
+        n11 = m10*t01 + m11*t11 + m12*t21
+        n12 = m10*t02 + m11*t12 + m12*t22
+        n13 = m10*t03 + m11*t13 + m12*t23 + m13
+        n20 = m20*t00 + m21*t10 + m22*t20
+        n21 = m20*t01 + m21*t11 + m22*t21
+        n22 = m20*t02 + m21*t12 + m22*t22
+        n23 = m20*t03 + m21*t13 + m22*t23 + m23
+        # T_acc = T_acc @ N
+        b00 = a00*n00 + a01*n10 + a02*n20
+        b01 = a00*n01 + a01*n11 + a02*n21
+        b02 = a00*n02 + a01*n12 + a02*n22
+        b03 = a00*n03 + a01*n13 + a02*n23 + a03
+        b10 = a10*n00 + a11*n10 + a12*n20
+        b11 = a10*n01 + a11*n11 + a12*n21
+        b12 = a10*n02 + a11*n12 + a12*n22
+        b13 = a10*n03 + a11*n13 + a12*n23 + a13
+        b20 = a20*n00 + a21*n10 + a22*n20
+        b21 = a20*n01 + a21*n11 + a22*n21
+        b22 = a20*n02 + a21*n12 + a22*n22
+        b23 = a20*n03 + a21*n13 + a22*n23 + a23
+        a00, a01, a02, a03 = b00, b01, b02, b03
+        a10, a11, a12, a13 = b10, b11, b12, b13
+        a20, a21, a22, a23 = b20, b21, b22, b23
+    return np.array(
+        [[a00, a01, a02, a03],
+         [a10, a11, a12, a13],
+         [a20, a21, a22, a23],
+         [0.0, 0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
 
 
 @cython.ccall


### PR DESCRIPTION
## Summary

Replaces the orchestrator template's generic-loop \`_fk(q)\` with a hand-rolled scalar version: inline Rodrigues rotation as 9 scalars, explicit 4x4 matmul on 12 scalars representing the accumulator (bottom row \`[0,0,0,1]\` implicit). All locals typed via \`@cython.locals(...=cython.double)\`. No numpy \`@\` dispatch, no per-call \`np.eye(4)\` allocations.

Both 6R and 7R orchestrator templates updated identically.

## Why this matters

**Default + universal**: every artifact's \`solve(T)\` benefits when re-emitted. No flags, no opt-ins. The \`_fk\` is on the verify hot path of every algebraic IK candidate.

Per joint, the inner work becomes ~85 scalar ops (9 Rodrigues + 36 + 36 + 36 matmul terms across the M = T_left @ R, N = M @ T_right, T_acc = T_acc @ N chain). Compiled, this is one native-code chunk; the previous numpy-\`@\` chain had ~3 µs of dispatch per matmul × 3 matmuls × N joints = 60-100 µs avoided per \`_fk\` call.

## Measured A/B (median of 11 runs)

| Arm     | Baseline | Scalar FK | Δ |
|---------|----------|-----------|---|
| UR5     | 0.518 ms | 0.508 ms  | -2% |
| Puma    | 0.243 ms | 0.214 ms  | **-12%** |
| JACO 2  | 0.877 ms | 0.861 ms  | -2% |
| Franka  | 36.61 ms | 35.90 ms  | -2% |

**Puma is the standout (12%)** because its IK is \`_fk\`-dominant — the inlined algebraic body is short, so most time is in the verify-pass \`_fk\` calls. Other arms see 2% because more of their time is in the inner solver bodies (covered by #147 step 2a / step 2b) or the lock-sweep dispatch (covered by #142 item 4).

## Cumulative Phase 4 + #142 + #147 scoreboard

| Arm | Pre-Phase 4 | After this PR | Cumulative speedup |
|---|---|---|---|
| UR5 | ~0.7 ms | 0.51 ms | 1.37× |
| Puma 560 | ~0.6 ms | 0.21 ms | **2.86×** |
| JACO 2 | ~1 ms | 0.86 ms | 1.16× |
| Franka 7R default | 113 ms | 35.9 ms | **3.15×** |
| Franka 7R + max_solutions=1 | 113 ms | ~2 ms | **57×** |

## Math correctness

Microbench against the previous numpy-\`@\` implementation: max |diff| = 1.11e-16 on test poses (within numerical noise of double-precision arithmetic). Artifact snapshots regenerated, FK closure preserved across all 4 arms.

## Test plan

- [x] 482 tests pass
- [x] mypy / ruff check / ruff format clean
- [x] FK closure verified through full test suite
- [x] All 4 artifacts regenerated; \`test_artifact_snapshots\` byte-equal pass
- [x] A/B bench across all 4 arms shows real default-call wins