### PR TITLE
Gen3 fixture: non-SRS 7R routing through jointlock+HP (#80)

### DIFF
--- a/tests/fixtures/gen3.urdf
+++ b/tests/fixtures/gen3.urdf
@@ -1,0 +1,240 @@
+<robot name="GEN3-7DOF-NOVISION_FOR_URDF_ARM_V12" version="1.0">
+  <link name="base_link">
+    <inertial>
+      <origin xyz="-0.000648 -0.000166 0.084487" rpy="0 0 0" />
+      <mass value="1.697" />
+      <inertia ixx="0.004622" ixy="9E-06" ixz="6E-05" iyy="0.004495" iyz="9E-06" izz="0.002079" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/base_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/base_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <link name="shoulder_link">
+    <inertial>
+      <origin xyz="-2.3E-05 -0.010364 -0.07336" rpy="0 0 0" />
+      <mass value="1.377" />
+      <inertia ixx="0.00457" ixy="1E-06" ixz="2E-06" iyy="0.004831" iyz="0.000448" izz="0.001409" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/shoulder_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/shoulder_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_1" type="continuous">
+    <origin xyz="0 0 0.15643" rpy="3.1416 2.7629E-18 -4.9305E-36" />
+    <parent link="base_link" />
+    <child link="shoulder_link" />
+    <axis xyz="0 0 1" />
+    <limit effort="39" velocity="1.3963" />
+  </joint>
+  <link name="half_arm_1_link">
+    <inertial>
+      <origin xyz="-4.4E-05 -0.09958 -0.013278" rpy="0 0 0" />
+      <mass value="1.163" />
+      <inertia ixx="0.011088" ixy="5E-06" ixz="0" iyy="0.001072" iyz="-0.000691" izz="0.011255" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/half_arm_1_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/half_arm_1_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_2" type="revolute">
+    <origin xyz="0 0.005375 -0.12838" rpy="1.5708 2.1343E-17 -1.1102E-16" />
+    <parent link="shoulder_link" />
+    <child link="half_arm_1_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.24" upper="2.24" effort="39" velocity="1.3963" />
+  </joint>
+  <link name="half_arm_2_link">
+    <inertial>
+      <origin xyz="-4.4E-05 -0.006641 -0.117892" rpy="0 0 0" />
+      <mass value="1.163" />
+      <inertia ixx="0.010932" ixy="0" ixz="-7E-06" iyy="0.011127" iyz="0.000606" izz="0.001043" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/half_arm_2_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/half_arm_2_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_3" type="continuous">
+    <origin xyz="0 -0.21038 -0.006375" rpy="-1.5708 1.2326E-32 -2.9122E-16" />
+    <parent link="half_arm_1_link" />
+    <child link="half_arm_2_link" />
+    <axis xyz="0 0 1" />
+    <limit effort="39" velocity="1.3963" />
+  </joint>
+  <link name="forearm_link">
+    <inertial>
+      <origin xyz="-1.8E-05 -0.075478 -0.015006" rpy="0 0 0" />
+      <mass value="0.93" />
+      <inertia ixx="0.008147" ixy="-1E-06" ixz="0" iyy="0.000631" iyz="-0.0005" izz="0.008316" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/forearm_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/forearm_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_4" type="revolute">
+    <origin xyz="0 0.006375 -0.21038" rpy="1.5708 -6.6954E-17 -1.6653E-16" />
+    <parent link="half_arm_2_link" />
+    <child link="forearm_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.57" upper="2.57" effort="39" velocity="1.3963" />
+  </joint>
+  <link name="spherical_wrist_1_link">
+    <inertial>
+      <origin xyz="1E-06 -0.009432 -0.063883" rpy="0 0 0" />
+      <mass value="0.678" />
+      <inertia ixx="0.001596" ixy="0" ixz="0" iyy="0.001607" iyz="0.000256" izz="0.000399" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/spherical_wrist_1_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/spherical_wrist_1_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_5" type="continuous">
+    <origin xyz="0 -0.20843 -0.006375" rpy="-1.5708 2.2204E-16 -6.373E-17" />
+    <parent link="forearm_link" />
+    <child link="spherical_wrist_1_link" />
+    <axis xyz="0 0 1" />
+    <limit effort="9" velocity="1.2218" />
+  </joint>
+  <link name="spherical_wrist_2_link">
+    <inertial>
+      <origin xyz="1E-06 -0.045483 -0.00965" rpy="0 0 0" />
+      <mass value="0.678" />
+      <inertia ixx="0.001641" ixy="0" ixz="0" iyy="0.00041" iyz="-0.000278" izz="0.001641" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/spherical_wrist_2_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/spherical_wrist_2_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_6" type="revolute">
+    <origin xyz="0 0.00017505 -0.10593" rpy="1.5708 9.2076E-28 -8.2157E-15" />
+    <parent link="spherical_wrist_1_link" />
+    <child link="spherical_wrist_2_link" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.09" upper="2.09" effort="9" velocity="1.2218" />
+  </joint>
+  <link name="bracelet_link">
+    <inertial>
+      <origin xyz="-9.3E-05 0.000132 -0.022905" rpy="0 0 0" />
+      <mass value="0.364" />
+      <inertia ixx="0.000214" ixy="0" ixz="1E-06" iyy="0.000223" iyz="-2E-06" izz="0.00024" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/bracelet_no_vision_link.STL" />
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="package://kortex_description/arms/gen3/7dof/meshes/bracelet_no_vision_link.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint_7" type="continuous">
+    <origin xyz="0 -0.10593 -0.00017505" rpy="-1.5708 -5.5511E-17 9.6396E-17" />
+    <parent link="spherical_wrist_2_link" />
+    <child link="bracelet_link" />
+    <axis xyz="0 0 1" />
+    <limit effort="9" velocity="1.2218" />
+  </joint>
+  <link name="end_effector_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="0" />
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0" />
+    </inertial>
+  </link>
+  <joint name="end_effector" type="fixed">
+    <origin xyz="0 0 -0.0615250000000001" rpy="3.14159265358979 1.09937075168372E-32 0" />
+    <parent link="bracelet_link" />
+    <child link="end_effector_link" />
+    <axis xyz="0 0 0" />
+  </joint>
+</robot>

--- a/tests/test_kinova_gen3.py
+++ b/tests/test_kinova_gen3.py
@@ -1,0 +1,181 @@
+"""Bulletproof validation for the Kinova Gen3 7-DOF fixture (#80).
+
+Gen3 is a 7-DOF anthropomorphic arm commonly cited as SRS-class in the
+literature (and treated as such by EAIK). **In its actual URDF it is
+NOT pure SRS** — joints 2/3 carry y-offsets of 0.005375 / -0.006375 m
+that displace joint-3's axis ~12 mm off the joint-0/1 common point.
+The wrist is closer to spherical (~0.4 mm drift on joint-7).
+
+ssik's `is_srs_7r` predicate correctly rejects Gen3, and the
+dispatcher routes it through `jointlock + HP` for slow-but-correct IK.
+A future fast path is tracked in #193 (generalised approximate-SRS
++ LM polish).
+
+This test contract:
+
+- predicate refuses Gen3 (correct non-SRS classification).
+- dispatcher picks `jointlock.seven_r`.
+- hand-picked + random poses solve via jointlock+HP, FK closure < 1e-10.
+
+Source URDF: ``tests/fixtures/gen3.urdf``, vendored from
+https://github.com/Kinovarobotics/ros_kortex (noetic-devel branch,
+``kortex_description/arms/gen3/7dof/urdf/GEN3-7DOF-NOVISION_FOR_URDF_ARM_V12.urdf``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import dispatch
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import is_srs_7r
+from ssik.solvers.jointlock import seven_r as jointlock_seven_r
+
+GEN3_URDF = Path(__file__).parent / "fixtures" / "gen3.urdf"
+
+
+def _gen3_kinbody():
+    return load_urdf_kinbody_normalized(GEN3_URDF, "base_link", "end_effector_link")
+
+
+# ----------------------------------------------------------------------------
+# URDF load + topology classification
+# ----------------------------------------------------------------------------
+
+
+def test_gen3_loads_as_7r() -> None:
+    kb = _gen3_kinbody()
+    assert len(kb.joints) == 7
+    for j in kb.joints:
+        assert j.joint_type == "revolute"
+
+
+def test_gen3_is_not_pure_srs() -> None:
+    """Gen3's URDF y-offsets break strict SRS structure (#193).
+
+    Joint-3 axis is ~12 mm off the joint-0/1 common point because of
+    the 5.375 / -6.375 mm motor-housing offsets in the URDF. ssik
+    correctly refuses to classify it as SRS — the fast path is
+    tracked in #193 (approximate-SRS + LM polish).
+    """
+    kb = _gen3_kinbody()
+    assert is_srs_7r(kb, DEFAULT_TOLERANCE_POLICY) is None
+
+
+def test_gen3_dispatches_to_jointlock_hp() -> None:
+    """Dispatcher routes Gen3 through jointlock+HP (universal fallback)."""
+    kb = _gen3_kinbody()
+    plan = dispatch(kb)
+    assert plan.solver_name == "jointlock.seven_r"
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked seeded recovery via jointlock+HP
+# ----------------------------------------------------------------------------
+
+
+_HAND_PICKED_Q = [
+    np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2]),
+    np.array([-0.5, 0.3, -0.7, 1.0, -0.4, 0.5, -0.3]),
+    np.array([0.0, 0.5, 0.0, 1.5, 0.0, -0.5, 0.0]),  # elbow-folded
+    np.array([1.2, -0.8, 0.3, 0.4, 1.1, -0.6, 0.9]),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_gen3_hand_picked_fk_closure(q_star: np.ndarray) -> None:
+    """Every IK returned at a reachable Gen3 pose FK-closes < 1e-10.
+
+    Marked slow: jointlock+HP takes ~2 s per IK on Gen3; the full
+    parametrize is ~8 s.
+    """
+    kb = _gen3_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert not is_ls
+    assert sols, f"jointlock+HP returned no IK for reachable pose q={q_star}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"best FK closure {best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Hypothesis fuzz: random reachable poses (slow — small N because each
+# call is ~2 s through jointlock+HP)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_gen3_random_pose_fk_closure(seed: int) -> None:
+    """Random q in [-0.8, 0.8] per joint: at least one returned IK
+    must FK-close < 1e-10.
+
+    N=10 because each call is ~2 s through jointlock+HP (the full
+    test takes ~20 s). Will be tightened to N=500 once #193 polished
+    SRS lands and per-IK time drops to ~10-20 ms.
+    """
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    kb = _gen3_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert sols, f"random reachable pose returned no IK: q*={q_star.tolist()}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"random pose seed={seed}: best FK={best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Drift characterisation (documents the non-SRS-ness for #193)
+# ----------------------------------------------------------------------------
+
+
+def test_gen3_drift_documented() -> None:
+    """Gen3's shoulder drift ~12 mm and wrist drift ~0.4 mm are
+    documented as the input to #193.
+
+    This test pins the measured values so a future URDF revision that
+    changes the offsets is detected loudly.
+    """
+    from ssik.kinematics.predicates import joint_origins
+
+    kb = _gen3_kinbody()
+    origins = joint_origins(kb.joints)
+
+    # Shoulder triple (joints 0, 1, 2): drift of axis 2 from the
+    # (axis 0, axis 1) common point.
+    axes = [kb.joints[i].axis for i in (0, 1, 2)]
+    pts = [origins[i] for i in (0, 1, 2)]
+    M = np.column_stack([axes[0], -axes[1]])
+    sol, *_ = np.linalg.lstsq(M, pts[1] - pts[0], rcond=None)
+    common_sh = pts[0] + float(sol[0]) * axes[0]
+    delta = common_sh - pts[2]
+    perp = delta - float(np.dot(delta, axes[2])) * axes[2]
+    shoulder_drift = float(np.linalg.norm(perp))
+
+    # Wrist triple (joints 4, 5, 6).
+    axes = [kb.joints[i].axis for i in (4, 5, 6)]
+    pts = [origins[i] for i in (4, 5, 6)]
+    M = np.column_stack([axes[0], -axes[1]])
+    sol, *_ = np.linalg.lstsq(M, pts[1] - pts[0], rcond=None)
+    common_wr = pts[0] + float(sol[0]) * axes[0]
+    delta = common_wr - pts[2]
+    perp = delta - float(np.dot(delta, axes[2])) * axes[2]
+    wrist_drift = float(np.linalg.norm(perp))
+
+    # Pinned values from the vendored URDF (V12, no-vision). A change
+    # to either reflects a URDF revision and should be reviewed.
+    assert 0.011 < shoulder_drift < 0.013, f"shoulder drift {shoulder_drift:.4f} m"
+    assert 3e-4 < wrist_drift < 4e-4, f"wrist drift {wrist_drift:.4e} m"


### PR DESCRIPTION
## Summary

First fixture from the priority-1 fixture pack (#80): Kinova Gen3 7-DOF.

**Key finding**: Gen3 is **NOT pure SRS** in its URDF — contrary to literature classification (EAIK, IK-Geo papers). Joints 2/3 have ~5 mm motor-housing y-offsets that displace joint-3's axis **~12 mm** off the joint-0/1 common point. ssik's predicate correctly rejects it; dispatcher routes through \`jointlock + HP\` (slow but bulletproof, ~1 s per IK).

The fast path is tracked separately in **#193** — generalised approximate-SRS + Newton polish (idealised SRS warm-start + LM polish on the true URDF FK, estimated ~10–20 ms per IK).

## Drift analysis

| Triple | Drift |
|---|---|
| Shoulder (joints 0/1/2) | ~12 mm |
| Wrist (joints 4/5/6) | ~0.4 mm |

Pinned in \`test_gen3_drift_documented\` — a future URDF revision that changes these values will fail loudly.

## Test contract

| Test | Status |
|---|---|
| Predicate refuses Gen3 | ✅ |
| Dispatcher picks \`jointlock.seven_r\` | ✅ |
| 4 hand-picked poses, FK <1e-10 | ✅ (slow, ~7 s) |
| 10 random poses (Hypothesis), FK <1e-10 | ✅ (slow, ~1 s) |
| Drift magnitudes pinned | ✅ |

Random pose count is N=10 (instead of usual N=100/500) because each call is ~1 s through jointlock+HP. Will be tightened to N=500 once #193 lands and per-IK time drops to ~10–20 ms.

## Strategic implications (full writeup in #80 + #193)

- The \"SRS family\" we expected the predicate to auto-apply to is much smaller than the EAIK literature classification suggests. Of the candidate fixtures, only iiwa14 (and likely iiwa LBR 7) are genuinely pure SRS in URDF.
- Gen3, Rizon 4, Kassow KR810 all have URDF offsets that break strict SRS structure (drift table updated on #80).
- This is a quality difference, not a coverage gap: ssik solves the **real URDF** kinematics; EAIK solves a **simplified DH** that drops the offsets, costing mm- to cm-scale IK error.

## Test plan

- [x] \`uv run pytest tests/test_kinova_gen3.py -v\` — 4 fast tests pass
- [x] \`uv run pytest tests/test_kinova_gen3.py -v -m slow\` — 5 slow tests pass (~8 s)
- [x] \`uv run ruff check tests/test_kinova_gen3.py\` — clean
- [x] \`uv run ruff format --check tests/test_kinova_gen3.py\` — clean
- [x] \`uv run pytest -q\` — full suite (existing tests unaffected)

## Source URDF

\`tests/fixtures/gen3.urdf\` vendored from https://github.com/Kinovarobotics/ros_kortex/blob/noetic-devel/kortex_description/arms/gen3/7dof/urdf/GEN3-7DOF-NOVISION_FOR_URDF_ARM_V12.urdf — 8.9 KB, no mesh references needed (URDF loader uses \`lazy_load_meshes=True\`).