### PR TITLE
#144: move cython from dev-only to runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,17 @@ classifiers = [
 dependencies = [
     "numpy>=2.0",
     "sympy>=1.10",
+    # Required for ``import cython`` at module top in compiled-source modules
+    # (``ssik.kinematics._scalar3``, ``ssik.subproblems._rotation``,
+    # ``ssik.subproblems.sp5``, ``ssik.kinematics.poe_fk``,
+    # ``ssik.solvers.ikgeo.spherical``, ``ssik.refinement``). When ssik is
+    # installed from a wheel with pre-compiled .so files, the Python-source
+    # ``import cython`` lines never execute -- but a fresh ``pip install ssik``
+    # without the .so (sdist build, or platform without prebuilt wheel) does
+    # execute them. The Cython runtime is small and well-maintained, so making
+    # it a hard dep is the simplest fix vs. a try/except fallback shim.
+    # See #144 for the regression history.
+    "cython>=3.1",
 ]
 dynamic = ["version"]
 
@@ -47,7 +58,8 @@ dev = [
     "mypy>=1.13",
     "urchin>=0.0.27",  # exercised by the URDF-adapter tests
     "hypothesis>=6.112",  # property-based fuzzing of the URDF loader
-    "cython>=3.1",  # in-place builds via scripts/build_cython.py (#137 Slice 1)
+    # cython itself is in runtime ``[project.dependencies]`` (#144); only the
+    # build-side ``setuptools`` extension stays here.
     "setuptools>=70",  # cythonize+setuptools build backend
 ]
 docs = [


### PR DESCRIPTION
## Summary

\`pyproject.toml\`: cython moves from \`[dependency-groups].dev\` to \`[project.dependencies]\`. Setuptools stays in dev (only \`scripts/build_cython.py\` needs it).

## Why

Slice 1 of #137 added unconditional \`import cython\` to several \`src/ssik\` modules. A fresh \`pip install ssik\` without the dev group installs into an env without cython; the first import of any cython-using module fails with \`ModuleNotFoundError\`.

Wheel users with pre-compiled \`.so\` files don't actually execute the source \`import cython\` line at runtime (the .so bypasses the .py), but source-install users on platforms without a prebuilt wheel hit the failure. This blocks any TestPyPI / PyPI publish.

The simplest fix (Option A from #144) — cython is small and well-maintained, so making it a hard runtime dep avoids the alternative try/except shim.

## Unblocks

- #132 (PyPI alpha publish): fresh \`pip install ssik\` in an empty venv now imports.

## Test plan

- [x] mypy / ruff check / ruff format clean
- [x] dev install (this venv) still works (cython is now reached via runtime deps + dev group still resolves)
- [ ] (post-merge, in #132) verify TestPyPI install in a fresh venv successfully imports \`ssik\`