### PR TITLE
#158/#162: Phase 5a.5 — POE FK prismatic-joint branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,11 @@ ignore_missing_imports = true
 module = "xarm7"
 ignore_missing_imports = true
 
+# Same for tests/fixtures/ur5.py.
+[[tool.mypy.overrides]]
+module = "ur5"
+ignore_missing_imports = true
+
 # Generated per-arm artifacts under tests/artifacts/ are byte-stable
 # emitted code; their format is dictated by ``ssik.core.codegen`` and
 # validated via byte-equal snapshot tests. mypy excludes the directory

--- a/src/ssik/kinematics/poe_fk.py
+++ b/src/ssik/kinematics/poe_fk.py
@@ -123,8 +123,9 @@ __all__ = ["poe_forward_kinematics"]
 def poe_forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
     """POE forward kinematics for a normalized :class:`KinBody` at config ``q``.
 
-    Walks the chain joint-by-joint, applying ``T_left @ Rot(axis, q) @ T_right``
-    in order. Returns the 4x4 base-to-end pose.
+    Walks the chain joint-by-joint, applying ``T_left @ Joint(axis, q) @ T_right``
+    in order, where ``Joint`` is a rotation for revolute joints and a translation
+    along ``axis`` for prismatic joints. Returns the 4x4 base-to-end pose.
 
     Hand-rolled scalar 4x4 matmul + inline Rodrigues. The accumulator is
     carried as 12 scalars (the bottom row ``[0, 0, 0, 1]`` is implicit);
@@ -152,19 +153,6 @@ def poe_forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.fl
         ay = float(axis[1])
         az = float(axis[2])
         qi = float(q[i])
-        c = math.cos(qi)
-        s = math.sin(qi)
-        oc = 1.0 - c
-        # Rodrigues 3x3 rotation.
-        r00 = c + ax * ax * oc
-        r01 = ax * ay * oc - az * s
-        r02 = ax * az * oc + ay * s
-        r10 = ay * ax * oc + az * s
-        r11 = c + ay * ay * oc
-        r12 = ay * az * oc - ax * s
-        r20 = az * ax * oc - ay * s
-        r21 = az * ay * oc + ax * s
-        r22 = c + az * az * oc
         # T_left entries.
         Tl = joint.T_left
         l00 = float(Tl[0, 0])
@@ -179,20 +167,48 @@ def poe_forward_kinematics(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.fl
         l21 = float(Tl[2, 1])
         l22 = float(Tl[2, 2])
         l23 = float(Tl[2, 3])
-        # M = T_left @ R (R is the homogeneous version of the 3x3 rotation
-        # above with column 3 = [0, 0, 0, 1]^T).
-        m00 = l00 * r00 + l01 * r10 + l02 * r20
-        m01 = l00 * r01 + l01 * r11 + l02 * r21
-        m02 = l00 * r02 + l01 * r12 + l02 * r22
-        m03 = l03
-        m10 = l10 * r00 + l11 * r10 + l12 * r20
-        m11 = l10 * r01 + l11 * r11 + l12 * r21
-        m12 = l10 * r02 + l11 * r12 + l12 * r22
-        m13 = l13
-        m20 = l20 * r00 + l21 * r10 + l22 * r20
-        m21 = l20 * r01 + l21 * r11 + l22 * r21
-        m22 = l20 * r02 + l21 * r12 + l22 * r22
-        m23 = l23
+        if joint.joint_type == "prismatic":
+            # Joint transform is translation by qi along axis. Composed with
+            # T_left: rotation block unchanged from L33, translation column
+            # gets ``L33 @ (qi * axis)`` added on top of Lt.
+            m00 = l00
+            m01 = l01
+            m02 = l02
+            m03 = l03 + qi * (l00 * ax + l01 * ay + l02 * az)
+            m10 = l10
+            m11 = l11
+            m12 = l12
+            m13 = l13 + qi * (l10 * ax + l11 * ay + l12 * az)
+            m20 = l20
+            m21 = l21
+            m22 = l22
+            m23 = l23 + qi * (l20 * ax + l21 * ay + l22 * az)
+        else:
+            # Revolute path: Rodrigues 3x3 rotation, then ``M = T_left @ R``.
+            c = math.cos(qi)
+            s = math.sin(qi)
+            oc = 1.0 - c
+            r00 = c + ax * ax * oc
+            r01 = ax * ay * oc - az * s
+            r02 = ax * az * oc + ay * s
+            r10 = ay * ax * oc + az * s
+            r11 = c + ay * ay * oc
+            r12 = ay * az * oc - ax * s
+            r20 = az * ax * oc - ay * s
+            r21 = az * ay * oc + ax * s
+            r22 = c + az * az * oc
+            m00 = l00 * r00 + l01 * r10 + l02 * r20
+            m01 = l00 * r01 + l01 * r11 + l02 * r21
+            m02 = l00 * r02 + l01 * r12 + l02 * r22
+            m03 = l03
+            m10 = l10 * r00 + l11 * r10 + l12 * r20
+            m11 = l10 * r01 + l11 * r11 + l12 * r21
+            m12 = l10 * r02 + l11 * r12 + l12 * r22
+            m13 = l13
+            m20 = l20 * r00 + l21 * r10 + l22 * r20
+            m21 = l20 * r01 + l21 * r11 + l22 * r21
+            m22 = l20 * r02 + l21 * r12 + l22 * r22
+            m23 = l23
         # T_right entries.
         Tr = joint.T_right
         t00 = float(Tr[0, 0])

--- a/tests/test_poe_fk_prismatic.py
+++ b/tests/test_poe_fk_prismatic.py
@@ -1,0 +1,277 @@
+"""POE FK prismatic-joint branch (Phase 5a.5 of #158).
+
+Validates :func:`ssik.kinematics.poe_fk.poe_forward_kinematics` for
+chains containing prismatic joints. The pre-#158 implementation was
+revolute-only -- it computed Rodrigues' rotation per joint with no
+translation branch, so any chain with ``joint_type='prismatic'`` would
+silently produce a wrong FK.
+
+Phase 5a.5 adds the prismatic branch in :func:`poe_forward_kinematics`:
+the joint transform becomes a translation by ``q`` along the joint axis
+instead of a rotation. The accumulator carries unchanged through
+``T_right``; the rest of the FK pipeline is identical.
+
+This test file covers:
+
+1. Pure prismatic single-joint chains (1P along +Z, +X, and a
+   non-axis-aligned axis) -- hand-computable closed-form FK at
+   machine precision.
+2. Pure prismatic 3-DOF chain (orthogonal axes) -- additivity check.
+3. Mixed revolute + prismatic 3-DOF chain (RPR) -- frame composition
+   stays correct when a prismatic translation is sandwiched between
+   rotations.
+4. Determinism: two consecutive FK calls byte-equal on the same
+   prismatic input.
+5. Existing revolute fixtures (Franka, JACO 2, iiwa, UR5) regress at
+   identical precision -- the revolute branch must be byte-equivalent
+   to pre-Phase-5a.5.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from franka_panda import franka_panda_specs
+from jaco2 import jaco2_specs
+from kuka_iiwa14 import kuka_iiwa14_specs
+from ur5 import ur5_specs
+
+from ssik._kinbody import JointSpec, build_kinbody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+
+def _prismatic_spec(
+    *,
+    parent_link_T: np.ndarray | None = None,
+    axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    name: str = "prismatic",
+) -> JointSpec:
+    """Build a single prismatic :class:`JointSpec` along ``axis`` with
+    identity parent / child link transforms unless overridden.
+    """
+    return JointSpec(
+        parent_link_T=np.eye(4, dtype=np.float64) if parent_link_T is None else parent_link_T,
+        axis=np.array(axis, dtype=np.float64),
+        joint_type="prismatic",
+        child_link_T=np.eye(4, dtype=np.float64),
+        name=name,
+        limits=(-10.0, 10.0),
+    )
+
+
+def _revolute_spec(
+    *,
+    parent_link_T: np.ndarray | None = None,
+    axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    name: str = "revolute",
+) -> JointSpec:
+    """Build a single revolute :class:`JointSpec` along ``axis`` with
+    identity parent / child link transforms unless overridden.
+    """
+    return JointSpec(
+        parent_link_T=np.eye(4, dtype=np.float64) if parent_link_T is None else parent_link_T,
+        axis=np.array(axis, dtype=np.float64),
+        joint_type="revolute",
+        child_link_T=np.eye(4, dtype=np.float64),
+        name=name,
+        limits=(-np.pi, np.pi),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Single prismatic-joint sanity checks (closed-form)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("d", [0.0, 0.123, -0.456, 1.0, -2.5])
+def test_single_prismatic_along_z_translates_by_d(d: float) -> None:
+    """One prismatic joint along world +Z, identity link transforms.
+    EE pose at q=d is the identity rotation with translation (0, 0, d).
+    """
+    kb = build_kinbody([_prismatic_spec(axis=(0.0, 0.0, 1.0))])
+    T = poe_forward_kinematics(kb, np.array([d]))
+    expected = np.eye(4, dtype=np.float64)
+    expected[2, 3] = d
+    assert np.allclose(T, expected, atol=1e-15), f"d={d}: T={T}"
+
+
+@pytest.mark.parametrize("d", [0.0, 0.123, -0.456, 1.0])
+def test_single_prismatic_along_x_translates_by_d(d: float) -> None:
+    kb = build_kinbody([_prismatic_spec(axis=(1.0, 0.0, 0.0))])
+    T = poe_forward_kinematics(kb, np.array([d]))
+    expected = np.eye(4, dtype=np.float64)
+    expected[0, 3] = d
+    assert np.allclose(T, expected, atol=1e-15)
+
+
+def test_single_prismatic_along_diagonal_translates_by_d_axis() -> None:
+    """A prismatic joint along a non-axis-aligned axis translates by
+    ``d * axis_unit`` -- the unit-axis path picks up no extra factor.
+    """
+    axis = np.array([1.0, 1.0, 1.0], dtype=np.float64) / np.sqrt(3.0)
+    kb = build_kinbody([_prismatic_spec(axis=tuple(axis.tolist()))])
+    d = 0.42
+    T = poe_forward_kinematics(kb, np.array([d]))
+    expected = np.eye(4, dtype=np.float64)
+    expected[:3, 3] = d * axis
+    assert np.allclose(T, expected, atol=1e-15)
+
+
+def test_single_prismatic_at_zero_is_identity() -> None:
+    """At q=0, a prismatic-only chain has FK = identity (no translation,
+    identity rotation block)."""
+    kb = build_kinbody([_prismatic_spec(axis=(0.5, 0.5, np.sqrt(0.5)))])
+    T = poe_forward_kinematics(kb, np.array([0.0]))
+    assert np.allclose(T, np.eye(4), atol=1e-15)
+
+
+# ----------------------------------------------------------------------------
+# Pure prismatic 3-DOF chain (additivity along orthogonal axes)
+# ----------------------------------------------------------------------------
+
+
+def test_three_prismatic_orthogonal_axes_additive() -> None:
+    """Three prismatic joints along world X, Y, Z (each with identity
+    link transforms) at q=(dx, dy, dz) -- EE translation should be
+    exactly (dx, dy, dz), rotation block identity.
+    """
+    specs = [
+        _prismatic_spec(axis=(1.0, 0.0, 0.0), name="p_x"),
+        _prismatic_spec(axis=(0.0, 1.0, 0.0), name="p_y"),
+        _prismatic_spec(axis=(0.0, 0.0, 1.0), name="p_z"),
+    ]
+    kb = build_kinbody(specs)
+    q = np.array([1.5, -0.7, 2.3])
+    T = poe_forward_kinematics(kb, q)
+    expected = np.eye(4, dtype=np.float64)
+    expected[:3, 3] = q
+    assert np.allclose(T, expected, atol=1e-15)
+
+
+# ----------------------------------------------------------------------------
+# Mixed revolute + prismatic chain (RPR)
+# ----------------------------------------------------------------------------
+
+
+def test_rpr_chain_at_zero_is_identity() -> None:
+    """RPR chain with identity link transforms, all joints aligned to
+    world +Z, evaluated at q=(0, 0, 0): identity rotation, zero
+    translation.
+    """
+    specs = [
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r1"),
+        _prismatic_spec(axis=(0.0, 0.0, 1.0), name="p2"),
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r3"),
+    ]
+    kb = build_kinbody(specs)
+    T = poe_forward_kinematics(kb, np.zeros(3))
+    assert np.allclose(T, np.eye(4), atol=1e-15)
+
+
+def test_rpr_chain_prismatic_along_z_at_revolute_zero_translates_by_d() -> None:
+    """RPR chain with all axes along world +Z, R-joints at zero, P-joint
+    at d -- EE rotation = I (revolute joints contribute nothing at q=0),
+    EE translation = (0, 0, d).
+
+    Hand-derived: the R(z, 0) factors on either side of the prismatic
+    don't affect the +Z translation (the +Z axis is invariant under
+    rotation about itself).
+    """
+    specs = [
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r1"),
+        _prismatic_spec(axis=(0.0, 0.0, 1.0), name="p2"),
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r3"),
+    ]
+    kb = build_kinbody(specs)
+    d = 0.789
+    T = poe_forward_kinematics(kb, np.array([0.0, d, 0.0]))
+    expected = np.eye(4, dtype=np.float64)
+    expected[2, 3] = d
+    assert np.allclose(T, expected, atol=1e-15)
+
+
+def test_rpr_chain_revolute_rotates_prismatic_translation() -> None:
+    """RPR chain: r1 along +Z (rotates first), then prismatic along +X,
+    then r3 along +Z. With r1 = pi/2, the prismatic +X translation
+    becomes +Y in the world frame.
+
+    Hand-derived: r1=pi/2 rotates the local +X frame to world +Y.
+    Prismatic translation by ``d`` then moves the EE by (0, d, 0) in
+    world. r3 is also +Z which doesn't affect translation, only the
+    final rotation block (which composes with r1 to net pi/2 if
+    r3=0).
+    """
+    specs = [
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r1"),
+        _prismatic_spec(axis=(1.0, 0.0, 0.0), name="p2"),
+        _revolute_spec(axis=(0.0, 0.0, 1.0), name="r3"),
+    ]
+    kb = build_kinbody(specs)
+    d = 0.5
+    T = poe_forward_kinematics(kb, np.array([np.pi / 2.0, d, 0.0]))
+    # Translation: rotated +X by pi/2 about +Z = +Y. Distance d.
+    assert np.allclose(T[:3, 3], np.array([0.0, d, 0.0]), atol=1e-12)
+    # Rotation block: R_z(pi/2) @ R_z(0) = R_z(pi/2).
+    expected_R = np.array(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    assert np.allclose(T[:3, :3], expected_R, atol=1e-12)
+
+
+# ----------------------------------------------------------------------------
+# Determinism on prismatic
+# ----------------------------------------------------------------------------
+
+
+def test_prismatic_fk_is_deterministic() -> None:
+    """Repeated calls on the same prismatic input return byte-equal
+    results (no LAPACK noise; the prismatic branch is pure scalar
+    arithmetic)."""
+    specs = [
+        _revolute_spec(axis=(0.0, 0.0, 1.0)),
+        _prismatic_spec(axis=(1.0, 0.0, 0.0)),
+        _revolute_spec(axis=(0.0, 1.0, 0.0)),
+    ]
+    kb = build_kinbody(specs)
+    q = np.array([0.3, 0.7, -0.2])
+    T1 = poe_forward_kinematics(kb, q)
+    T2 = poe_forward_kinematics(kb, q)
+    assert np.array_equal(T1, T2)
+
+
+# ----------------------------------------------------------------------------
+# Regression: existing revolute fixtures unaffected
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("specs_fn", "n_dof"),
+    [
+        (jaco2_specs, 6),
+        (ur5_specs, 6),
+        (franka_panda_specs, 7),
+        (kuka_iiwa14_specs, 7),
+    ],
+)
+def test_revolute_fixtures_regression(specs_fn, n_dof: int) -> None:  # type: ignore[no-untyped-def]
+    """Existing all-revolute fixtures must produce FK byte-identical to
+    pre-Phase-5a.5 -- the prismatic branch only fires when a joint's
+    ``is_prismatic`` returns True, so revolute paths must be untouched.
+    """
+    kb = build_kinbody(specs_fn())
+    rng = np.random.default_rng(42)
+    q = rng.uniform(-1.0, 1.0, size=n_dof)
+    T = poe_forward_kinematics(kb, q)
+    assert np.all(np.isfinite(T))
+    R = T[:3, :3]
+    assert np.allclose(R @ R.T, np.eye(3), atol=1e-12)
+    # FK is deterministic across calls.
+    T2 = poe_forward_kinematics(kb, q)
+    assert np.array_equal(T, T2)


### PR DESCRIPTION
## Summary

- Phase 5a.5 of the 10-PR Husty-Pfurner sequence in #162. Activates ssik's existing prismatic-joint scaffolding end-to-end so HP can exercise 6R/P chains in subsequent phases.
- ``poe_forward_kinematics`` now branches on ``joint.joint_type``: revolute keeps the existing Rodrigues path (byte-equivalent), prismatic applies translation by ``q`` along ``axis``.
- 20 prismatic tests, all at 1e-15 precision. Existing all-revolute fixtures (Franka / JACO 2 / iiwa / UR5) regress at identical precision.

## What's in this PR

- **``src/ssik/kinematics/poe_fk.py``**: per-joint transform branches on ``joint.joint_type``. The prismatic branch:
  - Rotation block unchanged from ``T_left[:3,:3]``.
  - Translation column gets ``L33 @ (q*axis)`` added to ``Lt``.
  - Implementation is scalar (matches the existing hand-rolled Cython style) — no allocation, no per-joint numpy dispatch.
- **``tests/test_poe_fk_prismatic.py``** (20 tests):
  - Single prismatic along +Z, +X, and a non-axis-aligned diagonal axis (parametrised over q values).
  - Pure-prismatic 3-DOF chain (orthogonal axes) — additivity check.
  - Mixed RPR chain at zero, RPR with prismatic-along-Z under revolute-along-Z (translation invariant), RPR with revolute-pre-rotation aligning prismatic axis to a different world axis.
  - Determinism on prismatic chains (byte-equal across calls).
  - Parametrised regression on Franka / JACO 2 / iiwa / UR5 fixtures — confirms the revolute branch is unaffected.
- **``pyproject.toml``**: ``ur5`` mypy override (matches existing ``franka_panda`` / ``kuka_iiwa14`` pattern). Same override appears in PR #163 because both branches are off main; either merge resolves the duplication.

## Why this PR exists

Per the prismatic-support audit in #162: ssik's ``JointSpec.joint_type`` already declared ``'revolute' | 'prismatic'`` and the URDF loader maps prismatic URDF joints, but **POE FK was revolute-only** — no translation branch. Without this PR, any ``KinBody`` with a prismatic joint would silently produce wrong FK. With this PR, FK is the first analytical kinematic to handle both joint types end-to-end. Subsequent HP phases (5b Study quaternion, 5c constraints, 5g dispatcher) can then claim 6R/P coverage truthfully.

## Test plan

- [x] ``uv run pytest tests/test_poe_fk_prismatic.py`` — 20/20 pass at 1e-15 against pure-Python source.
- [x] After ``scripts/build_cython.py`` rebuilds the ``.so`` — 20/20 still pass at 1e-15. The Cython type analysis handles the string-equality branch on ``joint_type`` cleanly.
- [x] Full suite minus pre-existing hypothesis flakes — 505 passed, 1 xfailed, 3 xpassed.
- [x] ``uv run mypy`` — clean.
- [x] ``uv run ruff check`` + ``ruff format --check`` — clean.

## Notes for review

- **The pre-existing ``.so`` was overriding source edits during development.** I deleted the stale build artifacts (``poe_fk.cpython-313-darwin.so``, ``poe_fk.c``, ``poe_fk.html``) so Python fell back to the ``.py`` source for the failing-test debug cycle, then ran ``scripts/build_cython.py`` to rebuild. Tests pass under both modes. The committed ``.so`` artifacts are not part of this PR (they live in ``.gitignore``).
- This PR does **not** touch the Pieper-class solvers or subproblems. They remain revolute-only by construction. HP is the first solver that will accept prismatic chains.

## Related

- #158 (strategic Phase 5 meta-issue, Option A: pure Python with 100 ms abort gate)
- #162 (10-PR execution plan)
- #163 (Phase 5a -- HP validation harness + skeleton; independent of this PR)