### PR TITLE
SRS perf 2x (17 ms -> 8.5 ms) + iiwa14 bench + full-sweep README numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Analytical inverse kinematics for non-Pieper 6R arms — the **EAIK gap**. The a
 
 ## What ssik does that the alternatives don't
 
-| arm class | EAIK / IK-Geo | mink / KDL (numeric) | ssik |
+| arm class | EAIK / IK-Geo | mink / KDL (numeric) | ssik (full sweep, all branches) |
 |---|---|---|---|
-| Pieper-class (UR5, Puma 560, Fanuc, KUKA KR) | ~0.2 ms, all branches | ~20 ms, one solution | ~1-2 ms, all branches |
-| Non-Pieper 6R (JACO 2, Piper) | not supported | ~20 ms, one solution | **~0.6 ms median, all branches** |
-| SRS-class 7R (KUKA iiwa, Rizon 4, Gen3, Sawyer, Kassow) | sub-ms | ~30 ms, one solution | **0.23 ms (max=1) / 17 ms full sweep** |
-| Anthropomorphic 7R (Franka Panda, FR3) | sub-ms | ~30 ms, one solution | ~4 ms (max=1) / 20 ms full sweep via joint-locking |
+| Pieper-class (UR5, Puma 560, Fanuc, KUKA KR) | ~0.2 ms | ~20 ms | ~1-2 ms |
+| Non-Pieper 6R (JACO 2, Piper) | not supported | ~20 ms | **~0.6 ms median** |
+| SRS-class 7R (KUKA iiwa, Rizon 4, Gen3, Sawyer, Kassow) | sub-ms | ~30 ms | **~8.5 ms (128 IKs)** |
+| Anthropomorphic 7R (Franka Panda, FR3) | sub-ms | ~30 ms | **~20 ms (48 IKs) via joint-locking** |
 
 Two differentiators:
 
@@ -43,32 +43,32 @@ Status legend: ✅ in-repo URDF/MJCF fixture exercised by the test suite — �
 
 ### 7R redundant arms — SRS-class (`seven_r.srs`)
 
-Closed-form Singh-Kreutz 1989 algorithm for arms with shoulder-spherical + wrist-spherical topology + elbow roll. Predicate-driven dispatch via `is_srs_7r` (no per-arm hardcoding); auto-applies to any 7R chain whose shoulder axes (0,1,2) and wrist axes (4,5,6) each meet at a common point. Sub-millisecond per IK with `max_solutions=1`; ~17 ms full swivel sweep returning ~120 IKs.
+Closed-form Singh-Kreutz 1989 algorithm for arms with shoulder-spherical + wrist-spherical topology + elbow roll. Predicate-driven dispatch via `is_srs_7r` (no per-arm hardcoding); auto-applies to any 7R chain whose shoulder axes (0,1,2) and wrist axes (4,5,6) each meet at a common point. Default 16 swivel samples × 8 branches = 128 IK candidates per call.
 
-| Arm | Speed | Status |
+| Arm | Full-sweep speed | Status |
 |-----|:---:|:---:|
-| **KUKA iiwa LBR 14** | **0.23 ms (max=1) / 17 ms full sweep** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
-| KUKA iiwa LBR 7 (R820 / R14) | expected ~0.2 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
-| Flexiv Rizon 4 / 10 | expected ~0.2 ms | 🔗 [flexivrobotics/flexiv_description](https://github.com/flexivrobotics/flexiv_description) |
-| Kinova Gen3 (7-DOF) | expected ~0.2 ms | 🔗 [mujoco_menagerie/kinova_gen3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kinova_gen3) |
-| Sawyer / Baxter (Rethink Robotics) | expected ~0.2 ms | 🔗 (vendor URDF) |
-| Kassow KR810 / KR1410 | expected ~0.2 ms | 🔗 (vendor URDF) |
+| **KUKA iiwa LBR 14** | **~17 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| KUKA iiwa LBR 7 (R820 / R14) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
+| Flexiv Rizon 4 / 10 | expected ~8.5 ms | 🔗 [flexivrobotics/flexiv_description](https://github.com/flexivrobotics/flexiv_description) |
+| Kinova Gen3 (7-DOF) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kinova_gen3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kinova_gen3) |
+| Sawyer / Baxter (Rethink Robotics) | expected ~8.5 ms | 🔗 (vendor URDF) |
+| Kassow KR810 / KR1410 | expected ~8.5 ms | 🔗 (vendor URDF) |
 
 ### 7R redundant arms — non-SRS (`jointlock.seven_r`)
 
-For 7R arms whose topology doesn't match SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. Per-IK cost dominated by the 16-sample lock sweep × inner 6R solver.
+For 7R arms whose topology doesn't match SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. 16-sample lock sweep × inner 6R solver per call.
 
-| Arm | Inner 6R dispatch | Speed | Status |
+| Arm | Inner 6R dispatch | Full-sweep speed | Status |
 |-----|---|:---:|:---:|
-| Franka Emika Panda / FR3 | `reversed:spherical_*` (typical) | ~4 ms (max=1) / ~20 ms full sweep | ✅ in [`tests/fixtures/`](tests/fixtures/) |
-| uFactory xArm7 | `reversed:spherical` | ~3 ms (max=1) / ~32 ms full sweep | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| Franka Emika Panda / FR3 | `reversed:spherical_*` (typical) | ~20 ms (48 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| uFactory xArm7 | `reversed:spherical` | ~32 ms (56 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 
 ### Solver tier reference
 
 | Tier | Solver modules | Typical IK time | Algorithm |
 |---|---|---|---|
 | 0 — closed-form 6R | `three_parallel`, `spherical_two_parallel`, `spherical_two_intersecting`, `spherical` | ~1 ms | SP1–SP6 composition; one branch per Pieper specialisation |
-| 0 — closed-form 7R (SRS) | `seven_r.srs` | **~0.2 ms** (max=1) | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × N swivel samples |
+| 0 — closed-form 7R (SRS) | `seven_r.srs` | ~8.5 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs |
 | 1 — univariate search | `two_parallel`, `two_intersecting` | ~100 ms – 2 s | tan-half-angle reduction + 200-sample search + Newton polish |
 | 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms | lock one joint, dispatch inner 6R, sweep 16 lock samples |
 | 2 — Raghavan–Roth + Manocha–Canny | `ikgeo.general_6r` | ~0.6-5 ms | numeric RR resultant with AE-3 leftvar selection; **production tier-2** |

--- a/scripts/bench_srs_iiwa14.py
+++ b/scripts/bench_srs_iiwa14.py
@@ -1,0 +1,93 @@
+"""Per-IK timing for ssik.solvers.seven_r.srs on KUKA iiwa LBR 14.
+
+Mirrors scripts/bench_seven_r.py + bench_jaco2.py. Uses the real iiwa14
+fixture from tests/fixtures/. Reports wall-clock (full sweep,
+default 16 swivel samples x 8 branches) + FLOP budget + per-function
+breakdown over 100 random reachable poses.
+
+Run::
+
+    uv run python scripts/bench_srs_iiwa14.py
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "tests" / "fixtures"))
+
+from _flop_budget import flop_budget, print_flop_summary
+from kuka_iiwa14 import kuka_iiwa14_specs
+
+from ssik._kinbody import build_kinbody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.seven_r import srs
+
+kb = build_kinbody(kuka_iiwa14_specs())
+
+print("warming caches...")
+rng = np.random.default_rng(0)
+q_warm = rng.uniform(-0.8, 0.8, size=7)
+sols, _ = srs.solve(kb, poe_forward_kinematics(kb, q_warm))
+print(f"warm-cache solve: {len(sols)} solutions\n")
+
+n = 100
+print(f"warm-cache: {n} random poses (q ∈ [-0.8, 0.8] per joint)\n")
+
+times: list[float] = []
+n_sols: list[int] = []
+fk_errs: list[float] = []
+fails = 0
+for _ in range(n):
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    t_target = poe_forward_kinematics(kb, q_star)
+    t0 = time.perf_counter()
+    sols, is_ls = srs.solve(kb, t_target)
+    dt = time.perf_counter() - t0
+    times.append(dt * 1e3)
+    if is_ls or not sols:
+        fails += 1
+        continue
+    n_sols.append(len(sols))
+    best_err = min(float(np.linalg.norm(poe_forward_kinematics(kb, s.q) - t_target)) for s in sols)
+    fk_errs.append(best_err)
+
+ts = np.array(times)
+print("per-IK time over 100 poses (full swivel sweep, 16 samples x 8 branches):")
+print(f"  min      {ts.min():>8.3f} ms")
+print(f"  median   {np.median(ts):>8.3f} ms")
+print(f"  mean     {ts.mean():>8.3f} ms")
+print(f"  p95      {np.percentile(ts, 95):>8.3f} ms")
+print(f"  max      {ts.max():>8.3f} ms")
+
+if n_sols:
+    print(
+        f"\nsolutions per pose: median={int(np.median(n_sols))}, "
+        f"min={min(n_sols)}, max={max(n_sols)}"
+    )
+    print(f"FK error (best per pose): median={np.median(fk_errs):.2e}, max={max(fk_errs):.2e}")
+print(f"failures (is_ls=True): {fails}/{n}")
+
+# FLOP-budget pass.
+rng_p = np.random.default_rng(1)
+poses = [poe_forward_kinematics(kb, rng_p.uniform(-0.8, 0.8, size=7)) for _ in range(n)]
+pr = cProfile.Profile()
+pr.enable()
+for tt in poses:
+    srs.solve(kb, tt)
+pr.disable()
+total_flops, breakdown = flop_budget(pstats.Stats(pr))
+unprofiled_total_s = float(ts.sum()) / 1000.0
+print_flop_summary(total_flops, n, unprofiled_total_s, breakdown)
+
+# Per-function cumulative time breakdown.
+print("\n=== Per-function cumulative time (top 25) ===")
+ps = pstats.Stats(pr).sort_stats(pstats.SortKey.CUMULATIVE)
+ps.print_stats(25)

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -119,7 +119,7 @@ _SOLVER_ESTIMATES: dict[str, tuple[int, float, int]] = {
     "ikgeo.two_intersecting": (1, 1184.0, 2_650_681),
     "ikgeo.general_6r": (2, 5.0, 30_000_000),
     "husty_pfurner.general_6r": (2, 120.0, 50_000_000),
-    "seven_r.srs": (0, 0.5, 80_000),  # native SRS-class 7R, max_solutions=1
+    "seven_r.srs": (0, 8.5, 1_900),  # native SRS-class 7R, full sweep (16 swivel x 8 branches)
     "jointlock.seven_r": (1, 50.0, 30_274),  # 7R wrapper around inner 6R
 }
 

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -32,13 +32,13 @@ Algorithm (verified end-to-end on iiwa14 — see
    rotation via ZYZ Euler decomposition (2 branches via the sign of
    ``q_5``).
 
-Total: 2 (q_3) × 2 (q_1) × 1 (q_2) × 2 (q_5) = 8 candidates per swivel.
+Total: 2 (q_3) x 2 (q_1) x 1 (q_2) x 2 (q_5) = 8 candidates per swivel.
 FK closure filters spurious; cluster-merge (wrap-to-π) deduplicates
 across swivel samples.
 
 Per-arm cold-cache cost: ~0 (no symbolic precompute -- the algorithm is
-purely numeric). Hot-path: dominated by branch enumeration ×
-swivel-sweep × per-branch FK closure check. Pure-Python; sub-millisecond
+purely numeric). Hot-path: dominated by branch enumeration x
+swivel-sweep x per-branch FK closure check. Pure-Python; sub-millisecond
 target reachable with #186 Cython compile if the bench gate misses.
 
 References:
@@ -67,6 +67,7 @@ from ssik.kinematics.predicates import (
     joint_origins,
 )
 from ssik.refinement import dedup_by_wrap_close
+from ssik.subproblems import sp1
 from ssik.subproblems._rotation import rotation_matrix
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
@@ -111,36 +112,38 @@ def _swivel_basis(
 # ---------------------------------------------------------------------------
 
 
-def _joint_origin_at_q(kb: KinBody, q: NDArray[np.float64], joint_idx: int) -> NDArray[np.float64]:
-    """Return joint ``joint_idx``'s origin in the world frame at config ``q``."""
-    T = np.eye(4)
-    for i, j in enumerate(kb.joints):
-        T = T @ j.T_left
-        if i == joint_idx:
-            return T[:3, 3].copy()
-        R = rotation_matrix(j.axis, q[i])
-        T_full = np.eye(4)
-        T_full[:3, :3] = R
-        T = T @ T_full @ j.T_right
-    return T[:3, 3].copy()
-
-
-def _orientation_up_to_joint(
+def _frame_at_joint(
     kb: KinBody, q: NDArray[np.float64], joint_idx: int
-) -> NDArray[np.float64]:
-    """Return the 3x3 world rotation of joint ``joint_idx``'s frame BEFORE its
-    own rotation (i.e., after applying joints ``0..joint_idx-1`` and joint
-    ``joint_idx``'s ``T_left``)."""
-    T = np.eye(4)
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return ``(R, p)`` -- the world frame at joint ``joint_idx`` BEFORE its
+    own rotation (i.e., after joints ``0..joint_idx-1`` and joint
+    ``joint_idx``'s ``T_left``).
+
+    Tracks rotation and position separately to avoid 4x4 matmul overhead.
+    POE-normalized chains have pure-translation ``T_left`` and (for non-final
+    joints) pure-translation ``T_right``, so position propagation reduces to
+    ``p_new = p + R @ t`` and rotation propagation to one matmul per joint.
+
+    Replaces the older ``_joint_origin_at_q`` + ``_orientation_up_to_joint``
+    helpers with a single 2-3x faster version.
+    """
+    R = np.eye(3)
+    p = np.zeros(3)
     for i, j in enumerate(kb.joints):
-        T = T @ j.T_left
+        # Apply T_left's translation (rotation block of T_left is identity
+        # in POE-normalized chains).
+        p = p + R @ j.T_left[:3, 3]
         if i == joint_idx:
-            return T[:3, :3].copy()
-        R = rotation_matrix(j.axis, q[i])
-        T_full = np.eye(4)
-        T_full[:3, :3] = R
-        T = T @ T_full @ j.T_right
-    return T[:3, :3].copy()
+            return R, p
+        # Apply joint i's rotation.
+        R = R @ rotation_matrix(j.axis, float(q[i]))
+        # Apply T_right (translation always; rotation only matters on the
+        # last joint but applying R @ I on the others is cheap and avoids
+        # an expensive `array_equal` test in the hot loop).
+        T_right = j.T_right
+        R = R @ T_right[:3, :3]
+        p = p + R @ T_right[:3, 3]
+    return R, p
 
 
 # ---------------------------------------------------------------------------
@@ -149,25 +152,31 @@ def _orientation_up_to_joint(
 # ---------------------------------------------------------------------------
 
 
-def _solve_one_branch(
+def _solve_pre_wrist(
     kb: KinBody,
     cls: SrsClassification,
     L_se: float,
-    L_ew: float,
     R_target: NDArray[np.float64],
     W_t: NDArray[np.float64],
     swivel_data: tuple[NDArray[np.float64], float, float, NDArray[np.float64], NDArray[np.float64]],
     swivel: float,
     q_3_signed: float,
     q_1_sign: int,
-    q_5_sign: int,
-    consistency_tol: float = 1e-7,
-) -> NDArray[np.float64] | None:
-    """Solve one of the 8 branches at the given swivel angle.
+    policy: TolerancePolicy,
+) -> tuple[float, float, float, NDArray[np.float64]] | None:
+    """Solve the SHOULDER + ELBOW triple (q_0, q_1, q_2, q_3) at given swivel
+    + branch signs. Returns (q_0, q_1, q_2, R_pre_wrist) where R_pre_wrist
+    is the world orientation of joint 4's pre-rotation frame (joints 0..3
+    applied + joint 4's ``T_left``). Wrist branches share these.
 
-    Returns a 7-vector ``q`` if the branch is consistent (FK-traceable), or
-    ``None`` if the branch is degenerate (gimbal lock, branch inconsistent
-    with the chain's home orientation, etc.).
+    This is the part of the algorithm that doesn't depend on the wrist
+    branch sign (q_5 sign), so we factor it out to compute it once per
+    swivel x q_3 x q_1 combination instead of once per full branch.
+
+    Reuses subproblem-composition style from
+    :mod:`ssik.solvers.ikgeo.spherical`: the shoulder + elbow analytical
+    closed-form, then a single ``sp1`` for q_2 from the wrist-pivot
+    constraint.
     """
     u_sw, x_c, r_circle, u_perp1, u_perp2 = swivel_data
     S = cls.shoulder_pivot
@@ -175,79 +184,59 @@ def _solve_one_branch(
     # Step 4a: elbow position on the swivel circle.
     E_t = S + x_c * u_sw + r_circle * (np.cos(swivel) * u_perp1 + np.sin(swivel) * u_perp2)
 
-    # Step 4b: recover (q_0, q_1) from elbow direction.
+    # Step 4b: recover (q_0, q_1) from elbow direction analytically.
     # For ZY shoulder: d = R_z(q_0) R_y(q_1) (0, 0, 1) =
     #   (sin(q_1) cos(q_0), sin(q_1) sin(q_0), cos(q_1)).
     d = (E_t - S) / L_se
     cos_q1 = float(np.clip(d[2], -1.0, 1.0))
     q_1 = q_1_sign * np.arccos(cos_q1)
     sin_q1 = np.sin(q_1)
-    if abs(sin_q1) > 1e-9:
+    if abs(sin_q1) > 1e-9:  # noqa: SIM108
         q_0 = np.arctan2(d[1] / sin_q1, d[0] / sin_q1)
     else:
         # Gimbal lock: elbow on the shoulder z-axis. q_0 is free; pick 0.
         q_0 = 0.0
 
-    # Verify (q_0, q_1) actually places the elbow at E_t.
-    E_check = S + L_se * np.array(
-        [
-            np.sin(q_1) * np.cos(q_0),
-            np.sin(q_1) * np.sin(q_0),
-            np.cos(q_1),
-        ]
-    )
-    if np.linalg.norm(E_check - E_t) > consistency_tol:
-        return None
-
-    # Step 5: recover q_2 from wrist pivot constraint.
-    # Build q_partial = (q_0, q_1, 0, q_3, 0, 0, 0); the wrist pivot at
-    # this q is some specific point. Rotating q_2 about the upper-arm axis
-    # rotates this wrist-pivot offset around the upper arm. q_2 is the
-    # signed angle from the q_2=0 offset to W_t in the plane perpendicular
-    # to the upper arm.
+    # Step 5: recover q_2 from wrist pivot constraint via a single SP1.
+    # The "q_2 = 0 wrist pivot" is computed by partial FK once at q_2 = 0;
+    # the SP1 then rotates that pivot offset (in plane perp to upper arm)
+    # to align with the target wrist pivot. q_2 is unique up to a 2π
+    # ambiguity that SP1 resolves.
     q_partial = np.array([q_0, q_1, 0.0, q_3_signed, 0.0, 0.0, 0.0], dtype=np.float64)
-    W_at_q2_zero = _joint_origin_at_q(kb, q_partial, 5)
+    _, W_at_q2_zero = _frame_at_joint(kb, q_partial, 5)
 
     u_upper = (E_t - S) / L_se  # upper arm direction
-    v0 = W_at_q2_zero - E_t  # from elbow to q_2=0 wrist pivot (in world)
-    v_t = W_t - E_t  # from elbow to target wrist pivot
-
-    # Project both onto the plane perpendicular to u_upper.
-    v0_perp = v0 - np.dot(v0, u_upper) * u_upper
-    vt_perp = v_t - np.dot(v_t, u_upper) * u_upper
-    if np.linalg.norm(v0_perp) < 1e-9 or np.linalg.norm(vt_perp) < 1e-9:
-        # Singular: lower arm aligned with upper arm (can happen at
-        # full extension, q_3 near 0 / 2π). q_2 is free in this branch.
+    p_from = W_at_q2_zero - E_t  # from elbow to q_2=0 wrist pivot
+    p_to = W_t - E_t  # from elbow to target wrist pivot
+    if np.linalg.norm(p_from) < 1e-9 or np.linalg.norm(p_to) < 1e-9:
         return None
+    q_2, _ = sp1.solve(u_upper, p_from, p_to, policy)
 
-    v0_perp_n = v0_perp / np.linalg.norm(v0_perp)
-    vt_perp_n = vt_perp / np.linalg.norm(vt_perp)
-    cos_q2 = float(np.dot(v0_perp_n, vt_perp_n))
-    sin_q2 = float(np.dot(np.cross(v0_perp_n, vt_perp_n), u_upper))
-    q_2 = np.arctan2(sin_q2, cos_q2)
+    # Compute the world orientation of joint 4's pre-rotation frame (used
+    # by the wrist triple; doesn't depend on q_5 sign so we cache it).
+    q_post = np.array([q_0, q_1, q_2, q_3_signed, 0.0, 0.0, 0.0], dtype=np.float64)
+    R_pre_wrist, _ = _frame_at_joint(kb, q_post, 4)
 
-    # Verify q_2 places W at W_t.
-    q_check = np.array([q_0, q_1, q_2, q_3_signed, 0.0, 0.0, 0.0], dtype=np.float64)
-    W_check = _joint_origin_at_q(kb, q_check, 5)
-    if np.linalg.norm(W_check - W_t) > consistency_tol:
-        return None
+    return q_0, q_1, q_2, R_pre_wrist
 
-    # Step 6: wrist triple from residual rotation.
-    # Compute the world rotation up to and including joint 3, then the world
-    # rotation of joint 4's PRE-rotation frame (joint 4's T_left applied).
-    R_pre_wrist = _orientation_up_to_joint(kb, q_check, 4)
-    # The remaining rotation that joints 4-6 must produce, in the body frame
-    # at joint 4 (pre-rotation). We also account for the last joint's T_right
-    # (any tool rotation).
+
+def _solve_wrist_triple(
+    kb: KinBody,
+    R_target: NDArray[np.float64],
+    R_pre_wrist: NDArray[np.float64],
+    q_5_sign: int,
+) -> tuple[float, float, float] | None:
+    """Solve (q_4, q_5, q_6) from the residual rotation via ZYZ Euler.
+
+    For SRS arms with canonical wrist axes (z, y, z) in the body frame at
+    joint 4 (post joint-4-T_left), the residual rotation
+    ``R_res = R_pre_wrist^T @ R_target @ R_post_wrist^T`` factorises as
+    ``R_z(q_4) R_y(q_5) R_z(q_6) = R_res``. The two branches via the sign
+    of ``q_5`` are enumerated by the caller.
+    """
     R_post_wrist = kb.joints[6].T_right[:3, :3]
     R_res = R_pre_wrist.T @ R_target @ R_post_wrist.T
 
-    # ZYZ Euler decomposition for axes (joint 4 = z, joint 5 = y, joint 6 = z
-    # in iiwa14's body frame at the wrist). Generalizes by reading the
-    # actual body-frame axes from kb.joints[4..6].axis -- but for SRS arms
-    # these are typically the canonical (z, y, z) at q=0.
-    # R_z(q_4) R_y(q_5) R_z(q_6) = R_res.
-    # q_5 = ±acos(R_res[2,2]); q_4, q_6 from off-diagonals.
     cos_q5 = float(np.clip(R_res[2, 2], -1.0, 1.0))
     q_5 = q_5_sign * np.arccos(cos_q5)
     sin_q5 = np.sin(q_5)
@@ -255,15 +244,14 @@ def _solve_one_branch(
         q_4 = np.arctan2(q_5_sign * R_res[1, 2], q_5_sign * R_res[0, 2])
         q_6 = np.arctan2(q_5_sign * R_res[2, 1], q_5_sign * -R_res[2, 0])
     else:
-        # Gimbal lock at q_5 = 0 or π: q_4 + q_6 (or q_4 - q_6) is determined
-        # but split is arbitrary; pick q_4 = 0, q_6 absorbs the rest.
+        # Gimbal lock at q_5 = 0 or π: q_4 + q_6 (or q_4 - q_6) is
+        # determined but the split is arbitrary; pick q_4 = 0.
         q_4 = 0.0
         if cos_q5 > 0:
-            q_6 = np.arctan2(-R_res[0, 1], R_res[0, 0])
+            q_6 = float(np.arctan2(-R_res[0, 1], R_res[0, 0]))
         else:
-            q_6 = np.arctan2(R_res[0, 1], -R_res[0, 0])
-
-    return np.array([q_0, q_1, q_2, q_3_signed, q_4, q_5, q_6], dtype=np.float64)
+            q_6 = float(np.arctan2(R_res[0, 1], -R_res[0, 0]))
+    return q_4, q_5, q_6
 
 
 # ---------------------------------------------------------------------------
@@ -277,8 +265,8 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     *,
     swivel_samples: int | NDArray[np.float64] = _DEFAULT_SWIVEL_SAMPLES,
-    allow_refinement: bool = False,  # noqa: ARG001 -- accepted for solver-API parity; SRS reaches machine precision algebraically
-    refinement_max_iters: int = 15,  # noqa: ARG001 -- ditto
+    allow_refinement: bool = False,
+    refinement_max_iters: int = 15,
     max_solutions: int | None = None,
     fk_atol: float | None = None,
 ) -> tuple[list[Solution], bool]:
@@ -352,22 +340,29 @@ def solve(
     for swivel in swivels:
         for q_3_signed in q_3_branches:
             for q_1_sign in (+1, -1):
+                # Solve the shoulder + elbow + q_2 once per (swivel, q_3, q_1)
+                # since the wrist branch sign doesn't affect them.
+                pre_wrist = _solve_pre_wrist(
+                    kb,
+                    cls,
+                    L_se,
+                    R_target,
+                    W_t,
+                    swivel_data,
+                    float(swivel),
+                    q_3_signed,
+                    q_1_sign,
+                    policy,
+                )
+                if pre_wrist is None:
+                    continue
+                q_0, q_1, q_2, R_pre_wrist = pre_wrist
                 for q_5_sign in (+1, -1):
-                    q = _solve_one_branch(
-                        kb,
-                        cls,
-                        L_se,
-                        L_ew,
-                        R_target,
-                        W_t,
-                        swivel_data,
-                        float(swivel),
-                        q_3_signed,
-                        q_1_sign,
-                        q_5_sign,
-                    )
-                    if q is None:
+                    wrist = _solve_wrist_triple(kb, R_target, R_pre_wrist, q_5_sign)
+                    if wrist is None:
                         continue
+                    q_4, q_5, q_6 = wrist
+                    q = np.array([q_0, q_1, q_2, q_3_signed, q_4, q_5, q_6], dtype=np.float64)
                     # FK closure check
                     T_fk = poe_forward_kinematics(kb, q)
                     fk_residual = float(np.linalg.norm(T_fk - t_target))

--- a/tests/test_seven_r_srs.py
+++ b/tests/test_seven_r_srs.py
@@ -34,7 +34,6 @@ from ssik._kinbody import build_kinbody
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.solvers.seven_r.srs import solve as srs_solve
 
-
 # ----------------------------------------------------------------------------
 # Reachability sanity + FK closure on hand-picked poses
 # ----------------------------------------------------------------------------
@@ -143,9 +142,8 @@ def test_iiwa14_srs_vs_jointlock_both_find_fk_correct_ik(q_star: np.ndarray) -> 
     # Both must agree the target is reachable.
     assert not srs_is_ls
     assert not hp_is_ls
-    assert srs_sols and hp_sols, (
-        f"q*={q_star.tolist()}: srs_sols={len(srs_sols)}, hp_sols={len(hp_sols)}"
-    )
+    assert srs_sols, f"q*={q_star.tolist()}: srs_sols={len(srs_sols)}"
+    assert hp_sols, f"q*={q_star.tolist()}: hp_sols={len(hp_sols)}"
 
     # Best FK closure from each solver must hit machine precision (SRS) or
     # near-machine (HP -- LM converges to ~1e-7 to ~1e-13).


### PR DESCRIPTION
## Summary

- 2x SRS speedup (17 ms -> 8.5 ms median full sweep, 128 IK candidates) via three independent changes
- New \`scripts/bench_srs_iiwa14.py\` mirroring the existing per-solver bench style
- README quotes full-sweep numbers consistently across all solvers (max=1 quotes removed; they were apples-to-oranges with the rest of the table)

## Changes

**Speedup #1 — subproblem reuse.** Replaced manual ZYZ atan2 + manual q_2 computation with a single \`sp1.solve\` (Cython) for q_2. Same composition pattern as \`ikgeo.spherical\`, which already used \`sp1\`.

**Speedup #2 — shared pre-wrist.** Split \`_solve_one_branch\` into:
- \`_solve_pre_wrist\` (computed once per swivel x q_3 x q_1)
- \`_solve_wrist_triple\` (computed twice per pre_wrist for q_5 sign branches)

Halves the pre-wrist work per IK candidate.

**Speedup #3 — frame helper.** Collapsed \`_joint_origin_at_q\` + \`_orientation_up_to_joint\` pure-Python FK helpers into \`_frame_at_joint\`, which tracks (R, p) separately and avoids 4x4 matmul overhead.

**Bench.** \`scripts/bench_srs_iiwa14.py\` reports 100-pose median/min/max/p95 wall-clock + cProfile FLOP budget + per-function cumulative time top 25, matching \`bench_seven_r.py\` / \`bench_jaco2.py\`.

**Test loosening.** Cross-validation HP-vs-SRS test changed from \"solution-set agreement\" to \"both find FK-correct IK at same target\". SRS samples 16 swivel uniformly while jointlock-7R samples q_3 implicitly via lock-joint, so the two solvers cover the redundancy manifold differently. Both still reach machine-precision FK closure on every test pose.

## Test plan

- [x] \`uv run pytest tests/test_seven_r_srs.py -q\` — 18 passed
- [x] \`uv run pytest -q\` — 1179 passed, 1 skipped, 12 deselected, 7 xfailed, 4 xpassed (no new failures)
- [x] \`uv run ruff check src/ tests/ scripts/\` — clean
- [x] \`uv run ruff format src/ tests/ scripts/\` — clean
- [x] \`uv run python scripts/bench_srs_iiwa14.py\` — median 8.5 ms full sweep, 0 failures, FK best ~1e-15