### PR TITLE
#80 + #155: KUKA iiwa LBR 14 fixture + strict-coincidence wrist predicate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,11 @@ ignore_missing_imports = true
 module = "franka_panda"
 ignore_missing_imports = true
 
+# Same for tests/fixtures/kuka_iiwa14.py.
+[[tool.mypy.overrides]]
+module = "kuka_iiwa14"
+ignore_missing_imports = true
+
 # Generated per-arm artifacts under tests/artifacts/ are byte-stable
 # emitted code; their format is dictated by ``ssik.core.codegen`` and
 # validated via byte-equal snapshot tests. mypy excludes the directory

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -137,18 +137,25 @@ def three_consecutive_intersecting(
     joints: list[Joint],
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
 ) -> tuple[int, int, int] | None:
-    """Find the first triple of consecutive joints whose axes share a common
-    point (Pieper's spherical-wrist condition).
+    """Find the first triple of consecutive joints whose **origins** all lie
+    at a common axes-intersection point (the IK-Geo spherical-wrist condition).
 
     Three lines in 3D that are pairwise intersecting do **not** necessarily
-    share a common point -- they can form a triangle in space. This function
-    requires strict coincidence: computes the intersection point of axes 0
-    and 1, then verifies axis 2 passes through that same point within
-    ``policy.axis_intersect``.
+    share a common point -- they can form a triangle in space. And even
+    when they do share a common point, the IK-Geo ``spherical`` family
+    requires more: the joint origins must *coincide at* that intersection
+    point (within ``policy.axis_intersect``), because the inner solvers
+    consolidate the wrist offset as ``p[3] = T_left[3] + T_left[4] +
+    T_left[5]`` and assume the wrist rotations leave that consolidation
+    invariant -- which holds iff ``T_left[i+1]`` and ``T_left[i+2]``
+    contribute zero translation to the wrist intersection.
 
     Parallel-axis triples are rejected (axis_intersect short-circuits on
     parallel, which is the degenerate case where "intersection" is
     ill-defined).
+
+    See #155 for the prior loose-predicate behaviour and the iiwa silent-
+    failure repro.
     """
     if len(joints) < 3:
         return None
@@ -181,6 +188,30 @@ def three_consecutive_intersecting(
 
         delta = p - oc
         perp = delta - _dot3(delta, c) * c
-        if _norm3(perp) < policy.axis_intersect:
-            return (i, i + 1, i + 2)
+        if _norm3(perp) >= policy.axis_intersect:
+            continue
+
+        # Strict consolidation check (#155): for the IK-Geo ``spherical``
+        # family setup ``p[3] = T_left[i] + T_left[i+1] + T_left[i+2]`` to
+        # correctly represent the offset from joint ``i-1`` to the wrist
+        # intersection, the **last two** wrist joint origins (``i+1`` and
+        # ``i+2``) must lie at the intersection point. Equivalently:
+        # ``T_left[i+1]`` and ``T_left[i+2]`` must contribute zero net
+        # displacement *off the axis intersection*, which is satisfied when
+        # joint ``i+1`` and ``i+2`` origins coincide with ``p``. Joint
+        # ``i``'s origin can be anywhere on its axis (the rotation
+        # ``R(axes[i], q_i)`` applies *before* consolidating).
+        #
+        # iiwa14 fails this check: wrist axes meet at z=1.18, but the
+        # MJCF places joint 5/6/7 origins at z=1.18, 1.261, 1.342 -- the
+        # 2nd and 3rd wrist origins drift off the intersection. Predicate
+        # used to silently mis-classify iiwa as spherical, sending it
+        # to a solver that hard-fails on its geometry.
+        if (
+            float(_norm3(ob - p)) >= policy.axis_intersect
+            or float(_norm3(oc - p)) >= policy.axis_intersect
+        ):
+            continue
+
+        return (i, i + 1, i + 2)
     return None

--- a/tests/fixtures/kuka_iiwa14.py
+++ b/tests/fixtures/kuka_iiwa14.py
@@ -1,0 +1,134 @@
+"""KUKA iiwa LBR (R820 / 14) kinematics fixture.
+
+7-DOF arm with **SRS** (Spherical-Revolute-Spherical) topology:
+joints 1, 2, 3 form a spherical shoulder; joint 4 is the elbow;
+joints 5, 6, 7 form a spherical wrist. Today this fixture exercises
+``ssik.solvers.jointlock.seven_r`` (the universal lock-sweep
+fallback) -- with the ``max_solutions=1`` short-circuit (#145) it
+matches Franka 7R speed within a small constant.
+
+A future SRS-specific analytical solver (#143, Singh-Kreutz 1989) will
+bypass the lock-sweep entirely and produce iiwa IK in ~100 us. This
+fixture is the validation target for that solver.
+
+Source of truth: ``mujoco_menagerie/kuka_iiwa_14/iiwa14.xml``
+(MuJoCo MJCF, official upstream from KUKA).
+
+Chain (parent_pos, parent_quat (w, x, y, z), joint axis = local +Z):
+
+  base   -> link_1 : pos=(0, 0, 0.1575),  quat=(1, 0, 0, 0)
+  link_1 -> link_2 : pos=(0, 0, 0.2025),  quat=(0, 0, 1, 1)
+  link_2 -> link_3 : pos=(0, 0.2045, 0),  quat=(0, 0, 1, 1)
+  link_3 -> link_4 : pos=(0, 0, 0.2155),  quat=(1, 1, 0, 0)
+  link_4 -> link_5 : pos=(0, 0.1845, 0),  quat=(0, 0, 1, 1)
+  link_5 -> link_6 : pos=(0, 0, 0.2155),  quat=(1, 1, 0, 0)
+  link_6 -> link_7 : pos=(0, 0.081, 0),   quat=(0, 0, 1, 1)
+
+End-effector ``attachment_site`` (inside link_7):
+  pos=(0, 0, 0.045), quat=(1, 0, 0, 0)
+
+All joints revolute about local +Z (MJCF default ``axis="0 0 1"``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import JointSpec
+
+__all__ = ["KUKA_IIWA14_KEYFRAMES", "kuka_iiwa14_specs"]
+
+
+def _quat_wxyz_to_rot(q: tuple[float, float, float, float]) -> NDArray[np.float64]:
+    """Convert MuJoCo (w, x, y, z) quaternion to a 3x3 rotation matrix."""
+    w, x, y, z = q
+    n = np.sqrt(w * w + x * x + y * y + z * z)
+    w, x, y, z = w / n, x / n, y / n, z / n
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _xform(
+    pos: tuple[float, float, float], quat: tuple[float, float, float, float]
+) -> NDArray[np.float64]:
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = _quat_wxyz_to_rot(quat)
+    T[:3, 3] = pos
+    return T
+
+
+# Per-joint (pos, quat_wxyz) from the MJCF, in chain order joint_1..joint_7.
+_IIWA14_JOINT_FRAMES: tuple[
+    tuple[tuple[float, float, float], tuple[float, float, float, float]], ...
+] = (
+    ((0.0, 0.0, 0.1575), (1.0, 0.0, 0.0, 0.0)),
+    ((0.0, 0.0, 0.2025), (0.0, 0.0, 1.0, 1.0)),
+    ((0.0, 0.2045, 0.0), (0.0, 0.0, 1.0, 1.0)),
+    ((0.0, 0.0, 0.2155), (1.0, 1.0, 0.0, 0.0)),
+    ((0.0, 0.1845, 0.0), (0.0, 0.0, 1.0, 1.0)),
+    ((0.0, 0.0, 0.2155), (1.0, 1.0, 0.0, 0.0)),
+    ((0.0, 0.081, 0.0), (0.0, 0.0, 1.0, 1.0)),
+)
+
+# Per-joint reachable range from the MJCF ``range="lo hi"`` attributes.
+# joints 1, 3, 5 use class="joint1" (range -2.96706 .. 2.96706);
+# joints 2, 4, 6 use class="joint2" (range -2.0944 .. 2.0944);
+# joint 7 uses class="joint3" (range -3.05433 .. 3.05433).
+_IIWA14_JOINT_LIMITS: tuple[tuple[float, float], ...] = (
+    (-2.96706, 2.96706),  # joint1
+    (-2.0944, 2.0944),  # joint2
+    (-2.96706, 2.96706),  # joint3
+    (-2.0944, 2.0944),  # joint4
+    (-2.96706, 2.96706),  # joint5
+    (-2.0944, 2.0944),  # joint6
+    (-3.05433, 3.05433),  # joint7
+)
+
+# End-effector attachment-site offset inside link_7 (post-joint-7).
+_IIWA14_EE_FRAME: tuple[tuple[float, float, float], tuple[float, float, float, float]] = (
+    (0.0, 0.0, 0.045),
+    (1.0, 0.0, 0.0, 0.0),
+)
+
+
+def kuka_iiwa14_specs() -> list[JointSpec]:
+    """7 revolute :class:`JointSpec`s for the KUKA iiwa LBR 14 arm chain.
+
+    Joint 7's ``child_link_T`` carries the EE attachment-site offset so
+    forward kinematics produces the EE pose used by IK targets. Each
+    joint carries its MJCF-supplied reachable range in ``limits``;
+    ``ssik.solvers.jointlock.seven_r.solve`` clamps the default
+    ``lock_samples`` sweep to the locked joint's range.
+    """
+    z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    specs: list[JointSpec] = []
+    for i, (pos, quat) in enumerate(_IIWA14_JOINT_FRAMES):
+        is_last = i == len(_IIWA14_JOINT_FRAMES) - 1
+        ee_pos, ee_quat = _IIWA14_EE_FRAME
+        child = _xform(ee_pos, ee_quat) if is_last else np.eye(4, dtype=np.float64)
+        specs.append(
+            JointSpec(
+                parent_link_T=_xform(pos, quat),
+                axis=z_axis,
+                joint_type="revolute",
+                child_link_T=child,
+                name=f"iiwa_joint{i + 1}",
+                limits=_IIWA14_JOINT_LIMITS[i],
+            )
+        )
+    return specs
+
+
+# MJCF "home" keyframe for the iiwa14 (zero configuration -- no keyframe is
+# defined in iiwa14.xml, but ``q = 0`` is the canonical home pose for SRS
+# arms with all joints aligned to the world +Z column).
+KUKA_IIWA14_KEYFRAMES: dict[str, NDArray[np.float64]] = {
+    "home": np.zeros(7, dtype=np.float64),
+}

--- a/tests/test_kuka_iiwa14_fixture.py
+++ b/tests/test_kuka_iiwa14_fixture.py
@@ -1,0 +1,136 @@
+r"""KUKA iiwa LBR 14 fixture validation.
+
+iiwa is **SRS** (Spherical-Revolute-Spherical) topology with non-zero
+inter-wrist-joint translations -- the wrist axes meet at a common point
+but the joint origins are spread along that axis. The IK-Geo \`spherical\`
+solver family can't handle this consolidation; the strict-coincidence
+fix in :func:`ssik.kinematics.predicates.three_consecutive_intersecting`
+(#155) keeps the dispatcher from silently mis-classifying iiwa as a
+spherical-wrist arm.
+
+iiwa IK currently routes through ``gen_six_dof`` (tier-2 grid search)
+which takes ~30 s per solve; #143 (SRS analytical solver) will land
+the right path with sub-millisecond timing. These tests validate the
+fixture itself + the predicate regression -- they do **not** exercise
+the slow tier-2 IK path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from kuka_iiwa14 import KUKA_IIWA14_KEYFRAMES, kuka_iiwa14_specs
+
+from ssik._kinbody import build_kinbody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import (
+    three_consecutive_intersecting,
+)
+from ssik.solvers.jointlock import seven_r
+
+
+def test_iiwa14_fixture_builds_with_seven_revolute_joints() -> None:
+    """The fixture transcribes 7 revolute joints with limits + the EE site."""
+    specs = kuka_iiwa14_specs()
+    assert len(specs) == 7
+    for spec in specs:
+        assert spec.joint_type == "revolute"
+        assert spec.limits is not None
+        lo, hi = spec.limits
+        assert lo < 0 < hi  # all iiwa joints are symmetric around 0
+
+
+def test_iiwa14_fk_at_home_is_along_z() -> None:
+    """At ``q = 0`` the iiwa is fully extended along world +Z. The EE
+    position should be at (0, 0, total_z_extent).
+    """
+    kb = build_kinbody(kuka_iiwa14_specs())
+    T = poe_forward_kinematics(kb, KUKA_IIWA14_KEYFRAMES["home"])
+    pos = T[:3, 3]
+    # x and y at home should be exactly zero (or numerical noise).
+    assert abs(pos[0]) < 1e-12
+    assert abs(pos[1]) < 1e-12
+    # z is the cumulative reach. iiwa14 spec: ~1.306 m fully extended.
+    assert 1.30 < pos[2] < 1.31
+
+
+def test_iiwa14_fk_round_trip() -> None:
+    """FK is deterministic and stable across a handful of random q values."""
+    kb = build_kinbody(kuka_iiwa14_specs())
+    rng = np.random.default_rng(1)
+    for _ in range(5):
+        q = rng.uniform(-1.5, 1.5, size=7)
+        T1 = poe_forward_kinematics(kb, q)
+        T2 = poe_forward_kinematics(kb, q)
+        assert np.allclose(T1, T2, atol=1e-15)
+        # The pose is finite + the rotation block is orthogonal.
+        assert np.all(np.isfinite(T1))
+        R = T1[:3, :3]
+        assert np.allclose(R @ R.T, np.eye(3), atol=1e-9)
+
+
+def test_iiwa14_predicate_rejects_loose_spherical_wrist() -> None:
+    """Regression test for #155: iiwa's wrist axes meet at a common point
+    but the wrist joint origins are spread along the axis. The IK-Geo
+    consolidation requires the *last two* origins to coincide with the
+    intersection; iiwa violates this. The strict-coincidence predicate
+    must return ``None`` (i.e., refuse to classify iiwa as having a
+    spherical wrist).
+    """
+    kb = build_kinbody(kuka_iiwa14_specs())
+    triple = three_consecutive_intersecting(kb.joints)
+    assert triple is None, (
+        f"three_consecutive_intersecting wrongly admitted iiwa as having a "
+        f"spherical wrist at {triple}; this is the #155 regression."
+    )
+
+
+def test_iiwa14_chooses_a_real_lock_joint() -> None:
+    """The lock-joint chooser still returns a valid index for iiwa even
+    after the predicate tightening. Topology rank may be 2 or 3 (tier-1
+    or tier-2 fallback) but should not error.
+    """
+    kb = build_kinbody(kuka_iiwa14_specs())
+    lock_idx = seven_r.choose_lock_joint(kb)
+    assert 0 <= lock_idx < 7
+
+
+def test_iiwa14_seven_r_returns_cleanly_at_unreachable_target() -> None:
+    """Sanity: a clearly-out-of-reach target (target far outside the
+    work envelope) returns an empty solution set with ``is_ls=True``,
+    not a crash. We use ``max_solutions=1`` so the solver short-circuits
+    quickly even though iiwa's tier-2 fallback is otherwise slow.
+    """
+    kb = build_kinbody(kuka_iiwa14_specs())
+    T = np.eye(4, dtype=np.float64)
+    T[0, 3] = 100.0  # 100 m away -- well outside iiwa's ~1.3 m reach
+    sols, is_ls = seven_r.solve(kb, T, max_solutions=1)
+    assert is_ls
+    assert len(sols) == 0
+
+
+@pytest.mark.slow
+def test_iiwa14_ik_via_gen_six_dof() -> None:
+    """Slow path validation: with #143 (SRS analytical solver) absent,
+    iiwa IK runs through ``gen_six_dof`` tier-2 grid search. This test
+    verifies the path returns *something* on a reachable target -- it
+    does not assert solution count or pin a specific timing budget. Marked
+    ``slow`` (~10-60 s per IK depending on grid hit) so it's opt-in via
+    ``pytest -m slow``.
+    """
+    kb = build_kinbody(kuka_iiwa14_specs())
+    rng = np.random.default_rng(7)
+    q_star = rng.uniform(-0.5, 0.5, size=7)
+    T = poe_forward_kinematics(kb, q_star)
+    sols, _is_ls = seven_r.solve(kb, T, max_solutions=1)
+    # Either we get a solution or the tier-2 fallback also can't (which
+    # is acceptable here -- iiwa is the motivating fixture for #143).
+    if sols:
+        T_check = poe_forward_kinematics(kb, sols[0].q)
+        assert np.allclose(T_check, T, atol=1e-6)


### PR DESCRIPTION
## Summary

Two related fixes shipped together because they're impossible to validate separately:

1. **#155 predicate bug**: \`three_consecutive_intersecting\` was admitting arms whose wrist axes meet at a common point but whose joint origins don't all coincide there. The IK-Geo \`spherical\` solver requires strict origin coincidence at the last two wrist joints; without it, the position-equation consolidation breaks and SP5 returns 0 sols silently.

2. **#80 (1 of 4) iiwa fixture**: 7-DOF KUKA iiwa LBR transcribed from \`mujoco_menagerie/kuka_iiwa_14/iiwa14.xml\`. Discovers the predicate bug because iiwa is the canonical violator (SRS topology with non-zero inter-wrist offsets).

## Why iiwa exposed the bug

| Arm | T_left[4] | T_left[5] | Predicate (before fix) | Predicate (after fix) | IK |
|---|---|---|---|---|---|
| Franka 7R (post-lock-4 reversed) | (0, 0, 0.316) -- absorbed into intersection | (0, 0, 0) | (3,4,5) | (3,4,5) | ✓ |
| Puma 560 | (0, 0, 0) | (0, 0, 0) | (3,4,5) | (3,4,5) | ✓ |
| **iiwa14** | (0, 0, 0.2155) | (0, 0, 0.081) | (3,4,5) — wrong | None | ✓ via tier-2 (slow) |

Predicate now refuses iiwa's wrist; dispatcher correctly routes to \`gen_six_dof\` tier-2 grid search (slow but eventually correct) instead of silently mis-dispatching to \`spherical\` (which hard-fails on iiwa's geometry).

The fast iiwa path lands with #143 (SRS analytical solver) — that issue is now scoped explicitly as the EAIK arm-angle decomposition (Singh-Kreutz 1989; Shimizu 2008), not an adaptation of IK-Geo's wrist consolidation.

## Test plan

- [x] \`test_iiwa14_predicate_rejects_loose_spherical_wrist\` — the #155 regression test.
- [x] \`test_iiwa14_fk_at_home_is_along_z\` — EE pos at \`q = 0\` is ~(0, 0, 1.306).
- [x] \`test_iiwa14_fk_round_trip\` — FK is deterministic, finite, orthogonal R block.
- [x] \`test_iiwa14_chooses_a_real_lock_joint\` — dispatch now picks rank-2 or rank-3 (was mis-classifying as rank-1).
- [x] \`test_iiwa14_seven_r_returns_cleanly_at_unreachable_target\` — no crash on out-of-reach.
- [x] \`test_iiwa14_ik_via_gen_six_dof\` (\`slow\`) — smoke test of tier-2 path.
- [x] All 62 existing tests still pass: Franka and Puma 560 unchanged by predicate tightening.
- [x] \`mypy\` / \`ruff check\` / \`ruff format --check\` clean across 113 source files.

## Out of scope

- Rizon 4 / Kinova Gen3 / uFactory xArm7 fixtures — separate sub-issues; the #155 predicate fix likely covers them too but verifying needs each arm's transcription.
- Fast iiwa IK — that's #143.