### PR TITLE
#158/#162: Phase 5b — Study quaternion / dual-quaternion machinery

### DIFF
--- a/src/ssik/solvers/husty_pfurner/_study.py
+++ b/src/ssik/solvers/husty_pfurner/_study.py
@@ -1,0 +1,278 @@
+"""Study quaternion / dual-quaternion machinery for Husty-Pfurner.
+
+The HP algorithm represents elements of SE(3) as **Study coordinates** -- an
+8-vector ``(x_0, x_1, x_2, x_3, y_0, y_1, y_2, y_3)`` corresponding to a
+dual quaternion ``sigma = p + epsilon * q`` where:
+
+* ``p = (x_0, x_1, x_2, x_3)`` is the rotation quaternion (``epsilon`` term zero).
+* ``q = (y_0, y_1, y_2, y_3)`` is the translation quaternion such that
+  ``q = (1/2) * t_quat * p``, where ``t_quat = (0, t_x, t_y, t_z)``.
+
+Valid SE(3) elements lie on the **Study quadric** ``x_0 y_0 + x_1 y_1 +
+x_2 y_2 + x_3 y_3 = 0`` with ``(x_0, x_1, x_2, x_3) != 0``.
+
+Dual quaternion arithmetic over the 8-vec form:
+
+* Sum: ``(p_a + eps q_a) + (p_b + eps q_b) = (p_a + p_b) + eps (q_a + q_b)``
+* Product: ``(p_a + eps q_a)(p_b + eps q_b) = p_a p_b + eps (p_a q_b + q_a p_b)``
+* Conjugate: ``sigma^* = p^* + eps q^*``  (quaternion conjugate of each part).
+
+Phase 5b of GitHub #158 / #162. Algorithmic reference: Capco, Loquias,
+Manongsong, Nemenzo (2019), 'Inverse Kinematics of Some General 6R/P
+Manipulators', arXiv 1906.07813, Section 2.
+
+This module is pure numpy (no Cython yet). Cython enters only as a
+profile-guided escalation in Phase 5h if the perf gate fires.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import KinBody
+
+__all__ = [
+    "DQ_IDENTITY",
+    "dq_chain",
+    "dq_conj",
+    "dq_from_se3",
+    "dq_joint",
+    "dq_mul",
+    "se3_from_dq",
+    "study_quadric_residual",
+]
+
+
+# Identity dual quaternion: identity rotation, zero translation.
+DQ_IDENTITY: NDArray[np.float64] = np.array(
+    [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64
+)
+
+
+# ---------------------------------------------------------------------------
+# Quaternion primitives. Quaternions are stored as 4-vec ``(p_0, p_1, p_2,
+# p_3)`` with the scalar in slot 0. All operations are pure numpy / scalar
+# math so we can lift them into Cython later without rework.
+# ---------------------------------------------------------------------------
+
+
+def _quat_mul(p: NDArray[np.float64], q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Hamilton product ``p * q`` of two unit quaternions.
+
+    ``(a_0 + a_1 i + a_2 j + a_3 k)(b_0 + b_1 i + b_2 j + b_3 k)`` expands
+    to four bilinear scalar combinations; we write them inline so the
+    function is allocation-free apart from the result array.
+    """
+    p0, p1, p2, p3 = float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    q0, q1, q2, q3 = float(q[0]), float(q[1]), float(q[2]), float(q[3])
+    return np.array(
+        [
+            p0 * q0 - p1 * q1 - p2 * q2 - p3 * q3,
+            p0 * q1 + p1 * q0 + p2 * q3 - p3 * q2,
+            p0 * q2 - p1 * q3 + p2 * q0 + p3 * q1,
+            p0 * q3 + p1 * q2 - p2 * q1 + p3 * q0,
+        ],
+        dtype=np.float64,
+    )
+
+
+def _quat_conj(p: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Quaternion conjugate ``(p_0, -p_1, -p_2, -p_3)``."""
+    return np.array([p[0], -p[1], -p[2], -p[3]], dtype=np.float64)
+
+
+def _quat_from_rot(R: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Extract a unit quaternion from a 3x3 rotation matrix (Shepperd 1978).
+
+    Picks the diagonal element with the largest magnitude as the
+    'numerically dominant' branch; this avoids the ill-conditioned
+    division near 180-degree rotations that the textbook trace-only
+    method suffers from.
+    """
+    m00, m01, m02 = float(R[0, 0]), float(R[0, 1]), float(R[0, 2])
+    m10, m11, m12 = float(R[1, 0]), float(R[1, 1]), float(R[1, 2])
+    m20, m21, m22 = float(R[2, 0]), float(R[2, 1]), float(R[2, 2])
+    tr = m00 + m11 + m22
+    if tr > 0.0:
+        s = math.sqrt(tr + 1.0) * 2.0  # s = 4 * q0
+        q0 = 0.25 * s
+        q1 = (m21 - m12) / s
+        q2 = (m02 - m20) / s
+        q3 = (m10 - m01) / s
+    elif m00 > m11 and m00 > m22:
+        s = math.sqrt(1.0 + m00 - m11 - m22) * 2.0  # s = 4 * q1
+        q0 = (m21 - m12) / s
+        q1 = 0.25 * s
+        q2 = (m01 + m10) / s
+        q3 = (m02 + m20) / s
+    elif m11 > m22:
+        s = math.sqrt(1.0 + m11 - m00 - m22) * 2.0  # s = 4 * q2
+        q0 = (m02 - m20) / s
+        q1 = (m01 + m10) / s
+        q2 = 0.25 * s
+        q3 = (m12 + m21) / s
+    else:
+        s = math.sqrt(1.0 + m22 - m00 - m11) * 2.0  # s = 4 * q3
+        q0 = (m10 - m01) / s
+        q1 = (m02 + m20) / s
+        q2 = (m12 + m21) / s
+        q3 = 0.25 * s
+    return np.array([q0, q1, q2, q3], dtype=np.float64)
+
+
+def _rot_from_quat(p: NDArray[np.float64]) -> NDArray[np.float64]:
+    """3x3 rotation matrix from a quaternion ``(p_0, p_1, p_2, p_3)``.
+
+    Uses the standard formula. The quaternion does not need to be unit
+    length: we normalise as part of the formula to keep the result on
+    SO(3) even if upstream arithmetic drifted off the unit sphere.
+    """
+    p0, p1, p2, p3 = float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    n = p0 * p0 + p1 * p1 + p2 * p2 + p3 * p3
+    if n == 0.0:
+        return np.eye(3, dtype=np.float64)
+    s = 2.0 / n
+    return np.array(
+        [
+            [1.0 - s * (p2 * p2 + p3 * p3), s * (p1 * p2 - p3 * p0), s * (p1 * p3 + p2 * p0)],
+            [s * (p1 * p2 + p3 * p0), 1.0 - s * (p1 * p1 + p3 * p3), s * (p2 * p3 - p1 * p0)],
+            [s * (p1 * p3 - p2 * p0), s * (p2 * p3 + p1 * p0), 1.0 - s * (p1 * p1 + p2 * p2)],
+        ],
+        dtype=np.float64,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dual quaternion primitives. The 8-vec carries ``(p, q)`` packed as
+# ``[p_0, p_1, p_2, p_3, q_0, q_1, q_2, q_3]``.
+# ---------------------------------------------------------------------------
+
+
+def dq_mul(sigma_a: NDArray[np.float64], sigma_b: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Dual-quaternion product ``sigma_a * sigma_b``.
+
+    ``(p_a + eps q_a)(p_b + eps q_b) = (p_a p_b) + eps (p_a q_b + q_a p_b)``.
+    """
+    p_a = sigma_a[:4]
+    q_a = sigma_a[4:]
+    p_b = sigma_b[:4]
+    q_b = sigma_b[4:]
+    p = _quat_mul(p_a, p_b)
+    q = _quat_mul(p_a, q_b) + _quat_mul(q_a, p_b)
+    return np.concatenate([p, q])
+
+
+def dq_conj(sigma: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Dual-quaternion conjugate ``(p^*, q^*)``.
+
+    The Study-coordinate inverse on the Study quadric. Useful for
+    constructing reverse-chain transforms (``sigma_E sigma_6^{-1}``).
+    """
+    return np.concatenate([_quat_conj(sigma[:4]), _quat_conj(sigma[4:])])
+
+
+def dq_from_se3(T: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Convert a 4x4 SE(3) matrix to its 8-vec dual-quaternion representation.
+
+    ``T = [[R, t], [0, 1]]`` -> ``sigma = (p, (1/2) t_quat p)`` where
+    ``p`` is the unit quaternion of ``R`` and ``t_quat = (0, t_x, t_y, t_z)``.
+    """
+    p = _quat_from_rot(T[:3, :3])
+    t = T[:3, 3]
+    t_quat = np.array([0.0, float(t[0]), float(t[1]), float(t[2])], dtype=np.float64)
+    q = 0.5 * _quat_mul(t_quat, p)
+    return np.concatenate([p, q])
+
+
+def se3_from_dq(sigma: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Convert an 8-vec dual quaternion to a 4x4 SE(3) matrix.
+
+    Recovers ``R`` from ``p`` and ``t`` from ``q`` via
+    ``t_quat = 2 * q * p^{-1}`` (the inverse of the construction in
+    :func:`dq_from_se3`). Also valid for non-unit dual quaternions:
+    we divide by ``|p|^2`` so the result is well-defined.
+    """
+    p = sigma[:4]
+    q = sigma[4:]
+    R = _rot_from_quat(p)
+    p_norm_sq = float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2] + p[3] * p[3])
+    if p_norm_sq == 0.0:
+        T = np.eye(4, dtype=np.float64)
+        return T
+    t_quat = 2.0 * _quat_mul(q, _quat_conj(p)) / p_norm_sq
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = R
+    T[:3, 3] = t_quat[1:]
+    return T
+
+
+def study_quadric_residual(sigma: NDArray[np.float64]) -> float:
+    """Return ``x_0 y_0 + x_1 y_1 + x_2 y_2 + x_3 y_3``.
+
+    Valid SE(3) elements lie on the Study quadric, so this should be
+    zero (within floating-point noise) for any pose constructed via
+    :func:`dq_from_se3` or :func:`dq_chain`.
+    """
+    s = sigma
+    return float(s[0] * s[4] + s[1] * s[5] + s[2] * s[6] + s[3] * s[7])
+
+
+# ---------------------------------------------------------------------------
+# Joint and chain composition
+# ---------------------------------------------------------------------------
+
+
+def dq_joint(axis: NDArray[np.float64], q: float, joint_type: str) -> NDArray[np.float64]:
+    """Dual-quaternion representation of a single joint at parameter ``q``.
+
+    * For ``joint_type == "revolute"``: rotation by ``q`` radians about
+      ``axis`` (assumed unit length). Quaternion ``(cos(q/2),
+      sin(q/2) * axis)``; translation part zero.
+    * For ``joint_type == "prismatic"``: translation by ``q`` units
+      along ``axis``. Quaternion ``(1, 0, 0, 0)`` (identity rotation);
+      translation part ``(0, q*ax/2, q*ay/2, q*az/2)``.
+
+    Other joint types raise :class:`ValueError`.
+    """
+    ax = float(axis[0])
+    ay = float(axis[1])
+    az = float(axis[2])
+    if joint_type == "revolute":
+        c = math.cos(0.5 * q)
+        s = math.sin(0.5 * q)
+        return np.array(
+            [c, s * ax, s * ay, s * az, 0.0, 0.0, 0.0, 0.0],
+            dtype=np.float64,
+        )
+    if joint_type == "prismatic":
+        return np.array(
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.5 * q * ax, 0.5 * q * ay, 0.5 * q * az],
+            dtype=np.float64,
+        )
+    raise ValueError(f"unsupported joint_type: {joint_type!r}")
+
+
+def dq_chain(kb: KinBody, q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Compose the full kinematic chain into an 8-vec dual quaternion.
+
+    Walks the joints in order, applying ``T_left @ Joint(axis, q) @ T_right``
+    as dual-quaternion products. The result represents the same SE(3)
+    pose as :func:`ssik.kinematics.poe_fk.poe_forward_kinematics` -- in
+    other words, ``se3_from_dq(dq_chain(kb, q)) == poe_forward_kinematics(
+    kb, q)`` up to floating-point precision.
+
+    Cross-validates the Study representation: if the chain composition
+    here disagrees with the SE(3) FK, the dual-quaternion arithmetic is
+    wrong somewhere upstream of HP.
+    """
+    sigma = DQ_IDENTITY.copy()
+    for i, joint in enumerate(kb.joints):
+        sigma_l = dq_from_se3(joint.T_left)
+        sigma_j = dq_joint(joint.axis, float(q[i]), joint.joint_type)
+        sigma_r = dq_from_se3(joint.T_right)
+        sigma_step = dq_mul(sigma_l, dq_mul(sigma_j, sigma_r))
+        sigma = dq_mul(sigma, sigma_step)
+    return sigma

--- a/tests/test_husty_pfurner_study.py
+++ b/tests/test_husty_pfurner_study.py
@@ -1,0 +1,376 @@
+"""Validation for the Study quaternion / dual-quaternion machinery
+(Phase 5b of #158 / #162).
+
+The HP algorithm builds on Study coordinates: a 4x4 SE(3) matrix gets
+encoded as an 8-vec dual quaternion, and chain composition becomes
+dual-quaternion multiplication. If the encoding / decoding / product
+is wrong, every downstream HP step (constraint quadrics, elimination,
+back-substitution) inherits the bug.
+
+This module covers four oracle classes:
+
+1. **SE(3) round-trip**: ``T -> dq -> T`` is identity at 1e-12 for any
+   rigid transform (Hypothesis fuzz over 100+ random poses).
+2. **Study quadric invariance**: every dual quaternion produced by
+   :func:`dq_from_se3` lies on the Study quadric within 1e-12.
+3. **Composition equivalence**: ``dq_mul(dq_a, dq_b)`` decodes to the
+   same SE(3) as ``T_a @ T_b`` (matrix product). Likewise for
+   :func:`dq_chain` vs :func:`ssik.kinematics.poe_fk.poe_forward_kinematics`
+   on revolute and revolute+prismatic chains.
+4. **Joint primitives**: revolute ``dq_joint(axis, theta, "revolute")``
+   matches Rodrigues; prismatic matches translation along axis.
+
+The harness operates on ``ssik.solvers.husty_pfurner._study`` directly
+-- no dependency on the (still-unimplemented) HP solver. This is the
+math-infra validation that any HP-implementation PR can rely on.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from franka_panda import franka_panda_specs
+from jaco2 import jaco2_specs
+from ur5 import ur5_specs
+
+from ssik._kinbody import JointSpec, build_kinbody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.husty_pfurner._study import (
+    DQ_IDENTITY,
+    dq_chain,
+    dq_conj,
+    dq_from_se3,
+    dq_joint,
+    dq_mul,
+    se3_from_dq,
+    study_quadric_residual,
+)
+
+# ----------------------------------------------------------------------------
+# Helpers: build random SE(3) elements, check approximate equality.
+# ----------------------------------------------------------------------------
+
+
+def _random_se3(rng: np.random.Generator) -> np.ndarray:
+    """Sample a uniformly-random rotation (axis-angle) + small translation."""
+    axis = rng.normal(size=3)
+    axis /= np.linalg.norm(axis)
+    angle = float(rng.uniform(-math.pi, math.pi))
+    c, s = math.cos(angle), math.sin(angle)
+    oc = 1.0 - c
+    ax, ay, az = float(axis[0]), float(axis[1]), float(axis[2])
+    R = np.array(
+        [
+            [c + ax * ax * oc, ax * ay * oc - az * s, ax * az * oc + ay * s],
+            [ay * ax * oc + az * s, c + ay * ay * oc, ay * az * oc - ax * s],
+            [az * ax * oc - ay * s, az * ay * oc + ax * s, c + az * az * oc],
+        ]
+    )
+    t = rng.uniform(-1.0, 1.0, size=3)
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = t
+    return T
+
+
+def _prismatic_spec(axis: tuple[float, float, float], name: str) -> JointSpec:
+    return JointSpec(
+        parent_link_T=np.eye(4, dtype=np.float64),
+        axis=np.array(axis, dtype=np.float64),
+        joint_type="prismatic",
+        child_link_T=np.eye(4, dtype=np.float64),
+        name=name,
+        limits=(-10.0, 10.0),
+    )
+
+
+def _revolute_spec(axis: tuple[float, float, float], name: str) -> JointSpec:
+    return JointSpec(
+        parent_link_T=np.eye(4, dtype=np.float64),
+        axis=np.array(axis, dtype=np.float64),
+        joint_type="revolute",
+        child_link_T=np.eye(4, dtype=np.float64),
+        name=name,
+        limits=(-math.pi, math.pi),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Oracle 1: SE(3) round-trip
+# ----------------------------------------------------------------------------
+
+
+def test_dq_identity_decodes_to_eye4() -> None:
+    """``DQ_IDENTITY`` should decode to the 4x4 identity at machine precision."""
+    T = se3_from_dq(DQ_IDENTITY)
+    assert np.allclose(T, np.eye(4), atol=1e-15)
+
+
+@pytest.mark.parametrize("seed", list(range(20)))
+def test_se3_round_trip_is_identity_seeded(seed: int) -> None:
+    """``T -> dq -> T`` is the identity transform at 1e-12 for 20 fixed seeds."""
+    rng = np.random.default_rng(seed)
+    T = _random_se3(rng)
+    sigma = dq_from_se3(T)
+    T_back = se3_from_dq(sigma)
+    assert np.allclose(T_back, T, atol=1e-12), (
+        f"seed={seed}: max|diff|={float(np.max(np.abs(T_back - T))):.2e}"
+    )
+
+
+@given(
+    rotvec=hnp.arrays(
+        dtype=np.float64,
+        shape=(3,),
+        elements=st.floats(min_value=-3.0, max_value=3.0, allow_nan=False, allow_infinity=False),
+    ),
+    t=hnp.arrays(
+        dtype=np.float64,
+        shape=(3,),
+        elements=st.floats(min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False),
+    ),
+)
+@settings(max_examples=200, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_se3_round_trip_hypothesis_fuzz(rotvec: np.ndarray, t: np.ndarray) -> None:
+    """Hypothesis fuzz: random rotation-vector + translation pairs round-trip
+    at 1e-12 over 200 examples.
+    """
+    angle = float(np.linalg.norm(rotvec))
+    if angle < 1e-12:
+        R = np.eye(3)
+    else:
+        axis = rotvec / angle
+        c, s = math.cos(angle), math.sin(angle)
+        oc = 1.0 - c
+        ax, ay, az = float(axis[0]), float(axis[1]), float(axis[2])
+        R = np.array(
+            [
+                [c + ax * ax * oc, ax * ay * oc - az * s, ax * az * oc + ay * s],
+                [ay * ax * oc + az * s, c + ay * ay * oc, ay * az * oc - ax * s],
+                [az * ax * oc - ay * s, az * ay * oc + ax * s, c + az * az * oc],
+            ]
+        )
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = t
+    sigma = dq_from_se3(T)
+    T_back = se3_from_dq(sigma)
+    assert np.allclose(T_back, T, atol=1e-10), f"max|diff|={float(np.max(np.abs(T_back - T))):.2e}"
+
+
+# ----------------------------------------------------------------------------
+# Oracle 2: Study quadric invariance
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", list(range(20)))
+def test_study_quadric_zero_after_dq_from_se3(seed: int) -> None:
+    """``study_quadric_residual(dq_from_se3(T))`` is zero within 1e-12
+    for any rigid transform.
+    """
+    rng = np.random.default_rng(seed)
+    T = _random_se3(rng)
+    sigma = dq_from_se3(T)
+    residual = study_quadric_residual(sigma)
+    assert abs(residual) < 1e-12, f"seed={seed}: residual={residual:.2e}"
+
+
+def test_study_quadric_zero_for_identity() -> None:
+    assert abs(study_quadric_residual(DQ_IDENTITY)) < 1e-15
+
+
+# ----------------------------------------------------------------------------
+# Oracle 3: composition equivalence (DQ product vs matrix product)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", list(range(10)))
+def test_dq_mul_matches_matrix_product(seed: int) -> None:
+    """``dq_mul(dq_a, dq_b)`` decodes to ``T_a @ T_b``.
+
+    Two random rigid transforms; compose via DQ and via matrix multiplication;
+    the two SE(3) outputs must match at 1e-12.
+    """
+    rng = np.random.default_rng(seed)
+    T_a = _random_se3(rng)
+    T_b = _random_se3(rng)
+    expected = T_a @ T_b
+    sigma = dq_mul(dq_from_se3(T_a), dq_from_se3(T_b))
+    actual = se3_from_dq(sigma)
+    assert np.allclose(actual, expected, atol=1e-10), (
+        f"seed={seed}: max|diff|={float(np.max(np.abs(actual - expected))):.2e}"
+    )
+
+
+def test_dq_mul_associativity() -> None:
+    """``(a * b) * c`` decodes to the same SE(3) as ``a * (b * c)`` for
+    random rigid transforms.
+    """
+    rng = np.random.default_rng(0)
+    a = dq_from_se3(_random_se3(rng))
+    b = dq_from_se3(_random_se3(rng))
+    c = dq_from_se3(_random_se3(rng))
+    left = dq_mul(dq_mul(a, b), c)
+    right = dq_mul(a, dq_mul(b, c))
+    assert np.allclose(se3_from_dq(left), se3_from_dq(right), atol=1e-10)
+
+
+def test_dq_mul_identity_is_identity() -> None:
+    """``DQ_IDENTITY * sigma == sigma * DQ_IDENTITY == sigma``."""
+    rng = np.random.default_rng(0)
+    sigma = dq_from_se3(_random_se3(rng))
+    assert np.allclose(dq_mul(DQ_IDENTITY, sigma), sigma, atol=1e-15)
+    assert np.allclose(dq_mul(sigma, DQ_IDENTITY), sigma, atol=1e-15)
+
+
+def test_dq_conj_inverts_unit_dq() -> None:
+    """For a unit dual quaternion (which any pose-DQ is by construction),
+    ``sigma * conj(sigma)`` decodes to the identity SE(3).
+    """
+    rng = np.random.default_rng(0)
+    sigma = dq_from_se3(_random_se3(rng))
+    product = dq_mul(sigma, dq_conj(sigma))
+    T = se3_from_dq(product)
+    assert np.allclose(T, np.eye(4), atol=1e-10), (
+        f"max|diff|={float(np.max(np.abs(T - np.eye(4)))):.2e}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Oracle 4: joint primitives match the standalone formulas
+# ----------------------------------------------------------------------------
+
+
+def test_dq_joint_revolute_about_z_quarter_turn() -> None:
+    """Revolute joint about world +Z by pi/2: rotation block matches the
+    canonical 90-degree-about-Z matrix; translation column is zero.
+    """
+    axis = np.array([0.0, 0.0, 1.0])
+    sigma = dq_joint(axis, math.pi / 2.0, "revolute")
+    T = se3_from_dq(sigma)
+    expected_R = np.array(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    assert np.allclose(T[:3, :3], expected_R, atol=1e-15)
+    assert np.allclose(T[:3, 3], 0.0, atol=1e-15)
+
+
+def test_dq_joint_prismatic_along_x_translates_by_d() -> None:
+    """Prismatic joint along world +X by d: identity rotation, translation = (d, 0, 0)."""
+    axis = np.array([1.0, 0.0, 0.0])
+    d = 0.42
+    sigma = dq_joint(axis, d, "prismatic")
+    T = se3_from_dq(sigma)
+    assert np.allclose(T[:3, :3], np.eye(3), atol=1e-15)
+    assert np.allclose(T[:3, 3], np.array([d, 0.0, 0.0]), atol=1e-15)
+
+
+def test_dq_joint_unsupported_type_raises() -> None:
+    """Non-revolute / non-prismatic joint types raise ``ValueError`` with
+    a clear message."""
+    with pytest.raises(ValueError, match="joint_type"):
+        dq_joint(np.array([0.0, 0.0, 1.0]), 0.5, "fixed")
+
+
+# ----------------------------------------------------------------------------
+# Oracle 3 (continued): chain composition matches POE FK
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("specs_fn", "n_dof"),
+    [
+        (jaco2_specs, 6),
+        (ur5_specs, 6),
+        (franka_panda_specs, 7),
+    ],
+)
+def test_dq_chain_matches_poe_fk_revolute_fixtures(  # type: ignore[no-untyped-def]
+    specs_fn, n_dof: int
+) -> None:
+    """``se3_from_dq(dq_chain(kb, q))`` equals ``poe_forward_kinematics(kb, q)``
+    on the existing all-revolute fixtures (JACO 2, UR5, Franka). 5 random q
+    seeds per arm; tolerance 1e-10.
+    """
+    kb = build_kinbody(specs_fn())
+    rng = np.random.default_rng(42)
+    for _ in range(5):
+        q = rng.uniform(-1.0, 1.0, size=n_dof)
+        T_poe = poe_forward_kinematics(kb, q)
+        T_dq = se3_from_dq(dq_chain(kb, q))
+        assert np.allclose(T_dq, T_poe, atol=1e-10), (
+            f"{specs_fn.__name__}: max|diff|={float(np.max(np.abs(T_dq - T_poe))):.2e}"
+        )
+
+
+def test_dq_chain_matches_poe_fk_mixed_rp_chain() -> None:
+    """A synthetic R-P-R chain composed via dual quaternions matches POE FK.
+
+    Mirrors ``test_poe_fk_prismatic.py``'s RPR fixture: r1 about world +Z,
+    p2 along +X, r3 about +Z. With r1=pi/2, the prismatic translation
+    rotates from local +X to world +Y.
+    """
+    specs = [
+        _revolute_spec((0.0, 0.0, 1.0), "r1"),
+        _prismatic_spec((1.0, 0.0, 0.0), "p2"),
+        _revolute_spec((0.0, 0.0, 1.0), "r3"),
+    ]
+    kb = build_kinbody(specs)
+    q = np.array([math.pi / 2.0, 0.5, 0.0])
+    T_poe = poe_forward_kinematics(kb, q)
+    T_dq = se3_from_dq(dq_chain(kb, q))
+    assert np.allclose(T_dq, T_poe, atol=1e-10), (
+        f"max|diff|={float(np.max(np.abs(T_dq - T_poe))):.2e}"
+    )
+
+
+def test_dq_chain_at_zero_is_dq_of_link_product_only() -> None:
+    """At ``q=0``, every revolute / prismatic joint contributes the identity
+    transform; the chain DQ is just the dual quaternion of the cumulative
+    ``T_left @ T_right`` product.
+    """
+    kb = build_kinbody(jaco2_specs())
+    q = np.zeros(6)
+    sigma = dq_chain(kb, q)
+    T_dq = se3_from_dq(sigma)
+    T_poe = poe_forward_kinematics(kb, q)
+    assert np.allclose(T_dq, T_poe, atol=1e-10)
+
+
+def test_dq_chain_residual_on_study_quadric() -> None:
+    """``study_quadric_residual(dq_chain(kb, q))`` is zero within 1e-10
+    for any reachable configuration. Composition of valid SE(3) DQs
+    stays on the Study quadric.
+    """
+    kb = build_kinbody(jaco2_specs())
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        q = rng.uniform(-1.0, 1.0, size=6)
+        sigma = dq_chain(kb, q)
+        residual = study_quadric_residual(sigma)
+        assert abs(residual) < 1e-10, f"residual={residual:.2e}"
+
+
+# ----------------------------------------------------------------------------
+# Oracle 3 (continued): determinism
+# ----------------------------------------------------------------------------
+
+
+def test_dq_chain_is_deterministic() -> None:
+    """Repeated calls on the same input produce byte-equal 8-vec results."""
+    kb = build_kinbody(jaco2_specs())
+    q = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    s1 = dq_chain(kb, q)
+    s2 = dq_chain(kb, q)
+    assert np.array_equal(s1, s2)


### PR DESCRIPTION
## Summary

- Phase 5b of the 10-PR Husty-Pfurner sequence in #162. The math-infra layer for SE(3) ↔ Study coordinates, dual-quaternion product, joint and chain composition. Every subsequent HP step (5c constraints, 5d elimination, 5f back-substitution) builds on this.
- 66 tests covering round-trip, Study quadric invariance, composition equivalence, joint primitives (revolute + prismatic), and chain composition matching ``poe_forward_kinematics`` on JACO 2 / UR5 / Franka + a synthetic R-P-R fixture.
- Pure numpy. No algorithm content yet. No Cython yet (Phase 5h hot-spot escalation only).

## What's in this PR

**``src/ssik/solvers/husty_pfurner/_study.py``** — math primitives:

- ``DQ_IDENTITY`` constant.
- ``dq_from_se3(T) → 8-vec`` and ``se3_from_dq(σ) → 4×4``. Quaternion extraction uses Shepperd 1978 (numerically stable near 180° rotations, unlike the textbook trace-only method).
- ``dq_mul(σ_a, σ_b)`` — dual-quaternion product. Decomposition: ``(p_a + ε q_a)(p_b + ε q_b) = p_a p_b + ε(p_a q_b + q_a p_b)``.
- ``dq_conj(σ)`` — conjugate (Study-coordinate inverse on the quadric).
- ``dq_joint(axis, q, joint_type)`` — single joint as DQ. Revolute uses the standard half-angle quaternion; prismatic uses the ``ε`` half-translation. Raises ``ValueError`` on unsupported types.
- ``dq_chain(kb, q)`` — POE-normalised chain → final EE pose as DQ.
- ``study_quadric_residual(σ)`` — quadric check for diagnostics.

**``tests/test_husty_pfurner_study.py``** — 66 tests across four oracle classes:

| Oracle | Coverage |
|---|---|
| 1. SE(3) round-trip | 20 seeded + 200 Hypothesis-fuzzed rigid transforms; ``T → DQ → T`` identity at 1e-12. |
| 2. Study quadric invariance | every ``dq_from_se3(T)`` lies on the quadric within 1e-12. |
| 3. Composition equivalence | ``dq_mul`` matches matrix product; associativity; identity element; conjugate inverse. ``dq_chain`` matches ``poe_forward_kinematics`` on JACO 2 / UR5 / Franka (5 random q each) and on a synthetic R-P-R chain (mirrors the Phase 5a.5 RPR case). |
| 4. Joint primitives | revolute about Z by π/2 produces the canonical 90° matrix; prismatic along X by ``d`` translates by ``(d, 0, 0)``; unsupported types raise. |

Plus a determinism check (byte-equal output across calls).

## Test plan

- [x] ``uv run pytest tests/test_husty_pfurner_study.py -v`` — 66/66 pass at the documented tolerances.
- [x] ``uv run mypy src/ssik/solvers/husty_pfurner/_study.py tests/test_husty_pfurner_study.py`` — clean.
- [x] ``uv run ruff check`` + ``ruff format --check`` — clean.

## Branch dependency

This PR is branched off ``m2-158-hp-skeleton`` (PR #163) because that PR creates the ``husty_pfurner`` package's ``__init__.py``. Will rebase on main after #163 merges.

## What's NOT in this PR

- Constraint quadrics (Phase 5c) — needs the parametrised 3-space hyperplane equations from Capco et al. eq. (5).
- Elimination → degree-16 univariate (Phase 5d) — the resultant pipeline.
- Polynomial root finding (Phase 5e) and back-substitution (Phase 5f).
- Dispatcher wiring (Phase 5g).

## Algorithmic reference

Capco, Loquias, Manongsong, Nemenzo (2019), *'Inverse Kinematics of Some General 6R/P Manipulators'*, arXiv 1906.07813, Section 2 (dual quaternions, Study coordinates, kinematic equation).

## Related

- #158 (strategic Phase 5 meta-issue, Option A: pure Python with 100 ms abort gate)
- #162 (10-PR execution plan)
- #163 (Phase 5a — HP validation harness + skeleton; this PR depends on its package skeleton)
- #164 (Phase 5a.5 — POE FK prismatic-joint branch; ``dq_joint`` mirrors that decision for prismatic chain composition)