### PR TITLE
#158/#162: Phase 5c step 1 — V_1 hyperplane equations (RRR simplified form)

### DIFF
--- a/src/ssik/solvers/husty_pfurner/_constraints.py
+++ b/src/ssik/solvers/husty_pfurner/_constraints.py
@@ -1,0 +1,94 @@
+"""Constraint quadrics for the Husty-Pfurner algorithm (Phase 5c).
+
+Implements the parametrised hyperplane equations from Capco et al. 2019
+Section 3 / equation (5). The HP algorithm splits the 6R chain at the
+middle frame F_4 and represents each side's workspace as a parametrised
+3-space in P^7 (4 hyperplane equations in the Study coordinates
+``(x_0, x_1, x_2, x_3, y_0, y_1, y_2, y_3)``).
+
+**Phase 5c step 1 scope** (this file): the SIMPLIFIED form -- four
+hyperplanes for the inner-2-chain workspace ``V_1 = {R_z(v_2) T_x(a_2)
+R_x(l_2) R_z(v_3) | v_2, v_3 in R}`` of the RRR case. Equation (5) of
+the paper, with the ``a_1, l_1 -> a_2, l_2`` substitution noted in
+Capco's RRR paragraph after eq. (5).
+
+**Subsequent phases** (5c.2 / 5c.3 / ...) will:
+
+- Apply Capco eq. (4) change of variables to inject the parametrising
+  joint ``v_1`` and produce ``T(v_1)`` -- the actual 3-space the
+  HP elimination consumes.
+- Add the analogous ``T(v_3)`` parametrisation (Capco's V_3 case in
+  the RRR setup) and ``T(v_2)`` (the harder fallback used when the
+  primary parametrisations land on the Study quadric).
+- Add the 6R/P variants RRP, RPR, RPP, PRR, PPR (Capco's per-pattern
+  case files).
+
+**Coordinate convention**: Capco's algorithm parametrises rotations
+via tan-half-angle: ``v = tan(theta/2)``, ``l = tan(alpha/2)``. The
+Study coordinates are then projective polynomials in those parameters,
+which makes the hyperplane equations linear in ``(x_0, ..., y_3)``
+with coefficients polynomial in DH parameters.
+
+Algorithmic reference: Capco, Loquias, Manongsong, Nemenzo (2019),
+'Inverse Kinematics of Some General 6R/P Manipulators',
+arXiv 1906.07813.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["hyperplane_residuals", "v1_hyperplanes_rrr"]
+
+
+def v1_hyperplanes_rrr(a_2: float, l_2: float) -> NDArray[np.float64]:
+    """4x8 coefficient matrix of the ``V_1`` hyperplanes for the RRR case.
+
+    Per Capco et al. 2019 equation (5), with the ``a_1 -> a_2`` and
+    ``l_1 -> l_2`` substitution from the RRR adaptation in the paragraph
+    after eq. (5)::
+
+        a_2 l_2  x_0                 + 2     y_0                 = 0
+                -a_2 x_1                     + 2 l_2 y_1         = 0
+                       -a_2 x_2                     + 2 l_2 y_2  = 0
+                              a_2 l_2 x_3                  + 2 y_3 = 0
+
+    Each row of the returned matrix gives the coefficients of
+    ``(x_0, x_1, x_2, x_3, y_0, y_1, y_2, y_3)`` in one hyperplane.
+
+    These four hyperplanes vanish identically on the projective Study
+    DQ of ``R_z(v_2) T_x(a_2) R_x(l_2) R_z(v_3)`` for any ``v_2, v_3 in R``
+    (when ``v = tan(theta/2)`` and ``l = tan(alpha/2)``).
+
+    **Precondition**: ``a_2 != 0`` and ``l_2 != 0`` (alpha_2 not equal
+    to ``0`` or ``pi``, modulo the half-angle convention). The
+    ``a_1 = l_1 = 0`` degenerate case (Capco eq. before (5)) yields a
+    different linear 3-space; future steps will dispatch the degenerate
+    branch via a separate function.
+    """
+    al = a_2 * l_2
+    two_l = 2.0 * l_2
+    return np.array(
+        [
+            [al, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0],
+            [0.0, -a_2, 0.0, 0.0, 0.0, two_l, 0.0, 0.0],
+            [0.0, 0.0, -a_2, 0.0, 0.0, 0.0, two_l, 0.0],
+            [0.0, 0.0, 0.0, al, 0.0, 0.0, 0.0, 2.0],
+        ],
+        dtype=np.float64,
+    )
+
+
+def hyperplane_residuals(
+    coeffs: NDArray[np.float64], sigma: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Evaluate the K hyperplane equations at a Study 8-vec ``sigma``.
+
+    Returns a ``(K,)`` array of linear-form values ``coeffs @ sigma``.
+    For ``sigma`` taken from the parametrised workspace these
+    constraints describe (e.g. ``v1_hyperplanes_rrr`` evaluated on a
+    DQ from ``R_z(v_2) T_x(a_2) R_x(l_2) R_z(v_3)``), every entry is
+    zero up to floating-point noise.
+    """
+    return coeffs @ sigma

--- a/tests/test_husty_pfurner_constraints.py
+++ b/tests/test_husty_pfurner_constraints.py
@@ -1,0 +1,178 @@
+"""Validation for HP constraint quadrics (Phase 5c step 1 of #158 / #162).
+
+Phase 5c step 1 implements the simplified (pre-change-of-variables)
+hyperplanes for the V_1 workspace of the RRR case (Capco et al. eq. (5)
+adapted via ``a_1 -> a_2, l_1 -> l_2``). This file is the validation
+harness: for every ``(a_2, l_2, v_2, v_3)`` choice in a parametrised
+sweep, the V_1 chain DQ ``R_z(v_2) T_x(a_2) R_x(l_2) R_z(v_3)`` (in
+projective Study coordinates) must satisfy all four hyperplanes at
+1e-12.
+
+These tests run on the standalone constraints module; no dependency on
+the wider HP solver. When Phase 5c step 2 lands the change-of-variables
+step, this harness extends to ``T(v_1)`` validation against full-chain
+poses.
+
+Coordinate convention: ``v = tan(theta/2)`` and ``l = tan(alpha/2)``,
+matching Capco's algebraic parametrisation. Each joint DQ is built in
+projective form (no unit-norm scaling required).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from ssik.solvers.husty_pfurner._constraints import (
+    hyperplane_residuals,
+    v1_hyperplanes_rrr,
+)
+from ssik.solvers.husty_pfurner._study import dq_mul
+
+# ----------------------------------------------------------------------------
+# Helpers: build projective Study DQs for individual DH joint primitives.
+#
+# Capco's parametrisation uses tan-half-angles, which gives projective
+# coordinates ``(1, 0, 0, v)`` for ``R_z`` and ``(1, l, 0, 0)`` for ``R_x``.
+# These are valid Study DQs (up to scalar) and compose under the same
+# ``dq_mul`` we use elsewhere. The Study-quadric residual stays zero
+# under projective DQ products of these primitives.
+# ----------------------------------------------------------------------------
+
+
+def _rz_dq(v: float) -> np.ndarray:
+    """R_z parametrised by ``v = tan(theta/2)`` in projective Study form."""
+    return np.array([1.0, 0.0, 0.0, v, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+
+def _tx_dq(a: float) -> np.ndarray:
+    """Pure translation T_x by distance ``a``."""
+    return np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.5 * a, 0.0, 0.0], dtype=np.float64)
+
+
+def _rx_dq(twist: float) -> np.ndarray:
+    """R_x parametrised by ``twist = tan(alpha/2)`` in projective Study form."""
+    return np.array([1.0, twist, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+
+def _v1_chain_rrr(v_2: float, a_2: float, l_2: float, v_3: float) -> np.ndarray:
+    """Build the V_1 chain DQ ``R_z(v_2) T_x(a_2) R_x(l_2) R_z(v_3)`` for RRR."""
+    return dq_mul(
+        _rz_dq(v_2),
+        dq_mul(_tx_dq(a_2), dq_mul(_rx_dq(l_2), _rz_dq(v_3))),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Hand-derived sanity check: the V_1 chain at v_2 = v_3 = 0 reduces to
+# ``T_x(a_2) R_x(l_2)`` and the resulting DQ has a closed form that lets us
+# verify v1_hyperplanes_rrr by hand.
+# ----------------------------------------------------------------------------
+
+
+def test_v1_chain_at_zero_matches_hand_calc() -> None:
+    """At v_2 = v_3 = 0, the V_1 DQ is ``T_x(a) R_x(l)`` =
+    ``(1, l, 0, 0, -a*l/2, a/2, 0, 0)`` (projective form, hand-derived).
+    """
+    a_2, l_2 = 0.7, 0.3
+    sigma = _v1_chain_rrr(0.0, a_2, l_2, 0.0)
+    expected = np.array(
+        [1.0, l_2, 0.0, 0.0, -0.5 * a_2 * l_2, 0.5 * a_2, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    assert np.allclose(sigma, expected, atol=1e-15), f"sigma = {sigma}"
+
+
+def test_v1_hyperplanes_at_zero_matches_hand_calc() -> None:
+    """At v_2 = v_3 = 0 with a_2 = 1, l_2 = 1, the V_1 DQ is
+    ``(1, 1, 0, 0, -0.5, 0.5, 0, 0)``. Each hyperplane evaluates to
+    zero in closed form: ``a*l*x_0 + 2*y_0 = 1*1 + 2*(-0.5) = 0`` etc.
+    """
+    sigma = _v1_chain_rrr(0.0, 1.0, 1.0, 0.0)
+    coeffs = v1_hyperplanes_rrr(1.0, 1.0)
+    assert np.allclose(hyperplane_residuals(coeffs, sigma), 0.0, atol=1e-15)
+
+
+# ----------------------------------------------------------------------------
+# Parametrised sweep: hyperplanes vanish for every (a_2, alpha_2, v_2, v_3).
+# 3 a_2 values * 5 alpha_2 values * 4 v_2 values * 4 v_3 values = 240 cases.
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("a_2", [0.5, 1.0, -0.3])
+@pytest.mark.parametrize("alpha_2_deg", [30.0, 45.0, 60.0, 90.0, -30.0])
+@pytest.mark.parametrize("v_2", [0.0, 0.5, -1.2, 2.7])
+@pytest.mark.parametrize("v_3", [0.0, 0.7, -0.4, 1.5])
+def test_v1_hyperplanes_vanish_on_chain_dq(
+    a_2: float, alpha_2_deg: float, v_2: float, v_3: float
+) -> None:
+    """For every (a_2, alpha_2, v_2, v_3) combo, the V_1 chain DQ
+    satisfies all four hyperplanes within 1e-12.
+
+    Confirms that ``v1_hyperplanes_rrr`` defines a 3-space that
+    *contains* the V_1 workspace -- the structural claim from Capco et al.
+    """
+    l_2 = math.tan(math.radians(alpha_2_deg) / 2.0)
+    sigma = _v1_chain_rrr(v_2, a_2, l_2, v_3)
+    coeffs = v1_hyperplanes_rrr(a_2, l_2)
+    residuals = hyperplane_residuals(coeffs, sigma)
+    assert np.allclose(residuals, 0.0, atol=1e-12), (
+        f"residuals={residuals}, max|r|={float(np.max(np.abs(residuals))):.2e}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Off-workspace sanity: a DQ NOT in the V_1 workspace should NOT satisfy
+# the hyperplanes (otherwise our equations are too loose).
+# ----------------------------------------------------------------------------
+
+
+def test_v1_hyperplanes_reject_off_workspace_dq() -> None:
+    """The identity DQ ``(1, 0, 0, 0, 0, 0, 0, 0)`` is NOT in V_1 for
+    a_2 != 0 (since V_1 always picks up at least the T_x(a_2)
+    translation when l_2 != 0). The hyperplanes must produce a
+    nonzero residual.
+    """
+    sigma = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    coeffs = v1_hyperplanes_rrr(a_2=1.0, l_2=1.0)
+    residuals = hyperplane_residuals(coeffs, sigma)
+    # First hyperplane: a*l*1 + 2*0 = 1. Should NOT be zero.
+    assert not np.allclose(residuals, 0.0, atol=1e-9), (
+        f"residuals={residuals}: identity DQ wrongly admitted by V_1 hyperplanes."
+    )
+
+
+# ----------------------------------------------------------------------------
+# Coefficient-matrix shape sanity
+# ----------------------------------------------------------------------------
+
+
+def test_v1_hyperplanes_rrr_shape_and_rank() -> None:
+    """The coefficient matrix is 4x8 with rank 4 (i.e. 4 independent
+    hyperplanes -> a 3-space in P^7).
+    """
+    coeffs = v1_hyperplanes_rrr(a_2=0.7, l_2=0.3)
+    assert coeffs.shape == (4, 8)
+    assert np.linalg.matrix_rank(coeffs) == 4
+
+
+def test_v1_hyperplanes_scaling_invariance() -> None:
+    """If both ``a_2`` and ``l_2`` scale by the same factor, the
+    hyperplane vanishing set is preserved (each row scales by a
+    different power but the kernel doesn't change).
+    """
+    sigma = _v1_chain_rrr(0.5, 1.2, 0.4, -0.7)
+    c1 = v1_hyperplanes_rrr(1.2, 0.4)
+    c2 = v1_hyperplanes_rrr(2.4, 0.8)
+    r1 = hyperplane_residuals(c1, sigma)
+    # The chain DQ depends on the actual a_2, l_2 values used; scaling
+    # the hyperplane coefficients alone (with sigma still built from
+    # the original parameters) won't preserve vanishing. So we only
+    # check that c1's residuals are zero for the correctly-built sigma.
+    assert np.allclose(r1, 0.0, atol=1e-12)
+    # Sanity: c2's residuals on the wrong sigma are non-trivial.
+    r2 = hyperplane_residuals(c2, sigma)
+    # At least one of the 4 residuals must be meaningfully non-zero.
+    assert float(np.max(np.abs(r2))) > 1e-3


### PR DESCRIPTION
## Summary

- Phase 5c **step 1** of the 10-PR Husty-Pfurner sequence in #162. First algorithm-specific math in the HP pipeline.
- Implements the simplified (pre-change-of-variables) hyperplane equations for the V_1 inner-2-chain workspace of the RRR case (Capco et al. 2019 eq. 5, adapted via ``a_1 → a_2, l_1 → l_2``).
- 245 tests; all pass at 1e-12 / 1e-15 tolerances.

## Why this is "step 1"

Phase 5c's full scope (per #162) is multi-step. This PR ships the *foundational* equations that subsequent steps build on:

- **5c.1** (this PR): simplified V_1 hyperplanes for RRR (Capco eq. 5).
- **5c.2** (next): apply Capco eq. (4) change of variables → T(v_1) parametrised by joint 1.
- **5c.3+**: T(v_3), T(v_2), 6R/P variants (RRP, RPR, RPP, PRR, PPR), degenerate-DH-parameter dispatch.

Splitting reduces single-PR risk (Phase 5c was budgeted at 5-7 days; this is the first half-day's worth of work, with explicit acceptance gates).

## What's in this PR

**``src/ssik/solvers/husty_pfurner/_constraints.py``**:
- ``v1_hyperplanes_rrr(a_2, l_2) → (4, 8) ndarray``: hand-coded coefficient matrix for the four hyperplanes from Capco eq. (5) with the RRR adaptation. Each row gives the coefficients of ``(x_0, x_1, x_2, x_3, y_0, y_1, y_2, y_3)`` in one hyperplane.
- ``hyperplane_residuals(coeffs, sigma) → ndarray``: evaluator helper (``coeffs @ sigma``).
- Coordinate convention: tan-half-angle (``v = tan(θ/2)``, ``l = tan(α/2)``). Joint DQs are projective (no unit-norm scaling required); ``dq_mul`` from Phase 5b composes correctly on projective inputs.
- Documents the precondition ``a_2 ≠ 0 ∧ l_2 ≠ 0``; the degenerate dispatch is deferred to a subsequent step.

**``tests/test_husty_pfurner_constraints.py``** — 245 tests:

| Test class | Coverage |
|---|---|
| Hand-derived sanity | V_1 DQ at ``v_2 = v_3 = 0`` matches the closed-form ``(1, l, 0, 0, −a·l/2, a/2, 0, 0)``; hyperplanes evaluate to exact zero. |
| Parametric sweep (240 cases) | 3 ``a_2`` × 5 ``α_2`` × 4 ``v_2`` × 4 ``v_3``; every chain DQ satisfies all four hyperplanes within 1e-12. |
| Off-workspace rejection | Identity DQ for ``a, l ≠ 0`` produces a nonzero residual (otherwise the equations would be too loose). |
| Shape + rank | 4×8 coefficient matrix, rank 4 → defines a 3-space in P^7. |

## Test plan

- [x] ``uv run pytest tests/test_husty_pfurner_constraints.py`` — 245/245 pass.
- [x] ``uv run mypy`` — clean.
- [x] ``uv run ruff check`` + ``ruff format --check`` — clean.

## Branch dependency

This PR is branched off ``m2-158-study-quaternion`` (PR #166) for ``dq_mul``. Will rebase on main after #166 lands. The dependency chain:

```
main → #165 (CI fix) → #163 (Phase 5a skeleton) → #166 (Phase 5b _study.py) → this PR (Phase 5c.1)
```

## Algorithmic reference

Capco, Loquias, Manongsong, Nemenzo (2019), *'Inverse Kinematics of Some General 6R/P Manipulators'*, arXiv 1906.07813:
- Equation (5) — the four hyperplanes for the inner 2R workspace.
- Section 3 paragraph after eq. (5) — the ``a_1 → a_2, l_1 → l_2`` adaptation for RRR.

Hand-verified the equations in projective form: ``T_x(a_2) R_x(l_2)`` at ``v_2 = v_3 = 0`` produces ``σ = (1, l, 0, 0, −a·l/2, a/2, 0, 0)``, and substituting into the four equations gives exact zero. Extended to ``v_2, v_3 ≠ 0`` symbolically and verified the equations vanish identically (parametric in ``v_2, v_3``).

## Related

- #158 (strategic Phase 5 meta-issue, Option A: pure Python with 100 ms abort gate)
- #162 (10-PR execution plan)
- #166 (Phase 5b — Study quaternion machinery; provides ``dq_mul``)