### PR TITLE
#162: Phase 5f -- HP back-substitution + FK closure (full 6R IK working)

### DIFF
--- a/src/ssik/solvers/husty_pfurner/_back_substitute.py
+++ b/src/ssik/solvers/husty_pfurner/_back_substitute.py
@@ -1,0 +1,402 @@
+"""Back-substitution for the Husty-Pfurner universal-6R IK solver.
+
+Phase 5f of #162. Given a candidate ``(v_1, v_6) = (u, w)`` from
+:func:`ssik.solvers.husty_pfurner._eliminate.eliminate_uw_pairs`,
+recover the remaining four joint values ``(v_2, v_3, v_4, v_5)`` so
+that the full chain FK matches the target ``sigma_E``.
+
+Algorithm (per Capco et al. 2019 Section 5.4 / Pfurner 2009 ch. 4):
+
+1. Form ``sigma_inner = sigma_1(v_1)^-1 . sigma_E . sigma_6(v_6)^-1``
+   -- a numeric SE(3) factor that the inner four joints must produce.
+2. Recover the Cramer cofactor ``P(u, w)`` as a numeric 8-vec at the
+   refined ``(u, w)``. Algebraically ``P = sigma_1(v_1) . sigma_2 .
+   sigma_3 = sigma_E . sigma_6(v_6)^-1 . sigma_5^-1 . sigma_4^-1``,
+   so it gives the F_4 split-frame Study DQ.
+3. Two 2R sub-chains:
+
+   - ``sigma_2(v_2) sigma_3(v_3) = sigma_1(u)^-1 . P``: solve for
+     ``(v_2, v_3)``.
+   - ``sigma_4(v_4) sigma_5(v_5) = P^-1 . sigma_E . sigma_6(w)^-1``:
+     solve for ``(v_4, v_5)``.
+4. Each 2R subproblem decomposes via closed-form ZXZ-like atan2
+   (``alpha_a``, ``alpha_b`` are known DH twists; only the two
+   ``v_a``, ``v_b`` rotations are free).
+5. FK closure check: ``||FK(v_1, v_2, v_3, v_4, v_5, v_6) - sigma_E||``
+   below machine eps in projective Study norm. Candidates that fail
+   are spurious algebraic solutions (e.g. multiplicity-cluster
+   members that don't quite satisfy the original chain equation).
+
+The output is the list of full IK solutions, each polished to
+machine precision and FK-verified.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik.solvers.husty_pfurner._eliminate import (
+    EliminatePrecompute,
+    _apply_sigma_e_to_tw_pre,
+    _build_full_8x8,
+    eliminate_uw_pairs,
+)
+from ssik.solvers.husty_pfurner._study import dq_conj, dq_mul, se3_from_dq
+
+__all__ = [
+    "back_substitute_one",
+    "solve_ik",
+]
+
+
+# =============================================================================
+# Joint Study DQ primitives.
+# =============================================================================
+
+
+def _sigma_z(v: float) -> NDArray[np.float64]:
+    """Projective Study DQ of ``R_z(theta)`` with ``v = tan(theta/2)``."""
+    return np.array([1.0, 0.0, 0.0, v, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+
+def _sigma_tx(a: float) -> NDArray[np.float64]:
+    """Projective Study DQ of ``T_x(a)``."""
+    return np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.5 * a, 0.0, 0.0], dtype=np.float64)
+
+
+def _sigma_tz(d: float) -> NDArray[np.float64]:
+    """Projective Study DQ of ``T_z(d)``."""
+    return np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5 * d], dtype=np.float64)
+
+
+def _sigma_rx(twist: float) -> NDArray[np.float64]:
+    """Projective Study DQ of ``R_x(alpha)`` with ``twist = tan(alpha/2)``."""
+    return np.array([1.0, twist, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+
+def _sigma_joint_full(v: float, a: float, ls: float, d: float) -> NDArray[np.float64]:
+    """Projective Study DQ of one full DH joint:
+    ``R_z(v) . T_z(d) . T_x(a) . R_x(ls)`` where ``v = tan(theta/2)``
+    and ``ls = tan(alpha/2)``.
+    """
+    return dq_mul(
+        _sigma_z(v),
+        dq_mul(_sigma_tz(d), dq_mul(_sigma_tx(a), _sigma_rx(ls))),
+    )
+
+
+def _dq_inv(sigma: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Projective Study DQ inverse: for unit-norm ``sigma`` this is
+    just the conjugate; for projective (non-unit-norm) inputs, scale
+    by ``1/||sigma_p||^2`` afterwards. We'll work in projective form
+    and rely on ``dq_mul``'s scale-invariance (the chain product is
+    a projective DQ that gets normalised at FK closure check time).
+    """
+    return dq_conj(sigma)
+
+
+# =============================================================================
+# 2R sub-chain decomposition.
+# =============================================================================
+
+
+def _solve_2r_chain(
+    T_target: NDArray[np.float64],
+    a_a: float,
+    ls_a: float,
+    d_a: float,
+    a_b: float,
+    ls_b: float,
+    d_b: float,
+    *,
+    rot_tol: float = 1e-8,
+) -> list[tuple[float, float]]:
+    """Recover ``(v_a, v_b)`` from a 2R chain target.
+
+    Chain: ``sigma_a(v_a) sigma_b(v_b) = sigma_target``, where each
+    ``sigma_i(v_i) = R_z(v_i) T_z(d_i) T_x(a_i) R_x(alpha_i)``,
+    ``v_i = tan(theta_i/2)``, ``ls_i = tan(alpha_i/2)``.
+
+    Strategy: extract the 3x3 rotation ``R_target`` from the SE(3)
+    matrix, reduce to a 2-DOF ZXZ-like decomposition by undoing the
+    fixed ``alpha_b`` and ``d_b`` factors, then atan2 for each
+    ``v_i``. The translation part of ``T_target`` is used as a
+    consistency check (Phase 5f's FK closure handles full check).
+
+    :param T_target: 4x4 SE(3) target matrix.
+    :param a_a, ls_a, d_a: DH for joint a.
+    :param a_b, ls_b, d_b: DH for joint b.
+    :param rot_tol: gimbal-lock detection tolerance on
+        ``cos(alpha_a) - R'[2, 2]``.
+
+    :returns: list of ``(v_a, v_b)`` solutions (typically 1 in
+        non-degenerate cases; near gimbal lock there may be a
+        1-parameter family that we sample with a single representative
+        value from atan2). FK closure in :func:`solve_ik` filters
+        anyway.
+    """
+    R = T_target[:3, :3]
+
+    # Undo the fixed R_x(alpha_b) on the right of the chain:
+    # R · R_x(-alpha_b) = R_z(v_a) R_x(alpha_a) R_z(v_b).
+    # tan(alpha_b/2) = ls_b -> sin(alpha_b) = 2*ls_b / (1 + ls_b^2),
+    # cos(alpha_b) = (1 - ls_b^2) / (1 + ls_b^2).
+    denom_b = 1.0 + ls_b * ls_b
+    sa_b = 2.0 * ls_b / denom_b
+    ca_b = (1.0 - ls_b * ls_b) / denom_b
+    Rx_neg_alpha_b = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, ca_b, sa_b],
+            [0.0, -sa_b, ca_b],
+        ],
+        dtype=np.float64,
+    )
+    R_prime = R @ Rx_neg_alpha_b
+
+    denom_a = 1.0 + ls_a * ls_a
+    sa_a = 2.0 * ls_a / denom_a
+    ca_a = (1.0 - ls_a * ls_a) / denom_a
+
+    # R_prime e_z = R_z(v_a) R_x(alpha_a) e_z = (sa_a sin v_a, -sa_a cos v_a, ca_a).
+    rxz, ryz, rzz = float(R_prime[0, 2]), float(R_prime[1, 2]), float(R_prime[2, 2])
+
+    # Consistency: rzz should equal ca_a. Discrepancy indicates the
+    # 2R chain target is unreachable -- caller's (u, w) candidate is
+    # spurious. Return empty so FK closure rejects it.
+    if abs(rzz - ca_a) > rot_tol * max(1.0, abs(ca_a)):
+        return []
+
+    if abs(sa_a) < rot_tol:
+        # Gimbal lock: alpha_a = 0 or pi. v_a is degenerate; pick 0.0.
+        v_a = 0.0
+        R_double = R_prime
+    else:
+        # rxz = sa_a sin theta_a, -ryz = sa_a cos theta_a. Hence
+        # sin theta_a = rxz / sa_a, cos theta_a = -ryz / sa_a.
+        # atan2 is sign-sensitive in both args; for sa_a < 0 we need
+        # atan2(rxz/sa_a, -ryz/sa_a) which equals atan2(-rxz, ryz).
+        sign_sa_a = 1.0 if sa_a > 0.0 else -1.0
+        theta_a = float(np.arctan2(rxz * sign_sa_a, -ryz * sign_sa_a))
+        v_a = float(np.tan(0.5 * theta_a))
+
+        # Compute R'' = R_x(-alpha_a) R_z(-theta_a) R_prime.
+        c_va, s_va = np.cos(theta_a), np.sin(theta_a)
+        Rz_neg_va = np.array(
+            [[c_va, s_va, 0.0], [-s_va, c_va, 0.0], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
+        Rx_neg_alpha_a = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, ca_a, sa_a],
+                [0.0, -sa_a, ca_a],
+            ],
+            dtype=np.float64,
+        )
+        R_double = Rx_neg_alpha_a @ Rz_neg_va @ R_prime
+
+    # Recover v_b from R_double = R_z(theta_b).
+    theta_b = float(np.arctan2(R_double[1, 0], R_double[0, 0]))
+    v_b = float(np.tan(0.5 * theta_b))
+
+    return [(v_a, v_b)]
+
+
+# =============================================================================
+# Back-substitution and full IK.
+# =============================================================================
+
+
+def _build_dh_dict(pre: EliminatePrecompute) -> dict[str, float]:
+    """Recover the DH parameters that built ``pre`` by extracting them
+    from the ``T_u`` and ``T_w_pre`` tensors. (Or, more practically,
+    require the caller to pass them explicitly -- we'll do the latter.)
+    """
+    raise NotImplementedError(
+        "DH parameters cannot be reconstructed from EliminatePrecompute; "
+        "caller must provide them explicitly via dh_kwargs to solve_ik."
+    )
+
+
+def _cramer_P_at(
+    pre: EliminatePrecompute,
+    sigma_E: NDArray[np.float64],
+    u: float,
+    w: float,
+    drop_idx: int = 7,
+) -> NDArray[np.float64]:
+    """Evaluate the Cramer cofactor 8-vec ``P(u, w)`` at the refined
+    ``(u, w)``. Constructs the 8x8 system, takes the 7-of-8 sub-block,
+    computes ``[det(A), x_1*det(A), ..., x_7*det(A)]`` where
+    ``x = A^{-1} (-col_0)``.
+
+    Algebraically this matches what
+    :func:`ssik.solvers.husty_pfurner._eliminate._cramer_8vec_via_interp`
+    produces, evaluated at one specific ``(u, w)`` (not the whole
+    bivariate polynomial tensor).
+    """
+    sigma_E_arr = np.asarray(sigma_E, dtype=np.float64)
+    T_w = _apply_sigma_e_to_tw_pre(pre.T_w_pre, sigma_E_arr)
+    M_full = _build_full_8x8(pre.T_u, T_w, u, w)
+    keep = [i for i in range(8) if i != drop_idx]
+    M_7 = M_full[keep]
+    A = M_7[:, 1:]
+    rhs = -M_7[:, 0]
+    x = np.linalg.solve(A, rhs)
+    d = float(np.linalg.det(A))
+    P = np.empty(8, dtype=np.float64)
+    P[0] = d
+    P[1:] = x * d
+    return P
+
+
+def back_substitute_one(
+    pre: EliminatePrecompute,
+    sigma_E: NDArray[np.float64],
+    u: float,
+    w: float,
+    *,
+    a_1: float,
+    ls_1: float,
+    d_2: float,
+    a_2: float,
+    ls_2: float,
+    d_3: float,
+    a_3: float,
+    ls_3: float,
+    d_4: float,
+    a_4: float,
+    ls_4: float,
+    d_5: float,
+    a_5: float,
+    ls_5: float,
+) -> list[tuple[float, float, float, float]]:
+    """Recover ``(v_2, v_3, v_4, v_5)`` for one ``(u, w)`` candidate.
+
+    See module docstring for the algorithm. Returns a list because
+    each 2R sub-decomposition can in principle yield multiple
+    branches (though in this DH convention the closed-form atan2
+    yields a single solution per sub-chain; near gimbal lock there
+    is a 1-parameter family that we represent by a single sample).
+
+    Caller must pass DH parameters explicitly because the
+    ``EliminatePrecompute`` tensors don't preserve them in a
+    recoverable form.
+    """
+    # Build sigma_1(u) and sigma_6(w).
+    sigma_1 = _sigma_joint_full(u, a_1, ls_1, 0.0)  # joint 1: a_6 = d_6 = l_6 = 0 convention
+    sigma_6 = _sigma_z(w)
+
+    # Recover the Cramer cofactor P(u, w) at this refined point.
+    P = _cramer_P_at(pre, sigma_E, u, w)
+
+    # Compute the two 2R chain targets:
+    #   sigma_left  = sigma_2(v_2) sigma_3(v_3) = sigma_1(u)^-1 . P
+    #   sigma_right = sigma_4(v_4) sigma_5(v_5) = P^-1 . sigma_E . sigma_6(w)^-1
+    sigma_left = dq_mul(_dq_inv(sigma_1), P)
+    sigma_right = dq_mul(_dq_inv(P), dq_mul(sigma_E, _dq_inv(sigma_6)))
+
+    # Convert each to SE(3) and decompose.
+    T_left = se3_from_dq(sigma_left)
+    T_right = se3_from_dq(sigma_right)
+
+    sols_23 = _solve_2r_chain(T_left, a_2, ls_2, d_2, a_3, ls_3, d_3)
+    sols_45 = _solve_2r_chain(T_right, a_4, ls_4, d_4, a_5, ls_5, d_5)
+
+    return [(v_2, v_3, v_4, v_5) for (v_2, v_3) in sols_23 for (v_4, v_5) in sols_45]
+
+
+def solve_ik(
+    pre: EliminatePrecompute,
+    sigma_E: NDArray[np.float64],
+    *,
+    a_1: float,
+    ls_1: float,
+    d_2: float,
+    a_2: float,
+    ls_2: float,
+    d_3: float,
+    a_3: float,
+    ls_3: float,
+    d_4: float,
+    a_4: float,
+    ls_4: float,
+    d_5: float,
+    a_5: float,
+    ls_5: float,
+    fk_tol: float = 1e-8,
+) -> NDArray[np.float64]:
+    """Top-level HP IK solver.
+
+    1. Run :func:`eliminate_uw_pairs` to get refined ``(u, w)``
+       candidates.
+    2. For each ``(u, w)``, run :func:`back_substitute_one` to
+       recover ``(v_2, v_3, v_4, v_5)``.
+    3. Filter by FK closure: keep only ``q`` such that the chain
+       FK matches ``sigma_E`` in projective Study norm below
+       ``fk_tol``.
+
+    :returns: 2-D array of shape ``(n, 6)`` with rows
+        ``(v_1, v_2, v_3, v_4, v_5, v_6)``, each tan-half-angle.
+    """
+    pairs = eliminate_uw_pairs(pre, sigma_E)
+    if pairs.size == 0:
+        return np.empty((0, 6), dtype=np.float64)
+
+    sigma_E_arr = np.asarray(sigma_E, dtype=np.float64)
+    sigma_E_norm = float(np.linalg.norm(sigma_E_arr))
+    out: list[list[float]] = []
+
+    for u, w in pairs:
+        candidates = back_substitute_one(
+            pre,
+            sigma_E_arr,
+            float(u),
+            float(w),
+            a_1=a_1,
+            ls_1=ls_1,
+            d_2=d_2,
+            a_2=a_2,
+            ls_2=ls_2,
+            d_3=d_3,
+            a_3=a_3,
+            ls_3=ls_3,
+            d_4=d_4,
+            a_4=a_4,
+            ls_4=ls_4,
+            d_5=d_5,
+            a_5=a_5,
+            ls_5=ls_5,
+        )
+        for v_2, v_3, v_4, v_5 in candidates:
+            # FK closure: build the full 6R chain DQ and compare.
+            sigma_chain = dq_mul(
+                _sigma_joint_full(float(u), a_1, ls_1, 0.0),
+                dq_mul(
+                    _sigma_joint_full(v_2, a_2, ls_2, d_2),
+                    dq_mul(
+                        _sigma_joint_full(v_3, a_3, ls_3, d_3),
+                        dq_mul(
+                            _sigma_joint_full(v_4, a_4, ls_4, d_4),
+                            dq_mul(
+                                _sigma_joint_full(v_5, a_5, ls_5, d_5),
+                                _sigma_z(float(w)),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            # Projective comparison: align scales then compute residual.
+            scale = float(np.dot(sigma_chain, sigma_E_arr)) / max(
+                float(np.dot(sigma_chain, sigma_chain)), 1e-300
+            )
+            residue_abs = float(np.linalg.norm(sigma_chain * scale - sigma_E_arr))
+            residue_rel = residue_abs / max(sigma_E_norm, 1e-300)
+            if residue_rel < fk_tol:
+                out.append([float(u), v_2, v_3, v_4, v_5, float(w)])
+
+    if not out:
+        return np.empty((0, 6), dtype=np.float64)
+    return np.asarray(out, dtype=np.float64)

--- a/src/ssik/solvers/husty_pfurner/_eliminate.py
+++ b/src/ssik/solvers/husty_pfurner/_eliminate.py
@@ -73,6 +73,7 @@ __all__ = [
     "compute_fg_numeric",
     "eliminate_uw",
     "eliminate_uw_numeric",
+    "eliminate_uw_pairs",
     "evaluate_poly",
     "extract_uv_linear_tensor",
     "polynomial_residual",
@@ -627,51 +628,32 @@ def _build_fg_closures(
 _HP_CLUSTER_TOL = 1e-7
 
 
-def eliminate_uw_numeric(
+def eliminate_uw_pairs(
     pre: EliminatePrecompute,
     sigma_E: NDArray[np.float64],
     *,
     drop_indices: tuple[int, ...] = (7, 4, 0),
     residue_tol: float = _NEWTON_RESIDUE_TOL,
 ) -> NDArray[np.float64]:
-    """Run the full HP elimination pipeline on numeric inputs.
+    """Run the HP elimination pipeline; return refined ``(u, w)`` pairs.
 
-    Three-stage architecture, no tunable heuristics in the hot path:
+    Identical pipeline to :func:`eliminate_uw_numeric` but returns the
+    full bivariate candidates, not just the ``u`` projection. Phase 5f
+    back-substitution consumes ``(u, w)`` pairs; the public
+    :func:`eliminate_uw_numeric` wraps this and projects to ``u`` only
+    for callers that need just the ``v_1`` candidates.
 
-    1. **Algebraic coverage** (matrix pencil, 2 drops). Run the
-       Sylvester pencil eigsolve for each ``drop_idx`` in
-       ``drop_indices``. Each drop produces ``O(eps * cond)``
-       approximate ``(u_i, w_i)`` pairs; different drops cover
-       different parts of the V_L cap V_R variety (left-chain
-       rows ``{0..3}`` vs right-chain rows ``{4..7}``). Two
-       drops from complementary blocks guarantee coverage of every
-       IK candidate. Default ``(7, 4)``.
-    2. **Newton refinement** of every candidate against the
-       bivariate residual ``[f(u, w); g(u, w)] = 0`` via the
-       shared :func:`ssik._pencil.newton_refine_system`. Quadratic
-       convergence at simple roots; converges to machine precision
-       in 3 iterations from any pencil starting point at 1e-3.
-    3. **Residue filter + cluster merge**. Drop candidates whose
-       post-Newton residue stays above ``residue_tol`` (spurious
-       eigenvalues from the pencil's null space). Cluster-merge
-       near-duplicates within ``sqrt(float64 eps)`` -- handles
-       multiplicity-k root splits per Wilkinson 1965 and
-       collapses duplicates from the multiple drops.
-
-    :param pre: per-arm precomputed tensors (DH baked).
-    :param sigma_E: 8-vec Study DQ of the target end-effector pose.
-    :param drop_indices: tuple of drop-row indices. Default ``(7, 4)``.
-    :param residue_tol: maximum post-Newton relative residue
-        ``|f(u, w)|/Sigma|f[p,q]||u|^p|w|^q`` for accepted candidates.
-        Default 1e-12 (10 digits under float64 machine epsilon).
-
-    :returns: sorted 1-D array of real candidate ``u = v_1`` values.
+    :returns: 2-D array of shape ``(n, 2)`` with rows
+        ``[u_i, w_i]`` sorted lexicographically by ``u`` then ``w``.
+        Cluster-merging operates in 2-D Euclidean distance, so two
+        candidates at the same ``u`` but different ``w`` are kept
+        separate -- they are physically distinct IK solutions.
     """
     if not drop_indices:
         raise ValueError("drop_indices must be non-empty")
-    from ssik._pencil import cluster_merge_1d, newton_refine_system
+    from ssik._pencil import newton_refine_system
 
-    refined: list[float] = []
+    refined: list[tuple[float, float]] = []
     last_error: Exception | None = None
     for di in drop_indices:
         try:
@@ -700,10 +682,78 @@ def eliminate_uw_numeric(
                 tol=residue_tol,
             )
             if residue < residue_tol:
-                refined.append(float(x_ref[0]))
+                refined.append((float(x_ref[0]), float(x_ref[1])))
     if not refined and last_error is not None:
         raise last_error
-    return np.asarray(cluster_merge_1d(refined, tol=_HP_CLUSTER_TOL), dtype=np.float64)
+    if not refined:
+        return np.empty((0, 2), dtype=np.float64)
+    # Cluster-merge in (u, w) Euclidean space. Multiplicity-k splits and
+    # duplicates from different drops cluster within sqrt(eps); two
+    # genuinely distinct IK solutions stay separate.
+    refined.sort()
+    deduped: list[list[float]] = [list(refined[0])]
+    for uw in refined[1:]:
+        ref = deduped[-1]
+        d2 = (uw[0] - ref[0]) ** 2 + (uw[1] - ref[1]) ** 2
+        scale = 1.0 + abs(ref[0]) + abs(ref[1])
+        if d2 <= (_HP_CLUSTER_TOL * scale) ** 2:
+            # Merge: average into the cluster centroid.
+            ref[0] = 0.5 * (ref[0] + uw[0])
+            ref[1] = 0.5 * (ref[1] + uw[1])
+        else:
+            deduped.append(list(uw))
+    return np.asarray(deduped, dtype=np.float64)
+
+
+def eliminate_uw_numeric(
+    pre: EliminatePrecompute,
+    sigma_E: NDArray[np.float64],
+    *,
+    drop_indices: tuple[int, ...] = (7, 4, 0),
+    residue_tol: float = _NEWTON_RESIDUE_TOL,
+) -> NDArray[np.float64]:
+    """Run the full HP elimination pipeline; return refined ``v_1`` candidates.
+
+    Three-stage architecture, no tunable heuristics in the hot path:
+
+    1. **Algebraic coverage** (matrix pencil, multi-drop). Run the
+       Sylvester pencil eigsolve for each ``drop_idx`` in
+       ``drop_indices``. Each drop produces ``O(eps * cond)``
+       approximate ``(u_i, w_i)`` pairs; different drops cover
+       different parts of the V_L cap V_R variety (left-chain
+       rows ``{0..3}`` vs right-chain rows ``{4..7}``). The default
+       ``(7, 4, 0)`` -- two right-chain + one left-chain -- guarantees
+       coverage of every IK candidate.
+    2. **Newton refinement** of every candidate against the
+       bivariate residual ``[f(u, w); g(u, w)] = 0`` via the
+       shared :func:`ssik._pencil.newton_refine_system`. Quadratic
+       convergence at simple roots.
+    3. **Residue filter + cluster merge**. Drop candidates whose
+       post-Newton residue stays above ``residue_tol`` (spurious
+       eigenvalues). Cluster-merge near-duplicates within
+       ``sqrt(float64 eps)``.
+
+    :param pre: per-arm precomputed tensors (DH baked).
+    :param sigma_E: 8-vec Study DQ of the target end-effector pose.
+    :param drop_indices: tuple of drop-row indices. Default ``(7, 4, 0)``.
+    :param residue_tol: maximum post-Newton relative residue.
+
+    :returns: sorted 1-D array of real candidate ``u = v_1`` values.
+    """
+    pairs = eliminate_uw_pairs(
+        pre, sigma_E, drop_indices=drop_indices, residue_tol=residue_tol
+    )
+    if pairs.size == 0:
+        return np.asarray([], dtype=np.float64)
+    # Project to u only; re-cluster in 1-D since two pairs at the same u
+    # but different w (genuinely distinct IK solutions) collapse to a
+    # single u value.
+    from ssik._pencil import cluster_merge_1d
+
+    return np.asarray(
+        cluster_merge_1d(pairs[:, 0].tolist(), tol=_HP_CLUSTER_TOL),
+        dtype=np.float64,
+    )
 
 
 # =============================================================================

--- a/tests/test_husty_pfurner_back_substitute.py
+++ b/tests/test_husty_pfurner_back_substitute.py
@@ -1,0 +1,270 @@
+"""Bulletproof validation for the Husty-Pfurner back-substitution layer.
+
+Phase 5f of #158/#162. Validates that
+:func:`ssik.solvers.husty_pfurner._back_substitute.solve_ik` produces
+joint-tuples ``(v_1, ..., v_6)`` that:
+
+1. Include the FK-truth ``q*`` for every (DH, q) test config.
+2. Each returned tuple FK-closes to ``sigma_E`` at machine precision.
+3. The returned set of tuples are physically distinct IK solutions
+   (no duplicates within machine precision).
+
+Tolerance philosophy mirrors Phase 5d: hand-picked configs at
+``1e-10`` (joint-angle precision; this is tighter than v=tan(theta/2)
+precision because joint angles compress near theta=pi where v blows
+up). Hypothesis fuzz with the same ``assume()`` filter as Phase 5d
+to skip algebraically-pathological corners.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from ssik.solvers.husty_pfurner._back_substitute import solve_ik
+from ssik.solvers.husty_pfurner._eliminate import precompute_rrr_chain
+from tests.test_husty_pfurner_eliminate import (
+    _DH_BASELINE,
+    _DH_LARGE_ALPHA,
+    _DH_SMALL_LINK,
+    _full_6r_chain,
+)
+
+# ----------------------------------------------------------------------------
+# Hand-picked test configurations.
+# ----------------------------------------------------------------------------
+
+_HAND_PICKED_CASES: list[tuple[dict[str, float], tuple[float, ...]]] = [
+    (_DH_BASELINE, (0.30, -0.40, 0.60, 0.20, 0.50, -0.70)),
+    (_DH_BASELINE, (-0.20, 0.30, -0.50, 0.40, -0.60, 0.80)),
+    (_DH_BASELINE, (1.10, -0.90, 0.50, 1.30, -0.70, 0.40)),
+    (_DH_LARGE_ALPHA, (0.30, -0.40, 0.60, 0.20, 0.50, -0.70)),
+    (_DH_SMALL_LINK, (0.30, -0.40, 0.60, 0.20, 0.50, -0.70)),
+]
+
+
+def _kwargs_for_solve(dh: dict[str, float]) -> dict[str, float]:
+    """Map _DH_* dict keys (l_*) to solve_ik's expected kwargs (ls_*)."""
+    return dict(
+        a_1=dh["a_1"],
+        ls_1=dh["l_1"],
+        d_2=dh["d_2"],
+        a_2=dh["a_2"],
+        ls_2=dh["l_2"],
+        d_3=dh["d_3"],
+        a_3=dh["a_3"],
+        ls_3=dh["l_3"],
+        d_4=dh["d_4"],
+        a_4=dh["a_4"],
+        ls_4=dh["l_4"],
+        d_5=dh["d_5"],
+        a_5=dh["a_5"],
+        ls_5=dh["l_5"],
+    )
+
+
+def _sigma_for(dh: dict[str, float], v: tuple[float, ...]) -> np.ndarray:
+    """Build sigma_E for a given (DH, q) pair."""
+    return _full_6r_chain(
+        v=v,
+        a=(dh["a_1"], dh["a_2"], dh["a_3"], dh["a_4"], dh["a_5"]),
+        ls=(dh["l_1"], dh["l_2"], dh["l_3"], dh["l_4"], dh["l_5"]),
+        d=(dh["d_2"], dh["d_3"], dh["d_4"], dh["d_5"]),
+    )
+
+
+def _max_q_diff(a: tuple[float, ...] | np.ndarray, b: tuple[float, ...] | np.ndarray) -> float:
+    return max(abs(float(ai) - float(bi)) for ai, bi in zip(a, b, strict=True))
+
+
+# ----------------------------------------------------------------------------
+# API + shape sanity.
+# ----------------------------------------------------------------------------
+
+
+def test_solve_ik_returns_correct_shape() -> None:
+    dh = _DH_BASELINE
+    v = (0.3, -0.4, 0.6, 0.2, 0.5, -0.7)
+    pre = precompute_rrr_chain(**dh)
+    sigma_E = _sigma_for(dh, v)
+    sols = solve_ik(pre, sigma_E, **_kwargs_for_solve(dh))
+    assert sols.ndim == 2
+    assert sols.shape[1] == 6
+    assert sols.dtype == np.float64
+    assert np.all(np.isfinite(sols))
+
+
+def test_solve_ik_empty_when_unreachable() -> None:
+    """Sanity: a non-physical sigma_E (random gibberish 8-vec) should
+    yield zero IK solutions because no FK closure is achievable.
+    """
+    pre = precompute_rrr_chain(**_DH_BASELINE)
+    bogus_sigma = np.array([1.0, 0.5, 0.3, 0.7, 100.0, 200.0, 300.0, 400.0])
+    sols = solve_ik(pre, bogus_sigma, **_kwargs_for_solve(_DH_BASELINE))
+    assert sols.shape == (0, 6) or sols.shape[0] == 0
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked: each config recovers FK truth + every returned solution
+# satisfies FK closure.
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dh_v", _HAND_PICKED_CASES)
+def test_solve_ik_recovers_truth_and_fk_closes(
+    dh_v: tuple[dict[str, float], tuple[float, ...]],
+) -> None:
+    dh, v_truth = dh_v
+    pre = precompute_rrr_chain(**dh)
+    sigma_E = _sigma_for(dh, v_truth)
+    sols = solve_ik(pre, sigma_E, **_kwargs_for_solve(dh))
+    assert sols.shape[0] >= 1, f"no IK solutions for DH={dh}, v={v_truth}"
+
+    # FK closure: every returned solution must round-trip to sigma_E
+    # within machine precision (the FK closure filter inside solve_ik
+    # already enforces this via fk_tol; this is the test contract).
+    sigma_E_norm = float(np.linalg.norm(sigma_E))
+    for sol in sols:
+        sigma_chain = _sigma_for(dh, tuple(sol))
+        scale = float(sigma_chain @ sigma_E) / max(float(sigma_chain @ sigma_chain), 1e-300)
+        residue = float(np.linalg.norm(sigma_chain * scale - sigma_E)) / max(sigma_E_norm, 1e-300)
+        assert residue < 1e-7, (
+            f"FK closure failed for sol={sol}, residue={residue:.3e}, DH={dh}, truth={v_truth}"
+        )
+
+    # The FK truth must be among the returned solutions (modulo joint
+    # multivaluation: tan(theta/2) for theta and theta+2pi gives the
+    # same v, so direct comparison works).
+    nearest_err = min(_max_q_diff(sol, v_truth) for sol in sols)
+    assert nearest_err < 1e-9, (
+        f"FK truth {v_truth} not recovered: nearest sol max-abs-err {nearest_err:.3e} (DH={dh})"
+    )
+
+
+# ----------------------------------------------------------------------------
+# 100-pose Hypothesis fuzz: every (DH, q) round-trips through IK.
+# ----------------------------------------------------------------------------
+
+
+_safe_dh = st.floats(min_value=0.05, max_value=1.5, allow_nan=False, allow_infinity=False)
+_safe_alpha = st.floats(
+    min_value=0.05, max_value=math.pi - 0.05, allow_nan=False, allow_infinity=False
+)
+_safe_dist = st.floats(min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+_safe_q = st.floats(min_value=-3.0, max_value=3.0, allow_nan=False, allow_infinity=False)
+_sign = st.sampled_from([-1.0, 1.0])
+
+
+@given(
+    a_1=_safe_dh,
+    s_a1=_sign,
+    alpha_1=_safe_alpha,
+    d_2=_safe_dist,
+    a_2=_safe_dh,
+    s_a2=_sign,
+    alpha_2=_safe_alpha,
+    d_3=_safe_dist,
+    a_3=_safe_dh,
+    s_a3=_sign,
+    alpha_3=_safe_alpha,
+    d_4=_safe_dist,
+    a_4=_safe_dh,
+    s_a4=_sign,
+    alpha_4=_safe_alpha,
+    d_5=_safe_dist,
+    a_5=_safe_dh,
+    s_a5=_sign,
+    alpha_5=_safe_alpha,
+    v_1=_safe_q,
+    v_2=_safe_q,
+    v_3=_safe_q,
+    v_4=_safe_q,
+    v_5=_safe_q,
+    v_6=_safe_q,
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[
+        HealthCheck.too_slow,
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
+)
+def test_solve_ik_recovers_truth_hypothesis(
+    a_1: float,
+    s_a1: float,
+    alpha_1: float,
+    d_2: float,
+    a_2: float,
+    s_a2: float,
+    alpha_2: float,
+    d_3: float,
+    a_3: float,
+    s_a3: float,
+    alpha_3: float,
+    d_4: float,
+    a_4: float,
+    s_a4: float,
+    alpha_4: float,
+    d_5: float,
+    a_5: float,
+    s_a5: float,
+    alpha_5: float,
+    v_1: float,
+    v_2: float,
+    v_3: float,
+    v_4: float,
+    v_5: float,
+    v_6: float,
+) -> None:
+    """100 random (DH, q) configs. Each must produce at least one IK
+    solution that round-trips through FK to ``sigma_E`` within 1e-7.
+    The FK truth must be among the returned solutions (1e-7 max-abs-q
+    tolerance, looser than hand-picked because float64 precision at
+    multiplicity-2 roots gives ``v_i`` accuracy ~1e-8 by Wilkinson).
+
+    Same Hypothesis filter as Phase 5d: skip all-zero-q + replicated
+    symmetric DH (algebraically pathological corners that real robots
+    don't have).
+    """
+    a = (s_a1 * a_1, s_a2 * a_2, s_a3 * a_3, s_a4 * a_4, s_a5 * a_5)
+    ls = tuple(math.tan(0.5 * x) for x in (alpha_1, alpha_2, alpha_3, alpha_4, alpha_5))
+    d = (d_2, d_3, d_4, d_5)
+    v = (v_1, v_2, v_3, v_4, v_5, v_6)
+
+    assume(np.linalg.norm(np.asarray(v)) > 0.5)
+    a_spread = float(np.std(np.abs(a)))
+    alpha_spread = float(np.std([alpha_1, alpha_2, alpha_3, alpha_4, alpha_5]))
+    assume(a_spread > 0.05 or alpha_spread > 0.05)
+
+    dh_kwargs = dict(
+        a_1=a[0],
+        l_1=ls[0],
+        d_2=d[0],
+        a_2=a[1],
+        l_2=ls[1],
+        d_3=d[1],
+        a_3=a[2],
+        l_3=ls[2],
+        d_4=d[2],
+        a_4=a[3],
+        l_4=ls[3],
+        d_5=d[3],
+        a_5=a[4],
+        l_5=ls[4],
+    )
+    pre = precompute_rrr_chain(**dh_kwargs)
+    sigma_E = _full_6r_chain(v=v, a=a, ls=ls, d=d)
+    sols = solve_ik(pre, sigma_E, **_kwargs_for_solve(dh_kwargs))
+    if sols.shape[0] == 0:
+        pytest.fail(f"no IK solutions for DH={dh_kwargs}, v={v}")
+
+    nearest_err = min(_max_q_diff(sol, v) for sol in sols)
+    assert nearest_err < 1e-7, (
+        f"FK truth {v} not recovered: nearest sol max-abs-err {nearest_err:.3e} (DH={dh_kwargs})"
+    )


### PR DESCRIPTION
## Summary

Closes the second half of the Husty-Pfurner universal-6R IK solver. Given the `(v_1, v_6)` candidates from Phase 5d's elimination (PR #173), recover the remaining `(v_2, v_3, v_4, v_5)` and produce full IK solutions verified by FK closure.

**Algorithm** (Capco et al. 2019 Section 5.4):

1. `eliminate_uw_pairs` returns refined `(u, w)` pairs (Phase 5d's Newton already computed both; previously only `u` was exposed).
2. For each candidate, compute the Cramer cofactor `P(u, w)` = the F_4 split-frame Study DQ.
3. Two 2R sub-chains:
   - `sigma_2 sigma_3 = sigma_1(u)^-1 · P` → solve for `(v_2, v_3)`
   - `sigma_4 sigma_5 = P^-1 · sigma_E · sigma_6(w)^-1` → solve for `(v_4, v_5)`
4. Each 2R subproblem decomposes via closed-form ZXZ-like atan2.
5. FK closure filter: discard any candidate not satisfying `||FK(q) - sigma_E|| / ||sigma_E|| < 1e-8`.

**Smoke result on baseline DH**: 4 IK solutions returned including the FK truth at machine precision; all 4 satisfy FK closure.

## Test plan

- [x] 5 hand-picked configs (baseline / large-alpha / small-link DH × multiple q-targets): every config recovers FK truth at 1e-9 joint-angle precision; every returned solution FK-closes at 1e-7.
- [x] 100-pose Hypothesis fuzz (15 s) with the same `assume()` filter as Phase 5d.
- [x] 513 passing across all HP-related suites; the one failure is the pre-existing Phase 5d HP-eliminate Wilkinson-floor flake (unchanged by 5f).
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy` clean on the new module.

The high-level API still requires explicit DH params; Phase 5g (next PR) will wire HP into the `Manipulator`/`KinBody` dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)