### PR TITLE
Kassow KR810 fixture + drift summary across non-SRS 7R family (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Includes the "literature-SRS but URDF-non-SRS" arms — those whose published DH
 | uFactory xArm7 | non-SRS by design | ~32 ms (56 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 | **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | ~1 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — #193 polished-SRS candidate |
 | **Flexiv Rizon 4** | 65 mm / 151 mm | ~1.5 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — wrist drift outside Newton basin |
-| Kassow KR810 / KR1410 | ~50 mm shoulder | not measured | 🔗 (vendor URDF) |
+| **Kassow KR810** | 86 mm / 111 mm | ~1.5 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — wrist drift outside Newton basin |
+| Kassow KR1018 / KR1410 / KR1805 | similar geometry, expected ~80-110 mm | not measured | 🔗 [rcruzoliver/kr_ros2](https://github.com/rcruzoliver/kr_ros2) |
 | Sawyer / Baxter (Rethink Robotics) | not measured | not measured | 🔗 (vendor URDF) |
 
 ### Solver tier reference

--- a/tests/fixtures/kassow_kr810.urdf
+++ b/tests/fixtures/kassow_kr810.urdf
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<!--
+  Kassow Robots KR810 7-DOF arm.
+
+  Source: rendered from
+    https://github.com/rcruzoliver/kr_ros2 (main branch)
+    kr_robot_description/kr810/urdf/kr810_description.urdf.xacro
+
+  The xacro represents the chain with phantom fixed links between
+  active revolute joints (jointPL2, jointPL4, jointPL6 carry the
+  motor-housing offsets). This flat URDF inlines those fixed
+  transforms into the next active joint's origin to keep the chain
+  linear.
+
+  Active-joint origin computation (scale = 0.001 m / mm):
+
+    joint_1 (Z):  (0, 0, base_outer_height + base_inner_height)
+                = (0, 0, 0.035)
+    joint_2 (Y):  (joint1_x, joint1_y, joint1_z)
+                = (0.050, 0, 0.2737)
+    joint_3 (Z):  (jointPL2_x, jointPL2_y, 0) + (0, 0, link2_length)
+                = (-0.050, -0.0857, 0.274)
+    joint_4 (Y):  (joint3_x, joint3_y, joint3_z)
+                = (0.040, 0, 0.1429)
+    joint_5 (Z):  (jointPL4_x, jointPL4_y, jointPL4_z) + (0, 0, link4_length)
+                = (-0.040, 0.08405, 0.271)
+    joint_6 (Y):  (0, 0, joint5_zoffset)
+                = (0, 0, 0.1035)
+    joint_7 (Z):  (0, jointPL6_y, 0) + (0, 0, joint6_zoffset)
+                = (0, 0.111, 0.108)
+
+  No tool/flange offset post-joint-7; end_effector is joint_7's
+  direct child in the source xacro. Mesh references intentionally
+  omitted; ssik's URDF loader uses lazy_load_meshes=True.
+-->
+<robot name="KassowKR810">
+  <link name="base" />
+  <link name="link1" />
+  <link name="link2" />
+  <link name="link3" />
+  <link name="link4" />
+  <link name="link5" />
+  <link name="link6" />
+  <link name="end_effector" />
+
+  <joint name="joint_1" type="revolute">
+    <origin xyz="0 0 0.035" rpy="0 0 0" />
+    <parent link="base" />
+    <child link="link1" />
+    <axis xyz="0 0 1" />
+    <limit lower="-6.283185307" upper="6.283185307" effort="204" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_2" type="revolute">
+    <origin xyz="0.050 0 0.2737" rpy="0 0 0" />
+    <parent link="link1" />
+    <child link="link2" />
+    <axis xyz="0 1 0" />
+    <limit lower="-1.221730476" upper="3.141592654" effort="204" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_3" type="revolute">
+    <origin xyz="-0.050 -0.0857 0.274" rpy="0 0 0" />
+    <parent link="link2" />
+    <child link="link3" />
+    <axis xyz="0 0 1" />
+    <limit lower="-6.283185307" upper="6.283185307" effort="85" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_4" type="revolute">
+    <origin xyz="0.040 0 0.1429" rpy="0 0 0" />
+    <parent link="link3" />
+    <child link="link4" />
+    <axis xyz="0 1 0" />
+    <limit lower="-1.221730476" upper="3.141592654" effort="85" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_5" type="revolute">
+    <origin xyz="-0.040 0.08405 0.271" rpy="0 0 0" />
+    <parent link="link4" />
+    <child link="link5" />
+    <axis xyz="0 0 1" />
+    <limit lower="-6.283185307" upper="6.283185307" effort="51" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_6" type="revolute">
+    <origin xyz="0 0 0.1035" rpy="0 0 0" />
+    <parent link="link5" />
+    <child link="link6" />
+    <axis xyz="0 1 0" />
+    <limit lower="-6.283185307" upper="6.283185307" effort="51" velocity="3.927" />
+  </joint>
+
+  <joint name="joint_7" type="revolute">
+    <origin xyz="0 0.111 0.108" rpy="0 0 0" />
+    <parent link="link6" />
+    <child link="end_effector" />
+    <axis xyz="0 0 1" />
+    <limit lower="-6.283185307" upper="6.283185307" effort="51" velocity="3.927" />
+  </joint>
+</robot>

--- a/tests/test_kassow_kr810.py
+++ b/tests/test_kassow_kr810.py
@@ -1,0 +1,161 @@
+"""Bulletproof validation for the Kassow Robots KR810 7-DOF fixture (#80).
+
+KR810 is a 7-DOF arm in the Kassow KR* series (KR810 / KR1018 /
+KR1410 / KR1805). Often grouped with the SRS family in the 7R
+literature, but its **URDF carries motor-housing offsets that put
+both shoulder and wrist well outside strict SRS structure**:
+
+  * shoulder drift ~86 mm (joint-3 axis displaced from the
+    joint-0/1 common point)
+  * wrist drift ~111 mm (joint-7 axis displaced from the joint-4/5
+    common point)
+
+Both drifts exceed Newton's basin of attraction (~3-5 cm task
+space), so the future #193 polished-SRS solver is expected to
+**refuse** KR810. The universal `jointlock + HP` fallback
+(~1.5 s per IK on M3) is the only correct path unless a dedicated
+non-spherical-wrist 7R solver lands later.
+
+ssik's `is_srs_7r` predicate correctly rejects KR810; dispatcher
+routes through `jointlock + HP`.
+
+Source URDF: ``tests/fixtures/kassow_kr810.urdf``, hand-rendered
+from the xacro at https://github.com/rcruzoliver/kr_ros2 (main
+branch), ``kr_robot_description/kr810/urdf/kr810_description.urdf.xacro``.
+The xacro represents the chain with phantom fixed links between
+active joints (carrying motor-housing offsets); the flat URDF
+inlines those into each active joint's origin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import dispatch
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import is_srs_7r
+from ssik.solvers.jointlock import seven_r as jointlock_seven_r
+
+KR810_URDF = Path(__file__).parent / "fixtures" / "kassow_kr810.urdf"
+
+
+def _kr810_kinbody():
+    return load_urdf_kinbody_normalized(KR810_URDF, "base", "end_effector")
+
+
+# ----------------------------------------------------------------------------
+# URDF load + topology classification
+# ----------------------------------------------------------------------------
+
+
+def test_kr810_loads_as_7r() -> None:
+    kb = _kr810_kinbody()
+    assert len(kb.joints) == 7
+    for j in kb.joints:
+        assert j.joint_type == "revolute"
+
+
+def test_kr810_is_not_pure_srs() -> None:
+    """KR810's shoulder + wrist offsets break strict SRS structure
+    by enough that #193's polished-SRS path is also expected to
+    refuse it (drift gate ~40 mm).
+    """
+    kb = _kr810_kinbody()
+    assert is_srs_7r(kb, DEFAULT_TOLERANCE_POLICY) is None
+
+
+def test_kr810_dispatches_to_jointlock_hp() -> None:
+    """Dispatcher routes KR810 through jointlock+HP (universal fallback)."""
+    kb = _kr810_kinbody()
+    plan = dispatch(kb)
+    assert plan.solver_name == "jointlock.seven_r"
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked seeded recovery via jointlock+HP
+# ----------------------------------------------------------------------------
+
+
+_HAND_PICKED_Q = [
+    np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2]),
+    np.array([-0.5, 0.3, -0.7, 1.0, -0.4, 0.5, -0.3]),
+    np.array([0.0, 0.5, 0.0, 1.5, 0.0, -0.5, 0.0]),
+    np.array([1.2, -0.8, 0.3, 0.4, 1.1, -0.6, 0.9]),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_kr810_hand_picked_fk_closure(q_star: np.ndarray) -> None:
+    """Every IK returned at a reachable KR810 pose FK-closes < 1e-10.
+
+    Marked slow: jointlock+HP takes ~1.5 s per IK.
+    """
+    kb = _kr810_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert not is_ls
+    assert sols, f"jointlock+HP returned no IK for reachable pose q={q_star}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"best FK closure {best_fk:.2e} > 1e-10"
+
+
+@pytest.mark.slow
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_kr810_random_pose_fk_closure(seed: int) -> None:
+    """Random q in [-0.8, 0.8] per joint: at least one returned IK
+    must FK-close < 1e-10. N=10 because each call is ~1.5 s.
+    """
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    kb = _kr810_kinbody()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = jointlock_seven_r.solve(kb, T_target, allow_refinement=True)
+    assert sols, f"random reachable pose returned no IK: q*={q_star.tolist()}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"random pose seed={seed}: best FK={best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Drift characterisation
+# ----------------------------------------------------------------------------
+
+
+def test_kr810_drift_documented() -> None:
+    """Pin shoulder ~86 mm, wrist ~111 mm. Both exceed Newton's
+    basin (~3-5 cm), so #193 polished-SRS will refuse KR810. A
+    future xacro revision changing these values fails this test
+    loudly.
+    """
+    from ssik.kinematics.predicates import joint_origins
+
+    kb = _kr810_kinbody()
+    origins = joint_origins(kb.joints)
+
+    def _drift(idxs: tuple[int, int, int]) -> float:
+        axes = [kb.joints[i].axis for i in idxs]
+        pts = [origins[i] for i in idxs]
+        M = np.column_stack([axes[0], -axes[1]])
+        sol, *_ = np.linalg.lstsq(M, pts[1] - pts[0], rcond=None)
+        common = pts[0] + float(sol[0]) * axes[0]
+        delta = common - pts[2]
+        perp = delta - float(np.dot(delta, axes[2])) * axes[2]
+        return float(np.linalg.norm(perp))
+
+    shoulder_drift = _drift((0, 1, 2))
+    wrist_drift = _drift((4, 5, 6))
+
+    assert 0.080 < shoulder_drift < 0.090, f"shoulder drift {shoulder_drift:.4f} m"
+    assert 0.105 < wrist_drift < 0.115, f"wrist drift {wrist_drift:.4f} m"


### PR DESCRIPTION
## Summary

Third (and final immediate-priority) fixture from #80: Kassow Robots KR810 7-DOF.

**Drift findings**: shoulder **~86 mm**, wrist **~111 mm**. Both exceed Newton's basin of attraction (~3-5 cm task space), so #193's polished-SRS path is expected to **refuse** KR810. Universal \`jointlock + HP\` (~1.5 s per IK) is the only correct path unless a dedicated non-spherical-wrist 7R solver lands later.

## Drift summary across the non-SRS 7R fixture family

With this PR, all three priority-1 fixtures land:

| Arm | Shoulder | Wrist | #193 polished-SRS viable? |
|---|---|---|---|
| Kinova Gen3 | 12 mm | 0.4 mm | ✅ yes |
| Flexiv Rizon 4 | 65 mm | 151 mm | ❌ wrist outside basin |
| **Kassow KR810** | **86 mm** | **111 mm** | ❌ wrist outside basin |

Only Gen3 is a viable polished-SRS target. Rizon 4 + KR810 stay on universal jointlock+HP forever unless a dedicated non-spherical-wrist 7R algorithm is added.

## Strategic finding

The "SRS family" claim in the IK literature substantially overstates the coverage of strict SRS solvers when applied to real URDFs. Three of the four most-cited "SRS 7R commercial arms" (Gen3, Rizon 4, Kassow KR*) have URDF offsets that break strict SRS structure; only iiwa LBR carries genuinely concurrent shoulder + wrist axes at the URDF level.

This is the **bulletproof-correctness vs literature-coverage tradeoff**: ssik solves the real URDF (correct, sometimes slow); EAIK solves a simplified DH (fast, ~5-50 mm IK error). Without measuring the URDF, the trade is invisible.

## Test contract

| Test | Status |
|---|---|
| Predicate refuses KR810 | ✅ |
| Dispatcher picks \`jointlock.seven_r\` | ✅ |
| 4 hand-picked poses, FK <1e-10 | ✅ (slow, ~6 s) |
| 10 random poses (Hypothesis), FK <1e-10 | ✅ (slow, ~2 s) |
| Drift magnitudes pinned | ✅ |

## Source URDF

\`tests/fixtures/kassow_kr810.urdf\` — hand-rendered from https://github.com/rcruzoliver/kr_ros2 (main branch), \`kr_robot_description/kr810/urdf/kr810_description.urdf.xacro\`. The xacro uses **phantom fixed links** (\`jointPL2\`, \`jointPL4\`, \`jointPL6\`) to carry motor-housing offsets between active joints; this flat URDF inlines those into each active joint's origin.

## README updates

- KR810 row added under non-SRS 7R with measured drift.
- KR1018 / KR1410 / KR1805 noted as similar-geometry siblings (not measured); link to source.

## Test plan

- [x] \`uv run pytest tests/test_kassow_kr810.py -v\` — 4 fast tests pass
- [x] \`uv run pytest tests/test_kassow_kr810.py -v -m slow\` — 5 slow tests pass (~8 s)
- [x] \`uv run ruff check tests/test_kassow_kr810.py\` — clean
- [x] \`uv run ruff format --check tests/test_kassow_kr810.py\` — clean

## Closes

Part of #80 (KR810). Remaining sub-tasks: iiwa LBR 7, Agilex Piper. Sawyer/Baxter deferred per scope decision.