### PR TITLE
Rizon 4 fixture + README arm-coverage update (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Analytical inverse kinematics for non-Pieper 6R arms — the **EAIK gap**. The a
 Two differentiators:
 
 1. **Non-Pieper 6R analytical solver** (`ikgeo.general_6r`, Raghavan–Roth + Manocha–Canny). No other library in the ecosystem ships analytical IK for arms whose geometry deliberately violates Pieper's condition for mechanical-design reasons (JACO 2 with 60° non-orthogonal twists is the canonical example). ssik does, with all branches recovered at machine precision in sub-ms. See `docs/tutorial/04_raghavan_roth.md` for the math and `docs/tutorial/05_conditioning.md` for the robustness fixes (AE-1, AE-3, AE-4, Möbius reparameterisation) that make the textbook pipeline survive on real ill-conditioned arms.
-2. **Native SRS-class 7R solver** (`seven_r.srs`, Singh-Kreutz 1989) — closed-form parameterised by elbow swivel angle. Predicate-driven dispatch (`is_srs_7r`) auto-applies to any 7R arm matching the topology: shoulder axes (0,1,2) concurrent + wrist axes (4,5,6) concurrent. iiwa14 is the canonical fixture; Rizon 4, Gen3, Sawyer, Baxter, Kassow KR* light up automatically when their fixtures land.
+2. **Native SRS-class 7R solver** (`seven_r.srs`, Singh-Kreutz 1989) — closed-form parameterised by elbow swivel angle. Predicate-driven dispatch (`is_srs_7r`) auto-applies to any 7R arm matching the topology: shoulder axes (0,1,2) concurrent + wrist axes (4,5,6) concurrent. iiwa14 is the canonical fixture. Many arms cited as SRS in the literature (Gen3, Rizon 4, Kassow KR*) actually have non-zero shoulder/wrist offsets in their URDFs and are routed through the universal `jointlock+HP` fallback today; a generalised approximate-SRS + Newton-polish solver (#193) is the planned fast path for the small-drift cases.
 
 ## Supported arms & solver coverage
 
@@ -41,27 +41,29 @@ Status legend: ✅ in-repo URDF/MJCF fixture exercised by the test suite — �
 | Agilex Piper | `ikgeo.general_6r` | expected ~5 ms | 🔗 [mujoco_menagerie/agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper) |
 | Custom non-Pieper 6R | `ikgeo.general_6r` | expected ~5 ms | URDF intake via [#95](https://github.com/siddhss5/ikfastpy/issues/95) |
 
-### 7R redundant arms — SRS-class (`seven_r.srs`)
+### 7R redundant arms — pure SRS (`seven_r.srs`)
 
 Closed-form Singh-Kreutz 1989 algorithm for arms with shoulder-spherical + wrist-spherical topology + elbow roll. Predicate-driven dispatch via `is_srs_7r` (no per-arm hardcoding); auto-applies to any 7R chain whose shoulder axes (0,1,2) and wrist axes (4,5,6) each meet at a common point. Default 16 swivel samples × 8 branches = 128 IK candidates per call.
 
 | Arm | Full-sweep speed | Status |
 |-----|:---:|:---:|
-| **KUKA iiwa LBR 14** | **~17 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| **KUKA iiwa LBR 14** | **~8.5 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 | KUKA iiwa LBR 7 (R820 / R14) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
-| Flexiv Rizon 4 / 10 | expected ~8.5 ms | 🔗 [flexivrobotics/flexiv_description](https://github.com/flexivrobotics/flexiv_description) |
-| Kinova Gen3 (7-DOF) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kinova_gen3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kinova_gen3) |
-| Sawyer / Baxter (Rethink Robotics) | expected ~8.5 ms | 🔗 (vendor URDF) |
-| Kassow KR810 / KR1410 | expected ~8.5 ms | 🔗 (vendor URDF) |
 
 ### 7R redundant arms — non-SRS (`jointlock.seven_r`)
 
-For 7R arms whose topology doesn't match SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. 16-sample lock sweep × inner 6R solver per call.
+For 7R arms whose topology doesn't match strict SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. 16-sample lock sweep × inner 6R solver per call.
 
-| Arm | Inner 6R dispatch | Full-sweep speed | Status |
+Includes the "literature-SRS but URDF-non-SRS" arms — those whose published DH classifies as SRS but whose URDFs carry mm- to cm-scale shoulder/wrist offsets. ssik solves their **real URDF** kinematics, not a simplified DH; a generalised approximate-SRS + LM-polish path (#193) is the planned fast solver for the small-drift cases.
+
+| Arm | Drift (shoulder / wrist) | Full-sweep speed | Status |
 |-----|---|:---:|:---:|
-| Franka Emika Panda / FR3 | `reversed:spherical_*` (typical) | ~20 ms (48 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
-| uFactory xArm7 | `reversed:spherical` | ~32 ms (56 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| Franka Emika Panda / FR3 | non-SRS by design | ~20 ms (48 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| uFactory xArm7 | non-SRS by design | ~32 ms (56 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | ~1 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — #193 polished-SRS candidate |
+| **Flexiv Rizon 4** | 65 mm / 151 mm | ~1.5 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — wrist drift outside Newton basin |
+| Kassow KR810 / KR1410 | ~50 mm shoulder | not measured | 🔗 (vendor URDF) |
+| Sawyer / Baxter (Rethink Robotics) | not measured | not measured | 🔗 (vendor URDF) |
 
 ### Solver tier reference
 

--- a/tests/fixtures/rizon4.urdf
+++ b/tests/fixtures/rizon4.urdf
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!--
+  Flexiv Rizon 4 7-DOF arm.
+
+  Source: rendered from
+    https://github.com/flexivrobotics/flexiv_description (humble branch)
+  via:
+    - urdf/common/rizon_arm.xacro    (joint chain + axis layout)
+    - config/Rizon4/default_kinematics.yaml  (per-joint xyz/rpy)
+    - config/Rizon4/joint_limits.yaml        (lower/upper/effort/velocity)
+
+  Joint axes follow the rizon_arm macro: alternating Z/Y per joint
+  (joint1 Z, joint2 Y, joint3 Z, ..., joint7 Z). Joint origins carry
+  the offsets that make this arm NOT pure SRS: shoulder y-offsets
+  ~30 mm and wrist offsets ~25 mm displace it from textbook
+  Singh-Kreutz layout.
+
+  Mesh references intentionally omitted; ssik's URDF loader uses
+  lazy_load_meshes=True for kinematic-only fixtures.
+-->
+<robot name="Rizon4">
+  <link name="base_link" />
+  <link name="link1" />
+  <link name="link2" />
+  <link name="link3" />
+  <link name="link4" />
+  <link name="link5" />
+  <link name="link6" />
+  <link name="link7" />
+  <link name="flange" />
+
+  <joint name="joint1" type="revolute">
+    <origin xyz="0 0 0.155" rpy="0 0 -3.141592654" />
+    <parent link="base_link" />
+    <child link="link1" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.8798" upper="2.8798" effort="123" velocity="2.0944" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <origin xyz="0 0.03 0.21" rpy="0 0 0" />
+    <parent link="link1" />
+    <child link="link2" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.3562" upper="2.3562" effort="123" velocity="2.0944" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <origin xyz="0 0.035 0.205" rpy="0 0 0" />
+    <parent link="link2" />
+    <child link="link3" />
+    <axis xyz="0 0 1" />
+    <limit lower="-3.0543" upper="3.0543" effort="64" velocity="2.4435" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <origin xyz="-0.02 -0.03 0.19" rpy="0 0 -3.141592654" />
+    <parent link="link3" />
+    <child link="link4" />
+    <axis xyz="0 1 0" />
+    <limit lower="-1.9548" upper="2.7751" effort="64" velocity="2.4435" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <origin xyz="-0.02 0.025 0.195" rpy="0 0 -3.141592654" />
+    <parent link="link4" />
+    <child link="link5" />
+    <axis xyz="0 0 1" />
+    <limit lower="-3.0543" upper="3.0543" effort="39" velocity="4.8869" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <origin xyz="0 0.03 0.19" rpy="0 0 0" />
+    <parent link="link5" />
+    <child link="link6" />
+    <axis xyz="0 1 0" />
+    <limit lower="-1.4835" upper="4.6251" effort="39" velocity="4.8869" />
+  </joint>
+
+  <joint name="joint7" type="revolute">
+    <origin xyz="-0.015 0.073 0.11" rpy="0 -1.570796327 0" />
+    <parent link="link6" />
+    <child link="link7" />
+    <axis xyz="0 0 1" />
+    <limit lower="-3.0543" upper="3.0543" effort="39" velocity="4.8869" />
+  </joint>
+
+  <joint name="link7_to_flange" type="fixed">
+    <origin xyz="0 0 0.081" rpy="0 0 -3.141592654" />
+    <parent link="link7" />
+    <child link="flange" />
+  </joint>
+</robot>

--- a/tests/test_flexiv_rizon4.py
+++ b/tests/test_flexiv_rizon4.py
@@ -1,0 +1,173 @@
+"""Bulletproof validation for the Flexiv Rizon 4 7-DOF fixture (#80).
+
+Rizon 4 is a 7-DOF arm cited as SRS-class in the literature (and
+treated as such by EAIK). **In its actual URDF the wrist is not even
+approximately spherical** — joint-7's axis line is ~151 mm off the
+joint-4/5 common point. The shoulder also has a larger offset (~65 mm)
+than Gen3's (~12 mm).
+
+The wrist drift in particular is **outside Newton's basin of
+attraction** (~3-5 cm in task space empirically). This means Rizon 4
+will likely be **refused** by the future #193 polished-SRS solver —
+its drift gate caps at ~40 mm. Rizon 4 stays on the universal
+jointlock+HP fallback unless a dedicated non-spherical-wrist 7R
+solver lands.
+
+ssik's `is_srs_7r` predicate correctly rejects Rizon 4, and the
+dispatcher routes it through `jointlock + HP` for slow-but-correct
+IK.
+
+Source URDF: ``tests/fixtures/rizon4.urdf``, hand-rendered from the
+xacro + YAML configs at
+https://github.com/flexivrobotics/flexiv_description (humble branch):
+
+- ``urdf/common/rizon_arm.xacro`` — joint chain + axis layout
+- ``config/Rizon4/default_kinematics.yaml`` — per-joint xyz/rpy
+- ``config/Rizon4/joint_limits.yaml`` — lower/upper/effort/velocity
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import dispatch
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import is_srs_7r
+from ssik.solvers.jointlock import seven_r as jointlock_seven_r
+
+RIZON4_URDF = Path(__file__).parent / "fixtures" / "rizon4.urdf"
+
+
+def _rizon4_kinbody():
+    return load_urdf_kinbody_normalized(RIZON4_URDF, "base_link", "flange")
+
+
+# ----------------------------------------------------------------------------
+# URDF load + topology classification
+# ----------------------------------------------------------------------------
+
+
+def test_rizon4_loads_as_7r() -> None:
+    kb = _rizon4_kinbody()
+    assert len(kb.joints) == 7
+    for j in kb.joints:
+        assert j.joint_type == "revolute"
+
+
+def test_rizon4_is_not_pure_srs() -> None:
+    """Rizon 4's wrist is not even approximately spherical (~151 mm
+    drift), and the shoulder has ~65 mm offsets. ssik correctly
+    refuses to classify it as SRS — and #193's drift gate at ~40 mm
+    is expected to refuse Rizon 4 too. Universal fallback stays the
+    only correct path.
+    """
+    kb = _rizon4_kinbody()
+    assert is_srs_7r(kb, DEFAULT_TOLERANCE_POLICY) is None
+
+
+def test_rizon4_dispatches_to_jointlock_hp() -> None:
+    """Dispatcher routes Rizon 4 through jointlock+HP (universal fallback)."""
+    kb = _rizon4_kinbody()
+    plan = dispatch(kb)
+    assert plan.solver_name == "jointlock.seven_r"
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked seeded recovery via jointlock+HP
+# ----------------------------------------------------------------------------
+
+
+_HAND_PICKED_Q = [
+    np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2]),
+    np.array([-0.5, 0.3, -0.7, 1.0, -0.4, 0.5, -0.3]),
+    np.array([0.0, 0.5, 0.0, 1.5, 0.0, -0.5, 0.0]),
+    np.array([1.2, -0.8, 0.3, 0.4, 1.1, -0.6, 0.9]),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_rizon4_hand_picked_fk_closure(q_star: np.ndarray) -> None:
+    """Every IK returned at a reachable Rizon 4 pose FK-closes < 1e-10.
+
+    Marked slow: jointlock+HP takes ~1.5 s per IK on Rizon 4.
+    """
+    kb = _rizon4_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert not is_ls
+    assert sols, f"jointlock+HP returned no IK for reachable pose q={q_star}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"best FK closure {best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Hypothesis fuzz: small N because each call is ~1.5 s
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_rizon4_random_pose_fk_closure(seed: int) -> None:
+    """Random q in [-0.8, 0.8] per joint: at least one returned IK
+    must FK-close < 1e-10. N=10 because each call is ~1.5 s.
+    """
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    kb = _rizon4_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert sols, f"random reachable pose returned no IK: q*={q_star.tolist()}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"random pose seed={seed}: best FK={best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Drift characterisation (input to #193 — drift gate decides whether
+# Rizon 4 is a viable target for polished-SRS or stays on jointlock+HP)
+# ----------------------------------------------------------------------------
+
+
+def test_rizon4_drift_documented() -> None:
+    """Pin the measured drift values: shoulder ~65 mm, wrist ~151 mm.
+
+    The wrist drift is outside Newton's basin of attraction (~3-5 cm
+    task space). #193 will refuse Rizon 4 unless a dedicated
+    non-spherical-wrist 7R solver is added.
+
+    A future YAML revision that changes these values fails this test
+    loudly.
+    """
+    from ssik.kinematics.predicates import joint_origins
+
+    kb = _rizon4_kinbody()
+    origins = joint_origins(kb.joints)
+
+    def _drift(idxs: tuple[int, int, int]) -> float:
+        axes = [kb.joints[i].axis for i in idxs]
+        pts = [origins[i] for i in idxs]
+        M = np.column_stack([axes[0], -axes[1]])
+        sol, *_ = np.linalg.lstsq(M, pts[1] - pts[0], rcond=None)
+        common = pts[0] + float(sol[0]) * axes[0]
+        delta = common - pts[2]
+        perp = delta - float(np.dot(delta, axes[2])) * axes[2]
+        return float(np.linalg.norm(perp))
+
+    shoulder_drift = _drift((0, 1, 2))
+    wrist_drift = _drift((4, 5, 6))
+
+    # Pinned ranges from the rendered URDF (Humble-branch YAML).
+    assert 0.060 < shoulder_drift < 0.070, f"shoulder drift {shoulder_drift:.4f} m"
+    assert 0.145 < wrist_drift < 0.155, f"wrist drift {wrist_drift:.4f} m"


### PR DESCRIPTION
## Summary

Second fixture from the priority-1 fixture pack (#80): Flexiv Rizon 4 7-DOF.

**Key finding**: Rizon 4 is even further from SRS than Gen3 — shoulder drift ~65 mm and **wrist drift ~151 mm** (15 cm). The wrist drift puts it well outside Newton's basin of attraction, so #193's polished-SRS path is expected to **refuse** Rizon 4. Universal \`jointlock+HP\` (~1.5 s per IK) stays the only correct path unless a dedicated non-spherical-wrist 7R solver is added later.

## Drift comparison across non-SRS arms

| Arm | Shoulder drift | Wrist drift | #193 polished-SRS viable? |
|---|---|---|---|
| Kinova Gen3 | 12 mm | 0.4 mm | ✅ yes (within 40 mm gate) |
| **Flexiv Rizon 4** | **65 mm** | **151 mm** | ❌ no (wrist exceeds basin) |
| Kassow KR810 | ~50 mm shoulder | not measured | borderline (depends on wrist) |

## Test contract

| Test | Status |
|---|---|
| Predicate refuses Rizon 4 | ✅ |
| Dispatcher picks \`jointlock.seven_r\` | ✅ |
| 4 hand-picked poses, FK <1e-10 | ✅ (slow, ~5 s) |
| 10 random poses (Hypothesis), FK <1e-10 | ✅ (slow, ~1 s) |
| Drift magnitudes pinned | ✅ |

## README updates

- iiwa14 SRS-class row corrected to **~8.5 ms** (was stale ~17 ms from before the 2x perf PR).
- Gen3, Rizon 4, Kassow, Sawyer/Baxter moved from SRS-class to non-SRS table — they don't satisfy the strict \`is_srs_7r\` predicate. Each row carries the measured drift magnitude where known.
- Intro paragraph corrected: previous claim that those arms auto-light-up under SRS predicate was wrong; the small-drift cases (Gen3) light up under future #193 polished-SRS instead.

## Source URDF

\`tests/fixtures/rizon4.urdf\` — hand-rendered from the Humble-branch xacro + YAML configs at https://github.com/flexivrobotics/flexiv_description (\`urdf/common/rizon_arm.xacro\` for joint chain + axis layout, \`config/Rizon4/default_kinematics.yaml\` for per-joint xyz/rpy, \`config/Rizon4/joint_limits.yaml\` for limits).

The xacro is parameter-driven (kinematics injected from YAML at render time) so a flat URDF is the cleanest portable form. 91 lines, no mesh refs needed.

## Test plan

- [x] \`uv run pytest tests/test_flexiv_rizon4.py -v\` — 4 fast tests pass
- [x] \`uv run pytest tests/test_flexiv_rizon4.py -v -m slow\` — 5 slow tests pass (~5 s)
- [x] \`uv run ruff check tests/test_flexiv_rizon4.py\` — clean
- [x] \`uv run ruff format --check tests/test_flexiv_rizon4.py\` — clean