### PR TITLE
#158/#162: Phase 5d step 1 — T(v_6) right-chain hyperplanes (RRR, bulletproof)

### DIFF
--- a/src/ssik/solvers/husty_pfurner/_constraints.py
+++ b/src/ssik/solvers/husty_pfurner/_constraints.py
@@ -51,6 +51,7 @@ __all__ = [
     "hyperplane_residuals",
     "tv1_hyperplanes_rrr",
     "tv3_hyperplanes_rrr",
+    "tv6_hyperplanes_rrr",
     "v1_hyperplanes_rrr",
 ]
 
@@ -404,3 +405,123 @@ def tv3_hyperplanes_rrr(
             f"tv3_hyperplanes_rrr produced shape {result.shape}, expected (4, 8)"
         )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Phase 5d step 1: T(v_6) -- right-chain hyperplanes parametrised by joint 6.
+#
+# Per Capco eq. (6), the right chain
+#     V_R = {sigma_E sigma_6^{-1}(v_6) sigma_5^{-1}(v_5) sigma_4^{-1}(v_4)}
+# can be obtained from the LEFT-chain T(v_1) construction by:
+#
+#   1. Parameter substitutions (sign flips + index re-mapping):
+#        v_1 -> -v_6, a_1 -> -a_5, l_1 -> -l_5, d_2 -> -d_5
+#        v_2 -> -v_5, a_2 -> -a_4, l_2 -> -l_4
+#        v_3 -> -v_4, a_3 -> 0,   l_3 -> 0,    d_3 -> -d_4
+#   2. A final change of variables ``sigma -> sigma_E^* . sigma`` (left
+#      multiplication by the conjugate of the target end-effector pose).
+#
+# Convention: a_6 = d_6 = l_6 = 0 -- the EE site / last-link offset must be
+# absorbed into ``sigma_E`` by the caller (left-multiplying the end-pose
+# by the joint-6 EE offset DQ before passing it here).
+# ---------------------------------------------------------------------------
+
+
+def _quat_left_mult_matrix(p: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Return the 4x4 matrix ``L(p)`` such that ``L(p) @ q == p * q`` for
+    any quaternion ``q``.
+
+    Hamilton product written as a linear map in ``q``.
+    """
+    p0, p1, p2, p3 = float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    return np.array(
+        [
+            [p0, -p1, -p2, -p3],
+            [p1, p0, -p3, p2],
+            [p2, p3, p0, -p1],
+            [p3, -p2, p1, p0],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _dq_left_mult_matrix(eta: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Return the 8x8 matrix ``M_eta`` such that ``M_eta @ sigma == eta * sigma``
+    for any 8-vec dual quaternion ``sigma`` (using ``ssik.solvers.husty_pfurner._study.dq_mul``).
+
+    Block structure: top-left and bottom-right are ``L(eta_p)`` (the rotation
+    part of ``eta`` acts on both halves of ``sigma``); bottom-left is
+    ``L(eta_q)`` (the translation part of ``eta`` mixes ``sigma_p`` into
+    the result's translation half); top-right is zero (``sigma_q`` does
+    not contribute to the rotation half of the product).
+    """
+    eta_p = eta[:4]
+    eta_q = eta[4:]
+    Lp = _quat_left_mult_matrix(eta_p)
+    Lq = _quat_left_mult_matrix(eta_q)
+    M = np.zeros((8, 8), dtype=np.float64)
+    M[:4, :4] = Lp
+    M[4:, :4] = Lq
+    M[4:, 4:] = Lp
+    return M
+
+
+def tv6_hyperplanes_rrr(
+    a_4: float,
+    l_4: float,
+    d_4: float,
+    a_5: float,
+    l_5: float,
+    d_5: float,
+    sigma_E: NDArray[np.float64],
+    v_6: float,
+) -> NDArray[np.float64]:
+    """4x8 coefficient matrix of ``T(v_6)`` for the right chain in 6R/RRR.
+
+    Reuses the lambdified ``T(v_1)`` machinery via Capco eq. (6) parameter
+    substitutions, then applies the ``sigma_E^*``-left-multiplication
+    change of variables.
+
+    :param a_4, l_4, d_4: DH parameters for joint 4 (``l_4 = tan(alpha_4/2)``).
+    :param a_5, l_5, d_5: DH parameters for joint 5.
+    :param sigma_E: 8-vec Study DQ of the target end-effector pose. Caller
+        must absorb the joint-6 EE offset into ``sigma_E`` (since this
+        function assumes ``a_6 = d_6 = l_6 = 0`` per Capco's convention).
+    :param v_6: tan-half-angle of joint-6 rotation.
+
+    Precondition: ``a_5 != 0 ∧ l_5 != 0`` (mirrors V_1's eq. 5
+    precondition, transposed for the right chain).
+
+    Returns a 4x8 array; each row is the coefficients of ``(x_0, ..., y_3)``
+    in one of four hyperplanes that vanish on
+    ``V_R = sigma_E . sigma_6^{-1} . sigma_5^{-1} . sigma_4^{-1}``.
+    """
+    coeffs_pre_sigma_e = tv1_hyperplanes_rrr(
+        a_1=-a_5,
+        l_1=-l_5,
+        d_2=-d_5,
+        a_2=-a_4,
+        l_2=-l_4,
+        d_3=-d_4,
+        a_3=0.0,
+        l_3=0.0,
+        v_1=-v_6,
+    )
+    sigma_e_arr = np.asarray(sigma_E, dtype=np.float64)
+    if sigma_e_arr.shape != (8,):
+        raise ValueError(f"sigma_E must be 8-vec, got shape {sigma_e_arr.shape}")
+    sigma_e_conj = np.array(
+        [
+            sigma_e_arr[0],
+            -sigma_e_arr[1],
+            -sigma_e_arr[2],
+            -sigma_e_arr[3],
+            sigma_e_arr[4],
+            -sigma_e_arr[5],
+            -sigma_e_arr[6],
+            -sigma_e_arr[7],
+        ],
+        dtype=np.float64,
+    )
+    M_e = _dq_left_mult_matrix(sigma_e_conj)
+    return coeffs_pre_sigma_e @ M_e

--- a/tests/test_husty_pfurner_constraints.py
+++ b/tests/test_husty_pfurner_constraints.py
@@ -31,6 +31,7 @@ from ssik.solvers.husty_pfurner._constraints import (
     hyperplane_residuals,
     tv1_hyperplanes_rrr,
     tv3_hyperplanes_rrr,
+    tv6_hyperplanes_rrr,
     v1_hyperplanes_rrr,
 )
 from ssik.solvers.husty_pfurner._study import dq_mul
@@ -811,3 +812,439 @@ def test_tv3_shape() -> None:
     )
     assert coeffs.shape == (4, 8)
     assert coeffs.dtype == np.float64
+
+
+# ============================================================================
+# Phase 5d step 1: T(v_6) -- right-chain hyperplanes parametrised by joint 6.
+# ============================================================================
+#
+# Capco eq. (6) constructs T(v_6) from T(v_1) via parameter substitutions
+# + a final sigma_E^* change of variables. Conventions assumed by
+# tv6_hyperplanes_rrr: a_6 = d_6 = l_6 = 0 (caller absorbs joint-6 EE
+# offset into sigma_E by left-multiplying).
+#
+# Bulletproof property: for ANY q_star = (v_1, v_2, v_3, v_4, v_5, v_6) and
+# DH parameters with a_5, l_5 != 0, the T(v_6) hyperplanes vanish on the
+# left-chain DQ tau = sigma_1(v_1) sigma_2(v_2) sigma_3(v_3) when sigma_E
+# is the full 6R chain DQ at q_star.
+
+
+def _full_6r_chain_dq(
+    v_1: float,
+    a_1: float,
+    l_1: float,
+    d_2: float,
+    v_2: float,
+    a_2: float,
+    l_2: float,
+    v_3: float,
+    d_3: float,
+    a_3: float,
+    l_3: float,
+    v_4: float,
+    d_4: float,
+    a_4: float,
+    l_4: float,
+    v_5: float,
+    d_5: float,
+    a_5: float,
+    l_5: float,
+    v_6: float,
+) -> np.ndarray:
+    """Full 6R chain DQ: ``sigma_1 sigma_2 sigma_3 sigma_4 sigma_5 sigma_6``
+    with ``a_6 = d_6 = l_6 = 0`` (sigma_6 = R_z(v_6) only).
+    """
+    sigma_1 = dq_mul(_rz_dq(v_1), dq_mul(_tx_dq(a_1), _rx_dq(l_1)))
+    sigma_2 = dq_mul(
+        _rz_dq(v_2),
+        dq_mul(_tz_dq(d_2), dq_mul(_tx_dq(a_2), _rx_dq(l_2))),
+    )
+    sigma_3 = dq_mul(
+        _rz_dq(v_3),
+        dq_mul(_tz_dq(d_3), dq_mul(_tx_dq(a_3), _rx_dq(l_3))),
+    )
+    sigma_4 = dq_mul(
+        _rz_dq(v_4),
+        dq_mul(_tz_dq(d_4), dq_mul(_tx_dq(a_4), _rx_dq(l_4))),
+    )
+    sigma_5 = dq_mul(
+        _rz_dq(v_5),
+        dq_mul(_tz_dq(d_5), dq_mul(_tx_dq(a_5), _rx_dq(l_5))),
+    )
+    sigma_6 = _rz_dq(v_6)  # a_6 = d_6 = l_6 = 0
+    return dq_mul(
+        sigma_1,
+        dq_mul(sigma_2, dq_mul(sigma_3, dq_mul(sigma_4, dq_mul(sigma_5, sigma_6)))),
+    )
+
+
+@pytest.mark.parametrize("seed", list(range(10)))
+def test_tv6_hyperplanes_vanish_on_left_chain_dq(seed: int) -> None:
+    """T(v_6) hyperplanes vanish on the LEFT chain DQ when sigma_E is the
+    full 6R FK pose.
+
+    Setup: pick random (DH, q_star). Compute sigma_E = full 6R FK DQ.
+    The LEFT-chain DQ tau = sigma_1 sigma_2 sigma_3 belongs to V_L AND
+    to V_R = sigma_E sigma_6^{-1} sigma_5^{-1} sigma_4^{-1} (they coincide
+    at the IK solution by construction). T(v_6) is the V_R 3-space, so
+    its hyperplanes must vanish on tau.
+    """
+    rng = np.random.default_rng(seed + 400)
+    a_1 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+    l_1 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+    d_2 = float(rng.uniform(-1.0, 1.0))
+    a_2 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+    l_2 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+    d_3 = float(rng.uniform(-1.0, 1.0))
+    a_3 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+    l_3 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+    d_4 = float(rng.uniform(-1.0, 1.0))
+    a_4 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+    l_4 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+    d_5 = float(rng.uniform(-1.0, 1.0))
+    a_5 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+    l_5 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+
+    v_1 = float(rng.uniform(-2.0, 2.0))
+    v_2 = float(rng.uniform(-2.0, 2.0))
+    v_3 = float(rng.uniform(-2.0, 2.0))
+    v_4 = float(rng.uniform(-2.0, 2.0))
+    v_5 = float(rng.uniform(-2.0, 2.0))
+    v_6 = float(rng.uniform(-2.0, 2.0))
+
+    sigma_E = _full_6r_chain_dq(
+        v_1,
+        a_1,
+        l_1,
+        d_2,
+        v_2,
+        a_2,
+        l_2,
+        v_3,
+        d_3,
+        a_3,
+        l_3,
+        v_4,
+        d_4,
+        a_4,
+        l_4,
+        v_5,
+        d_5,
+        a_5,
+        l_5,
+        v_6,
+    )
+
+    # tau = sigma_1 sigma_2 sigma_3 (left chain only)
+    tau = _vl_chain_rrr(v_1, a_1, l_1, d_2, v_2, a_2, l_2, v_3, d_3, a_3, l_3)
+
+    coeffs = tv6_hyperplanes_rrr(a_4, l_4, d_4, a_5, l_5, d_5, sigma_E, v_6)
+    residuals = hyperplane_residuals(coeffs, tau)
+    sigma_norm = float(np.linalg.norm(tau))
+    row_norms = np.linalg.norm(coeffs, axis=1)
+    expected_scales = np.maximum(row_norms * sigma_norm, 1e-12)
+    relative = np.abs(residuals) / expected_scales
+    assert np.all(relative < 1e-10), (
+        f"seed={seed}: max relative residual={float(np.max(relative)):.2e}, "
+        f"absolute={residuals}, scales={expected_scales}"
+    )
+
+
+@pytest.mark.parametrize("v_4", [-1.0, 0.0, 0.7, 1.5])
+@pytest.mark.parametrize("v_5", [-1.0, 0.0, 0.7, 1.5])
+def test_tv6_invariant_under_v4_v5_changes(v_4: float, v_5: float) -> None:
+    """Fix DH and v_6; vary v_4, v_5 across V_R's other free parameters.
+    T(v_6) coefficients are independent of (v_4, v_5) by construction;
+    every V_L pose at the corresponding sigma_E must satisfy them.
+    """
+    a_1, l_1, d_2 = 0.5, 0.4, 0.1
+    a_2, l_2 = 0.6, 0.3
+    d_3, a_3, l_3 = 0.2, 0.4, 0.5
+    d_4, a_4, l_4 = 0.15, 0.45, 0.55
+    d_5, a_5, l_5 = 0.18, 0.5, 0.45
+    v_1, v_2, v_3, v_6 = 0.3, -0.4, 0.5, 0.7
+
+    sigma_E = _full_6r_chain_dq(
+        v_1,
+        a_1,
+        l_1,
+        d_2,
+        v_2,
+        a_2,
+        l_2,
+        v_3,
+        d_3,
+        a_3,
+        l_3,
+        v_4,
+        d_4,
+        a_4,
+        l_4,
+        v_5,
+        d_5,
+        a_5,
+        l_5,
+        v_6,
+    )
+    tau = _vl_chain_rrr(v_1, a_1, l_1, d_2, v_2, a_2, l_2, v_3, d_3, a_3, l_3)
+    coeffs = tv6_hyperplanes_rrr(a_4, l_4, d_4, a_5, l_5, d_5, sigma_E, v_6)
+    residuals = hyperplane_residuals(coeffs, tau)
+    sigma_norm = float(np.linalg.norm(tau))
+    row_norms = np.linalg.norm(coeffs, axis=1)
+    expected_scales = np.maximum(row_norms * sigma_norm, 1e-12)
+    relative = np.abs(residuals) / expected_scales
+    assert np.all(relative < 1e-10), (
+        f"v_4={v_4}, v_5={v_5}: max relative={float(np.max(relative)):.2e}"
+    )
+
+
+@given(
+    a_1=_safe_dh,
+    s_a1=_sign,
+    alpha_1=_safe_alpha,
+    d_2=_safe_dist,
+    a_2=_safe_dh,
+    s_a2=_sign,
+    alpha_2=_safe_alpha,
+    d_3=_safe_dist,
+    a_3=_safe_dh,
+    s_a3=_sign,
+    alpha_3=_safe_alpha,
+    d_4=_safe_dist,
+    a_4=_safe_dh,
+    s_a4=_sign,
+    alpha_4=_safe_alpha,
+    d_5=_safe_dist,
+    a_5=_safe_dh,
+    s_a5=_sign,
+    alpha_5=_safe_alpha,
+    v_1=_safe_q,
+    v_2=_safe_q,
+    v_3=_safe_q,
+    v_4=_safe_q,
+    v_5=_safe_q,
+    v_6=_safe_q,
+)
+@settings(
+    max_examples=500,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_tv6_hypothesis_fuzz_500_examples(
+    a_1: float,
+    s_a1: float,
+    alpha_1: float,
+    d_2: float,
+    a_2: float,
+    s_a2: float,
+    alpha_2: float,
+    d_3: float,
+    a_3: float,
+    s_a3: float,
+    alpha_3: float,
+    d_4: float,
+    a_4: float,
+    s_a4: float,
+    alpha_4: float,
+    d_5: float,
+    a_5: float,
+    s_a5: float,
+    alpha_5: float,
+    v_1: float,
+    v_2: float,
+    v_3: float,
+    v_4: float,
+    v_5: float,
+    v_6: float,
+) -> None:
+    """Bulletproof gate for T(v_6): 500 (DH, q) combos across full alpha
+    range; relative tolerance 1e-12. Sigma_E built from full 6R FK; T(v_6)
+    hyperplanes vanish on the left-chain DQ.
+    """
+    a_1_signed = s_a1 * a_1
+    a_2_signed = s_a2 * a_2
+    a_3_signed = s_a3 * a_3
+    a_4_signed = s_a4 * a_4
+    a_5_signed = s_a5 * a_5
+    l_1 = math.tan(0.5 * alpha_1)
+    l_2 = math.tan(0.5 * alpha_2)
+    l_3 = math.tan(0.5 * alpha_3)
+    l_4 = math.tan(0.5 * alpha_4)
+    l_5 = math.tan(0.5 * alpha_5)
+
+    sigma_E = _full_6r_chain_dq(
+        v_1,
+        a_1_signed,
+        l_1,
+        d_2,
+        v_2,
+        a_2_signed,
+        l_2,
+        v_3,
+        d_3,
+        a_3_signed,
+        l_3,
+        v_4,
+        d_4,
+        a_4_signed,
+        l_4,
+        v_5,
+        d_5,
+        a_5_signed,
+        l_5,
+        v_6,
+    )
+    tau = _vl_chain_rrr(v_1, a_1_signed, l_1, d_2, v_2, a_2_signed, l_2, v_3, d_3, a_3_signed, l_3)
+    coeffs = tv6_hyperplanes_rrr(a_4_signed, l_4, d_4, a_5_signed, l_5, d_5, sigma_E, v_6)
+    residuals = hyperplane_residuals(coeffs, tau)
+    sigma_norm = float(np.linalg.norm(tau))
+    row_norms = np.linalg.norm(coeffs, axis=1)
+    expected_scales = np.maximum(row_norms * sigma_norm, 1e-12)
+    relative = np.abs(residuals) / expected_scales
+    assert np.all(relative < 1e-12), (
+        f"max relative residual={float(np.max(relative)):.2e}; "
+        f"absolute={residuals}, scales={expected_scales}"
+    )
+
+
+def test_tv6_independent_path_agrees() -> None:
+    """T(v_6) lambdified path agrees with direct V_R computation.
+
+    Path A: tv6_hyperplanes_rrr(DH, sigma_E, v_6) @ tau (where tau is the
+    LEFT-chain DQ, which equals V_R-points by the IK relation).
+
+    Path B: build V_R explicitly via numerical conjugation:
+    tau_R = sigma_E . sigma_6^{-1} . sigma_5^{-1} . sigma_4^{-1}.
+    Apply T(v_1)-with-substitutions hyperplanes to tau_R (path BEFORE the
+    sigma_E^* change of variables). Should also vanish.
+
+    Both paths vanish on V_R points; agreement at 1e-9.
+    """
+    rng = np.random.default_rng(500)
+    for _ in range(20):
+        a_1 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+        l_1 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+        d_2 = float(rng.uniform(-1.0, 1.0))
+        a_2 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+        l_2 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+        d_3 = float(rng.uniform(-1.0, 1.0))
+        a_3 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+        l_3 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+        d_4 = float(rng.uniform(-1.0, 1.0))
+        a_4 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+        l_4 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+        d_5 = float(rng.uniform(-1.0, 1.0))
+        a_5 = float(rng.uniform(0.1, 1.5)) * float(rng.choice([-1.0, 1.0]))
+        l_5 = math.tan(0.5 * float(rng.uniform(0.1, math.pi - 0.1)))
+        v_1 = float(rng.uniform(-2.0, 2.0))
+        v_2 = float(rng.uniform(-2.0, 2.0))
+        v_3 = float(rng.uniform(-2.0, 2.0))
+        v_4 = float(rng.uniform(-2.0, 2.0))
+        v_5 = float(rng.uniform(-2.0, 2.0))
+        v_6 = float(rng.uniform(-2.0, 2.0))
+
+        sigma_E = _full_6r_chain_dq(
+            v_1,
+            a_1,
+            l_1,
+            d_2,
+            v_2,
+            a_2,
+            l_2,
+            v_3,
+            d_3,
+            a_3,
+            l_3,
+            v_4,
+            d_4,
+            a_4,
+            l_4,
+            v_5,
+            d_5,
+            a_5,
+            l_5,
+            v_6,
+        )
+        tau = _vl_chain_rrr(v_1, a_1, l_1, d_2, v_2, a_2, l_2, v_3, d_3, a_3, l_3)
+
+        # Path A: lambdified tv6_hyperplanes_rrr.
+        coeffs_a = tv6_hyperplanes_rrr(a_4, l_4, d_4, a_5, l_5, d_5, sigma_E, v_6)
+        residuals_a = coeffs_a @ tau
+
+        # Path B: apply sigma_E^* to tau (tau is the V_L pose, which equals
+        # sigma_E (full chain) at IK; sigma_E^* @ tau lands in V_R-pre-
+        # change-of-variables coordinates), then apply substituted T(v_1).
+        sigma_E_conj = _dq_conj_numpy(sigma_E)
+        # tau_R = sigma_E^* @ tau (== V_R-pre-sigma_E version of the IK pose)
+        tau_R = dq_mul(sigma_E_conj, tau)
+        coeffs_b = tv1_hyperplanes_rrr(
+            a_1=-a_5,
+            l_1=-l_5,
+            d_2=-d_5,
+            a_2=-a_4,
+            l_2=-l_4,
+            d_3=-d_4,
+            a_3=0.0,
+            l_3=0.0,
+            v_1=-v_6,
+        )
+        residuals_b = coeffs_b @ tau_R
+
+        assert np.allclose(residuals_a, 0.0, atol=1e-9), f"path A residuals: {residuals_a}"
+        assert np.allclose(residuals_b, 0.0, atol=1e-9), f"path B residuals: {residuals_b}"
+
+
+def test_tv6_at_identity_sigma_e_collapses_to_substituted_v1() -> None:
+    """When ``sigma_E = (1, 0, 0, 0, 0, 0, 0, 0)`` (identity DQ), the
+    sigma_E^* change of variables is identity, so T(v_6) reduces to
+    the substituted T(v_1). Sanity check on the wiring.
+    """
+    a_4, l_4, d_4 = 0.45, 0.55, 0.15
+    a_5, l_5, d_5 = 0.5, 0.45, 0.18
+    v_6 = 0.7
+    sigma_E_identity = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+    coeffs_tv6 = tv6_hyperplanes_rrr(a_4, l_4, d_4, a_5, l_5, d_5, sigma_E_identity, v_6)
+    coeffs_tv1_sub = tv1_hyperplanes_rrr(
+        a_1=-a_5,
+        l_1=-l_5,
+        d_2=-d_5,
+        a_2=-a_4,
+        l_2=-l_4,
+        d_3=-d_4,
+        a_3=0.0,
+        l_3=0.0,
+        v_1=-v_6,
+    )
+    assert np.allclose(coeffs_tv6, coeffs_tv1_sub, atol=1e-15)
+
+
+def test_tv6_shape() -> None:
+    sigma_E = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5], dtype=np.float64)
+    coeffs = tv6_hyperplanes_rrr(
+        a_4=0.5,
+        l_4=0.4,
+        d_4=0.1,
+        a_5=0.6,
+        l_5=0.3,
+        d_5=0.2,
+        sigma_E=sigma_E,
+        v_6=0.0,
+    )
+    assert coeffs.shape == (4, 8)
+    assert coeffs.dtype == np.float64
+
+
+def test_tv6_rejects_wrong_shape_sigma_e() -> None:
+    """sigma_E must be 8-vec; otherwise raise ValueError."""
+    with pytest.raises(ValueError, match="sigma_E must be 8-vec"):
+        tv6_hyperplanes_rrr(
+            a_4=0.5,
+            l_4=0.4,
+            d_4=0.1,
+            a_5=0.6,
+            l_5=0.3,
+            d_5=0.2,
+            sigma_E=np.zeros(7),  # wrong shape
+            v_6=0.0,
+        )


### PR DESCRIPTION
## Summary

Phase 5d step 1: T(v_6) parametrises the right-chain workspace ``V_R = σ_E σ_6⁻¹ σ_5⁻¹ σ_4⁻¹`` by joint v_6. **First piece of the elimination pipeline** that closes the IK problem.

Reuses the lambdified ``T(v_1)`` machinery via Capco eq. (6) parameter substitutions, then applies a numerical ``σ_E^* @ σ`` change of variables. ~4 µs per call.

## What's in this PR

**``_constraints.py``**:
- ``_quat_left_mult_matrix(p)`` — 4×4 L(p) with ``L(p) @ q = p * q``.
- ``_dq_left_mult_matrix(η)`` — 8×8 dual-quaternion left-mult matrix with the standard block structure.
- ``tv6_hyperplanes_rrr(a_4, l_4, d_4, a_5, l_5, d_5, σ_E, v_6) → (4, 8)``.
- Convention: ``a_6 = d_6 = l_6 = 0`` (caller absorbs joint-6 EE offset into σ_E).
- Precondition: ``a_5 ≠ 0 ∧ l_5 ≠ 0`` (mirrors V_1 eq. 5).

## Bulletproof tests (31 new, 379 total in file)

| Test class | Bar |
|---|---|
| Hand-derivation: σ_E = identity → T(v_6) = substituted T(v_1) | 1e-15 |
| Random-seed (10 cases) | Relative 1e-10 |
| **Hypothesis fuzz (500 examples)** full alpha range | **Relative tolerance < 1e-12** |
| (v_4, v_5) invariance (16 cases) | Relative 1e-10 |
| Independent-path cross-validation (20 seeds) | 1e-9 |
| Shape + rejects wrong-shape σ_E | strict |

## Test plan

- [x] ``uv run pytest tests/test_husty_pfurner_constraints.py`` — 379/379 pass
- [x] ``uv run mypy`` — clean (124 source files)
- [x] ``uv run ruff check`` + format — clean

## Algorithmic reference

Capco, Loquias, Manongsong, Nemenzo (2019), arXiv 1906.07813, **equation (6)** (right-chain transformation).

## What's next for Phase 5d

1. Combine T(u) + T(w) into 8×8 linear system over C(u, w).
2. Pick 7-of-8 hyperplanes, solve for P(u, w).
3. Substitute P into Study quadric → bivariate f(u, w).
4. Substitute P into 8th hyperplane → bivariate g(u, w).
5. Resultant of f, g w.r.t. w → univariate r(u). For pure 6R, degree 16.

The elimination pipeline is the algorithm's heart; remaining work after this PR (5d steps 2–6 + 5e + 5f + 5g) is mechanical.

## Related

- #166, #167, #169, #171: Phase 5b, 5c.1, 5c.2, 5c.3 (all merged)
- #158 strategic, #162 plan