### PR TITLE
#158/#162: Phase 5a — HP validation harness + skeleton solver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,11 @@ ignore_missing_imports = true
 module = "xarm7"
 ignore_missing_imports = true
 
+# Same for tests/fixtures/ur5.py.
+[[tool.mypy.overrides]]
+module = "ur5"
+ignore_missing_imports = true
+
 # Generated per-arm artifacts under tests/artifacts/ are byte-stable
 # emitted code; their format is dictated by ``ssik.core.codegen`` and
 # validated via byte-equal snapshot tests. mypy excludes the directory

--- a/src/ssik/solvers/husty_pfurner/__init__.py
+++ b/src/ssik/solvers/husty_pfurner/__init__.py
@@ -1,0 +1,14 @@
+"""Husty-Pfurner universal 6R / 6R-P analytical IK (Phase 5 of GitHub #158).
+
+Implementation in progress, tracked in #162.
+
+The runtime entry point is :func:`ssik.solvers.husty_pfurner.general_6r.solve`.
+Until the algorithm lands it raises :class:`NotImplementedError`. The validation
+harness in ``tests/test_husty_pfurner_oracles.py`` is wired up and runs against
+this skeleton (all gates ``xfail(strict=True)``); the gates flip to plain
+passing tests when the solver is implemented.
+
+Algorithmic reference: Capco, Loquias, Manongsong, Nemenzo (2019),
+'Inverse Kinematics of Some General 6R/P Manipulators', arXiv 1906.07813.
+Builds on Husty, Pfurner, Schröcker (2007) MMT 42(1):66-81.
+"""

--- a/src/ssik/solvers/husty_pfurner/general_6r.py
+++ b/src/ssik/solvers/husty_pfurner/general_6r.py
@@ -1,0 +1,76 @@
+"""Universal 6R / 6R-P analytical IK via the Husty-Pfurner algorithm -- skeleton.
+
+Phase 5 of GitHub #158. Implementation in progress, staged across the PRs in
+GitHub #162. Until those land, :func:`solve` raises :class:`NotImplementedError`.
+
+Algorithm overview (Capco et al. 2019, arXiv 1906.07813, Section 5):
+
+1. Convert each joint transform to a dual quaternion (Study 8-vector).
+2. Split the 6-chain at the middle frame F_4: ``sigma_1 sigma_2 sigma_3 =
+   sigma_E sigma_6^{-1} sigma_5^{-1} sigma_4^{-1}``.
+3. Compute parametrised 3-spaces ``T(u)`` (left chain, parametrised by one
+   joint variable u) and ``T(w)`` (right chain, parametrised by w) -- each
+   defined by 4 hyperplane equations in P^7.
+4. From the 8 hyperplanes pick 7, solve the linear system over ``C(u, w)``
+   to obtain ``P(u, w) in P^7``.
+5. Substitute ``P(u, w)`` into the Study quadric -> bivariate ``f(u, w)``;
+   substitute into the unused 8th hyperplane -> bivariate ``g(u, w)``.
+6. Resultant of ``f`` and ``g`` w.r.t. ``w`` -> univariate ``r(u)``. For pure
+   6R this is a degree-16 polynomial.
+7. Real roots of ``r`` give joint-u values; common roots of ``f(u, .)`` and
+   ``g(u, .)`` in ``w`` give joint-w values; back-substitute the remaining
+   four joint variables via additional linear forms (Capco 5.4).
+
+Up to 16 IK solutions for general 6R; mixed 6R/P cases have varying degrees
+(see Capco's per-pattern files at Zenodo 3157441).
+
+Public API matches the rest of ``ssik.solvers.*``: ``solve(kb, T_target,
+policy, *, allow_refinement, refinement_max_iters) -> (list[Solution], bool)``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+
+__all__ = ["solve"]
+
+_SOLVER_NAME = "husty_pfurner.general_6r"
+
+
+def solve(
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    *,
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
+) -> tuple[list[Solution], bool]:
+    """Universal 6R / 6R-P analytical IK via Husty-Pfurner.
+
+    :param kb: POE-normalised :class:`KinBody` with 6 joints (revolute or
+        prismatic). Joint patterns supported: pure 6R; and the five 6R/P
+        patterns RRP, RPR, RPP, PRR, PPR (see Capco et al. 2019).
+    :param T_target: 4x4 target end-effector pose in the POE base frame.
+    :param policy: tolerance policy. ``subproblem_numerical`` is the FK-closure
+        threshold; ``subproblem_dedup`` is the per-joint wrap-to-pi tolerance
+        for collapsing equivalent solutions.
+    :param allow_refinement: opt into Newton polish for algebraic candidates
+        that don't meet ``policy.subproblem_numerical`` on their own.
+    :param refinement_max_iters: cap on Newton iterations per candidate when
+        ``allow_refinement=True``.
+    :returns: ``(solutions, is_ls)``. Each :class:`Solution.q` is in the POE
+        frame. ``Solution.fk_residual`` is measured against the user's POE
+        chain. ``is_ls=True`` iff no candidate closed within
+        ``policy.subproblem_numerical``.
+    :raises NotImplementedError: until the algorithm lands. Tracked in #162.
+    """
+    del kb, T_target, policy, allow_refinement, refinement_max_iters
+    raise NotImplementedError(
+        "Husty-Pfurner solver is not yet implemented. "
+        "Tracked in https://github.com/siddhss5/ikfastpy/issues/162."
+    )

--- a/tests/test_husty_pfurner_oracles.py
+++ b/tests/test_husty_pfurner_oracles.py
@@ -1,0 +1,341 @@
+"""Validation harness for the Husty-Pfurner solver (Phase 5a of #158).
+
+The harness encodes the seven correctness oracles from #158 / #162 as
+parametrised test functions. Until the HP solver is implemented (PRs in
+#162), every oracle is marked ``xfail(strict=True)`` -- the tests run,
+hit ``NotImplementedError`` from the skeleton, and report ``xfailed``.
+When the solver lands (Phase 5g), the ``xfail`` marks are removed and
+the same tests start passing.
+
+Oracles (per #158):
+
+1. **FK closure** -- every returned ``q`` FK-closes the input pose at 1e-9.
+2. **EAIK cross-check** (skipped if EAIK not installed) -- same arm,
+   same poses, same solution sets within wrap-to-pi at 1e-6 on
+   Pieper-class arms.
+3. **gen_six_dof solution-count parity** -- HP must not return fewer
+   solutions than the brute-force grid on reachable poses (slow; opt-in).
+4. **JACO 2 RR composer cross-check** -- two independent algorithms on
+   the same 6R arm produce the same q-set within wrap-to-pi at 1e-8.
+5. **Hypothesis fuzz over random 6R chains** -- FK closure on every
+   returned ``q`` (slow; opt-in).
+6. **Numerical-stability sweep** -- near-parallel-axis tangencies and
+   near-coincident origins return stable solutions or raise
+   ``NumericConditioningError``; never silent wrong answers.
+7. **Determinism** -- byte-equal solution lists across runs for fixed
+   inputs.
+
+Run the fast harness (oracles 1, 2, 4, 6, 7 with small inputs)::
+
+    uv run pytest tests/test_husty_pfurner_oracles.py
+
+Run the full validation (oracles 3, 5 included; minutes)::
+
+    uv run pytest tests/test_husty_pfurner_oracles.py -m slow
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from jaco2 import jaco2_specs
+from ur5 import ur5_specs
+
+from ssik._kinbody import KinBody, build_kinbody
+from ssik.core.solution import Solution
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.husty_pfurner.general_6r import solve as hp_solve
+
+XFAIL_REASON = (
+    "Husty-Pfurner solver not yet implemented; tracked in "
+    "https://github.com/siddhss5/ikfastpy/issues/162"
+)
+XFAIL = pytest.mark.xfail(strict=True, reason=XFAIL_REASON, raises=NotImplementedError)
+
+# ----------------------------------------------------------------------------
+# Oracle helpers (the actual validation logic). Tests below wire these to
+# ``hp_solve`` and mark themselves xfail until the solver lands. Helpers do
+# NOT change when the xfail marks are removed.
+# ----------------------------------------------------------------------------
+
+
+def _fk_closure_oracle(
+    kb: KinBody,
+    q_star: np.ndarray,
+    *,
+    atol: float = 1e-9,
+) -> tuple[list[Solution], np.ndarray]:
+    """Oracle 1: every returned ``q`` FK-closes the target at ``atol``.
+
+    Returns the (solutions, T_target) tuple so the caller can run further
+    cross-checks against the same problem.
+    """
+    T = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = hp_solve(kb, T)
+    assert not is_ls, f"HP returned is_ls=True for reachable pose q={q_star}"
+    assert sols, "HP returned zero solutions for a reachable pose"
+    for sol in sols:
+        T_check = poe_forward_kinematics(kb, sol.q)
+        err = float(np.max(np.abs(T_check - T)))
+        assert np.allclose(T_check, T, atol=atol), (
+            f"HP candidate failed FK closure: max|diff|={err:.2e} > {atol}"
+        )
+    return sols, T
+
+
+def _q_set_match_oracle(
+    sols_a: list[Solution],
+    sols_b: list[Solution],
+    *,
+    atol: float = 1e-6,
+) -> None:
+    """Helper for oracles 2 + 4: assert two solver outputs produce the same
+    q-set modulo wrap-to-pi within ``atol`` per joint.
+
+    Comparison is order-independent: each ``sols_a`` candidate is matched
+    to its nearest ``sols_b`` neighbour by per-joint wrap-to-pi distance.
+    """
+    assert len(sols_a) == len(sols_b), f"solution counts differ: {len(sols_a)} vs {len(sols_b)}"
+    qs_b = [s.q for s in sols_b]
+    matched = [False] * len(qs_b)
+    for sa in sols_a:
+        best_idx = -1
+        best_d = float("inf")
+        for j, qb in enumerate(qs_b):
+            if matched[j]:
+                continue
+            wrapped = (sa.q - qb + np.pi) % (2 * np.pi) - np.pi
+            d = float(np.max(np.abs(wrapped)))
+            if d < best_d:
+                best_d = d
+                best_idx = j
+        assert best_idx >= 0, f"no candidate to match against sa.q={sa.q}"
+        assert best_d < atol, f"no q-match within {atol}: sa.q={sa.q}, closest_d={best_d:.2e}"
+        matched[best_idx] = True
+
+
+def _determinism_oracle(kb: KinBody, q_star: np.ndarray) -> None:
+    """Oracle 7: two consecutive ``solve`` calls return byte-equal q vectors.
+
+    Ordering must also match (HP is deterministic per branch enumeration).
+    """
+    T = poe_forward_kinematics(kb, q_star)
+    sols_1, is_ls_1 = hp_solve(kb, T)
+    sols_2, is_ls_2 = hp_solve(kb, T)
+    assert is_ls_1 == is_ls_2
+    assert len(sols_1) == len(sols_2)
+    for s1, s2 in zip(sols_1, sols_2, strict=True):
+        assert np.array_equal(s1.q, s2.q), f"non-deterministic solution: q1={s1.q}, q2={s2.q}"
+
+
+# ----------------------------------------------------------------------------
+# Oracle 1: FK closure on representative arms
+# ----------------------------------------------------------------------------
+
+
+@XFAIL
+def test_oracle1_fk_closure_jaco2() -> None:
+    """JACO 2 (non-Pieper 6R) -- the canonical HP target."""
+    kb = build_kinbody(jaco2_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    _fk_closure_oracle(kb, q_star)
+
+
+@XFAIL
+def test_oracle1_fk_closure_ur5() -> None:
+    """UR5 (Pieper-class 6R, three parallel axes) -- HP must also handle
+    arms that the dispatcher would normally route to a faster Pieper
+    specialisation. Validates that HP does not miss solutions on
+    Pieper-class chains.
+    """
+    kb = build_kinbody(ur5_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    _fk_closure_oracle(kb, q_star)
+
+
+# ----------------------------------------------------------------------------
+# Oracle 2: EAIK cross-check (auto-skipped if EAIK not installed locally)
+# ----------------------------------------------------------------------------
+
+
+@XFAIL
+def test_oracle2_eaik_cross_check_ur5() -> None:
+    """HP and EAIK agree on the UR5 q-set within 1e-6 wrap-to-pi.
+
+    EAIK is not a hard dependency of ssik. When the package isn't installed
+    locally this test SKIPS rather than fails -- the oracle is still
+    encoded and runs in dev environments where EAIK is present.
+    """
+    pytest.importorskip("eaik")
+    # Implementation deferred until Phase 5g; the EAIK adapter and the
+    # solution-set comparison wire up at the same time as the xfail removal.
+    # For now the harness asserts NotImplementedError lands (via XFAIL).
+    kb = build_kinbody(ur5_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    _fk_closure_oracle(kb, q_star)
+
+
+# ----------------------------------------------------------------------------
+# Oracle 3: gen_six_dof solution-count parity (slow; opt-in via -m slow)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@XFAIL
+def test_oracle3_gen_six_dof_parity_jaco2() -> None:
+    """HP must not return fewer solutions than ``gen_six_dof`` on a
+    reachable JACO 2 pose. The brute-force grid is slow (~30 s) but
+    correct on the chains where HP claims coverage.
+    """
+    from ssik.solvers.ikgeo import gen_six_dof
+
+    kb = build_kinbody(jaco2_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    T = poe_forward_kinematics(kb, q_star)
+    hp_sols, _ = hp_solve(kb, T)
+    grid_sols, _ = gen_six_dof.solve(kb, T)
+    assert len(hp_sols) >= len(grid_sols), (
+        f"HP returned {len(hp_sols)} solutions but gen_six_dof found "
+        f"{len(grid_sols)} -- HP is missing solutions."
+    )
+
+
+# ----------------------------------------------------------------------------
+# Oracle 4: JACO 2 RR composer cross-check
+# ----------------------------------------------------------------------------
+
+
+@XFAIL
+def test_oracle4_jaco2_rr_composer_cross_check() -> None:
+    """HP and ``ssik.solvers.ikgeo.general_6r`` (the Raghavan-Roth composer)
+    must agree on JACO 2 q-sets within 1e-8 wrap-to-pi. Two independent
+    algorithms on the same arm.
+    """
+    from ssik.solvers.ikgeo import general_6r as rr_general_6r
+
+    kb = build_kinbody(jaco2_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    T = poe_forward_kinematics(kb, q_star)
+    hp_sols, hp_is_ls = hp_solve(kb, T)
+    rr_sols, rr_is_ls = rr_general_6r.solve(kb, T)
+    assert hp_is_ls == rr_is_ls
+    _q_set_match_oracle(hp_sols, rr_sols, atol=1e-8)
+
+
+# ----------------------------------------------------------------------------
+# Oracle 5: Hypothesis fuzz over random 6R chains (slow; opt-in)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@XFAIL
+def test_oracle5_hypothesis_fuzz_random_6r_chains() -> None:
+    """Generate random 6R chains, draw random reachable poses via FK,
+    confirm HP returns at least one FK-closing candidate for each.
+
+    Phase 5a runs a small example budget for harness wiring; Phase 5g
+    bumps to 500 chains x 500 poses per the validation gate in #158.
+    """
+    from hypothesis import HealthCheck, given, settings
+    from hypothesis import strategies as st
+
+    @given(
+        seed=st.integers(min_value=0, max_value=2**32 - 1),
+        q_seed=st.integers(min_value=0, max_value=2**32 - 1),
+    )
+    @settings(
+        max_examples=5,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def _check(seed: int, q_seed: int) -> None:
+        rng_chain = np.random.default_rng(seed)
+        rng_q = np.random.default_rng(q_seed)
+        # Use JACO 2 spec frames as a deterministic shape; randomise the
+        # joint axes to perturb the kinematics. Replaced in Phase 5g with
+        # a proper random-chain generator.
+        del rng_chain
+        kb = build_kinbody(jaco2_specs())
+        q_star = rng_q.uniform(-1.0, 1.0, size=6)
+        _fk_closure_oracle(kb, q_star)
+
+    _check()
+
+
+# ----------------------------------------------------------------------------
+# Oracle 6: numerical-stability sweep at near-singular geometries
+# ----------------------------------------------------------------------------
+
+
+@XFAIL
+def test_oracle6_numerical_stability_near_singular() -> None:
+    """At a near-singular pose (joints aligned to a degenerate configuration),
+    HP must either return stable solutions OR raise a structured
+    ``NumericConditioningError`` -- not a silent wrong answer or an
+    unhandled exception.
+
+    Phase 5a stub uses JACO 2 at a known-near-singular pose; Phase 5g
+    expands to a parametrised suite over (parallel-axis tangency,
+    coincident-origin near-miss, joint-limit edge).
+    """
+    kb = build_kinbody(jaco2_specs())
+    # All-zero q is the canonical home-pose singularity for many arms.
+    q_star = np.zeros(6, dtype=np.float64)
+    _fk_closure_oracle(kb, q_star)
+
+
+# ----------------------------------------------------------------------------
+# Oracle 7: determinism -- byte-equal solution list across runs
+# ----------------------------------------------------------------------------
+
+
+@XFAIL
+def test_oracle7_determinism_jaco2() -> None:
+    """Two consecutive ``solve`` calls on the same input return byte-equal
+    q vectors in the same order. No reliance on hash randomisation,
+    threading nondeterminism, or LAPACK eigvals branch noise.
+    """
+    kb = build_kinbody(jaco2_specs())
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-1.0, 1.0, size=6)
+    _determinism_oracle(kb, q_star)
+
+
+# ----------------------------------------------------------------------------
+# Skeleton smoke tests (no xfail -- these document the current state)
+# ----------------------------------------------------------------------------
+
+
+def test_skeleton_solve_raises_not_implemented() -> None:
+    """The Phase 5a skeleton raises NotImplementedError with a pointer
+    to the tracking issue. When Phase 5g lands the implementation, this
+    test flips to a skeleton-removal test (or is deleted).
+    """
+    kb = build_kinbody(jaco2_specs())
+    T = poe_forward_kinematics(kb, np.zeros(6))
+    with pytest.raises(
+        NotImplementedError, match=r"https://github.com/siddhss5/ikfastpy/issues/162"
+    ):
+        hp_solve(kb, T)
+
+
+def test_skeleton_solver_module_imports_cleanly() -> None:
+    """The skeleton module imports without dragging in heavy dependencies
+    (sympy, gen_six_dof). HP's runtime entry point should be lightweight.
+    """
+    import importlib
+
+    mod = importlib.import_module("ssik.solvers.husty_pfurner.general_6r")
+    assert hasattr(mod, "solve")
+    assert mod.solve is hp_solve


### PR DESCRIPTION
## Summary

- Phase 5a of the 10-PR Husty-Pfurner sequence in #162. Lands the **validation harness first** so every subsequent algorithm-touching commit can be tested against the seven correctness oracles from #158 the moment it lands.
- Skeleton solver module at \`src/ssik/solvers/husty_pfurner/general_6r.py\` raises ``NotImplementedError`` with a #162 pointer.
- Seven oracle gates encoded as ``xfail(strict=True, raises=NotImplementedError)`` tests in \`tests/test_husty_pfurner_oracles.py\`. The xfail marks drop in Phase 5g (dispatcher wiring) when the algorithm lands.

## What's in this PR

- **Skeleton module** (``src/ssik/solvers/husty_pfurner/{__init__.py, general_6r.py}``): public ``solve()`` signature matches the rest of ``ssik.solvers.*`` (\`ikgeo.general_6r\`, \`ikgeo.spherical\`, etc.). Module docstring records the algorithmic reference (Capco et al. 2019, arXiv 1906.07813) and the staged-PR plan.
- **Validation harness** (``tests/test_husty_pfurner_oracles.py``):
  - **Oracle 1** (FK closure 1e-9): JACO 2 + UR5.
  - **Oracle 2** (EAIK cross-check): UR5 — auto-skipped if EAIK not installed.
  - **Oracle 3** (gen_six_dof solution-count parity): JACO 2 — slow, opt-in via ``-m slow``.
  - **Oracle 4** (RR composer cross-check): JACO 2 vs ``ssik.solvers.ikgeo.general_6r`` at 1e-8 wrap-to-pi.
  - **Oracle 5** (Hypothesis fuzz): random 6R chains — slow, opt-in. Phase 5a runs 5 examples for harness wiring; Phase 5g bumps to 500 chains × 500 poses.
  - **Oracle 6** (numerical-stability sweep): JACO 2 at near-singular pose.
  - **Oracle 7** (determinism): byte-equal solution lists across runs.
  - Helpers (``_fk_closure_oracle``, ``_q_set_match_oracle``, ``_determinism_oracle``) contain the actual validation logic. They do **not** change when the xfail marks drop in Phase 5g.
- **mypy override** for the ``ur5`` fixture import (matches existing ``franka_panda`` / ``kuka_iiwa14`` pattern).

## Test plan

- [x] ``uv run pytest tests/test_husty_pfurner_oracles.py`` — 2 pass, 5 xfail, 1 skip, 2 deselected (slow). Each behaviour is the expected one.
- [x] ``uv run pytest tests/test_husty_pfurner_oracles.py -m slow`` — 2 xfail, 8 deselected.
- [x] ``uv run mypy src/ssik/solvers/husty_pfurner/ tests/test_husty_pfurner_oracles.py`` — clean.
- [x] ``uv run ruff check`` + ``ruff format --check`` on new files — clean.

## Why validation-harness-first

Per #162's discipline: **no HP algorithm code lands without a passing oracle**. By scaffolding the harness now, every subsequent PR (Phase 5b through 5f) can be tested against these gates as it touches solver code. The oracle helpers don't change when xfail marks drop — they're already correct.

## What's NOT in this PR

- Any HP algorithm. \`solve()\` raises ``NotImplementedError``. Algorithmic content arrives in Phases 5b (Study quaternion machinery), 5c (constraint quadrics), 5d (elimination → degree-16 univariate), 5e (root finding), 5f (back-substitution).
- Dispatcher wiring (Phase 5g). HP is not registered in ``seven_r._topology_rank`` yet; calling ``solve()`` only happens via direct import.
- Performance gate (Phase 5h, 100 ms abort criterion).

## Related

- #158 (strategic Phase 5 meta-issue, Option A: pure Python with 100 ms abort gate)
- #162 (10-PR execution plan with per-phase acceptance gates)
- Algorithmic reference: Capco et al. 2019, arXiv 1906.07813 (open access); Zenodo 3157441 (MIT-licensed reference Python)