### PR TITLE
seven_r.srs_polished: approximate-SRS + LM polish (Gen3 16x faster, #193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,23 @@ Closed-form Singh-Kreutz 1989 algorithm for arms with shoulder-spherical + wrist
 | **KUKA iiwa LBR 14** | **~8.5 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 | KUKA iiwa LBR 7 (R820 / R14) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
 
+### 7R redundant arms — approximately-SRS with LM polish (`seven_r.srs_polished`)
+
+For arms whose URDF axes only **nearly** meet at common shoulder/wrist points (Kinova Gen3: 12 mm shoulder + 0.4 mm wrist drift), the strict SRS predicate refuses but the relaxed-predicate Singh-Kreutz solver still produces good warm-start candidates. Each is LM-polished against the original URDF FK to reach machine-precision closure (FK ≤ 1e-10). 16-30× faster than `jointlock + HP` on small-drift arms, with no IK error against the real URDF (unlike EAIK's simplified-DH path).
+
+Refused (drift exceeds Newton's basin, ~3-5 cm): falls back to `jointlock + HP`.
+
 ### 7R redundant arms — non-SRS (`jointlock.seven_r`)
 
-For 7R arms whose topology doesn't match strict SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. 16-sample lock sweep × inner 6R solver per call.
+For 7R arms whose topology doesn't match strict or approximate SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. Tier-2 fallback inside jointlock is `husty_pfurner.general_6r` for sub-chains with no Pieper / parallel-axis structure. 16-sample lock sweep × inner 6R solver per call.
 
-Includes the "literature-SRS but URDF-non-SRS" arms — those whose published DH classifies as SRS but whose URDFs carry mm- to cm-scale shoulder/wrist offsets. ssik solves their **real URDF** kinematics, not a simplified DH; a generalised approximate-SRS + LM-polish path (#193) is the planned fast solver for the small-drift cases.
+Covers Franka Panda (anthropomorphic 7R), uFactory xArm7 (mixed structure), and the literature-SRS-but-URDF-far-from-SRS arms whose drift exceeds the polished-SRS basin (Flexiv Rizon 4: 151 mm wrist drift; Kassow KR810: 111 mm wrist drift).
 
 | Arm | Drift (shoulder / wrist) | Full-sweep speed | Status |
 |-----|---|:---:|:---:|
 | Franka Emika Panda / FR3 | non-SRS by design | ~20 ms (48 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 | uFactory xArm7 | non-SRS by design | ~32 ms (56 IKs) | ✅ in [`tests/fixtures/`](tests/fixtures/) |
-| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | ~1 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — #193 polished-SRS candidate |
+| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | **~95 ms (`seven_r.srs_polished`)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
 | **Flexiv Rizon 4** | 65 mm / 151 mm | ~1.5 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — wrist drift outside Newton basin |
 | **Kassow KR810** | 86 mm / 111 mm | ~1.5 s (jointlock+HP) | ✅ in [`tests/fixtures/`](tests/fixtures/) — wrist drift outside Newton basin |
 | Kassow KR1018 / KR1410 / KR1805 | similar geometry, expected ~80-110 mm | not measured | 🔗 [rcruzoliver/kr_ros2](https://github.com/rcruzoliver/kr_ros2) |
@@ -72,6 +78,7 @@ Includes the "literature-SRS but URDF-non-SRS" arms — those whose published DH
 |---|---|---|---|
 | 0 — closed-form 6R | `three_parallel`, `spherical_two_parallel`, `spherical_two_intersecting`, `spherical` | ~1 ms | SP1–SP6 composition; one branch per Pieper specialisation |
 | 0 — closed-form 7R (SRS) | `seven_r.srs` | ~8.5 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs |
+| 0 — approximate SRS + LM polish | `seven_r.srs_polished` | ~95 ms full sweep | Relaxed Singh-Kreutz (small-drift arms) + Newton polish to machine precision against the original URDF FK |
 | 1 — univariate search | `two_parallel`, `two_intersecting` | ~100 ms – 2 s | tan-half-angle reduction + 200-sample search + Newton polish |
 | 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms | lock one joint, dispatch inner 6R, sweep 16 lock samples |
 | 2 — Raghavan–Roth + Manocha–Canny | `ikgeo.general_6r` | ~0.6-5 ms | numeric RR resultant with AE-3 leftvar selection; **production tier-2** |

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -120,6 +120,7 @@ _SOLVER_ESTIMATES: dict[str, tuple[int, float, int]] = {
     "ikgeo.general_6r": (2, 5.0, 30_000_000),
     "husty_pfurner.general_6r": (2, 120.0, 50_000_000),
     "seven_r.srs": (0, 8.5, 1_900),  # native SRS-class 7R, full sweep (16 swivel x 8 branches)
+    "seven_r.srs_polished": (0, 95.0, 200_000),  # approximate-SRS + LM polish (Gen3 et al.)
     "jointlock.seven_r": (1, 50.0, 30_274),  # 7R wrapper around inner 6R
 }
 
@@ -144,10 +145,10 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
     """
     if len(kb.joints) == 7:
         # Tier-0 7R: native SRS-class analytical solver (Singh-Kreutz).
-        # Detects shoulder-spherical + wrist-spherical topology by axis
-        # concurrence. Auto-applies to KUKA iiwa LBR, Flexiv Rizon, Kinova
-        # Gen3, Sawyer, Baxter, Kassow KR* -- all the SRS-class arms.
-        from ssik.kinematics.predicates import is_srs_7r
+        # Detects shoulder-spherical + wrist-spherical topology by exact
+        # axis concurrence. Covers KUKA iiwa LBR (the canonical strict-SRS
+        # arm).
+        from ssik.kinematics.predicates import is_approximately_srs_7r, is_srs_7r
 
         if is_srs_7r(kb, policy) is not None:
             plan = _make_plan(
@@ -157,13 +158,36 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "one point + wrist axes (joints 4, 5, 6) meet at one\n"
                     "point + joint 3 is the elbow. Closed-form Singh-Kreutz\n"
                     "1989 algorithm, parameterised by elbow swivel angle.\n"
-                    "Covers KUKA iiwa LBR, Flexiv Rizon 4/10, Kinova Gen3,\n"
-                    "Sawyer, Baxter, Kassow KR810/KR1410."
+                    "Covers KUKA iiwa LBR (canonical strict-SRS)."
                 ),
                 needs_symbolic_precompute=False,
             )
             _LOG.info("dispatch: chose %s (tier 0, native SRS-7R)", plan.solver_name)
             return plan
+
+        # Tier-0 7R: approximate-SRS variant for arms whose URDF axes only
+        # nearly meet (Kinova Gen3: 12 mm shoulder + 0.4 mm wrist drift).
+        # Singh-Kreutz solver as warm-start factory + LM polish to
+        # machine precision against the original URDF FK.
+        approx = is_approximately_srs_7r(kb, max_drift_m=0.04, policy=policy)
+        if approx is not None:
+            plan = _make_plan(
+                "seven_r.srs_polished",
+                reason=(
+                    "Approximately-SRS 7R: shoulder axes meet within "
+                    f"{approx.shoulder_drift_m * 1000:.1f} mm, wrist axes "
+                    f"meet within {approx.wrist_drift_m * 1000:.1f} mm.\n"
+                    "Singh-Kreutz on the relaxed pivots produces algebraic\n"
+                    "candidates; LM polish recovers machine-precision FK\n"
+                    "against the original URDF. 16-30x faster than the\n"
+                    "universal jointlock+HP fallback on small-drift arms.\n"
+                    "Covers Kinova Gen3 (12 mm / 0.4 mm drift)."
+                ),
+                needs_symbolic_precompute=False,
+            )
+            _LOG.info("dispatch: chose %s (tier 0, approximate-SRS-7R)", plan.solver_name)
+            return plan
+
         # Tier-1 7R fallback: joint-lock + dispatch the inner 6R.
         plan = _make_plan(
             "jointlock.seven_r",

--- a/src/ssik/kinematics/predicates.py
+++ b/src/ssik/kinematics/predicates.py
@@ -36,9 +36,11 @@ if TYPE_CHECKING:  # pragma: no cover -- typing only
     from ssik._kinbody import Joint, KinBody
 
 __all__ = [
+    "ApproxSrsClassification",
     "axes_meet_at_common_point",
     "axis_intersect",
     "axis_parallel",
+    "is_approximately_srs_7r",
     "is_srs_7r",
     "joint_origins",
     "three_consecutive_intersecting",
@@ -61,6 +63,26 @@ class SrsClassification:
     wrist_indices: tuple[int, int, int]
     shoulder_pivot: NDArray[np.float64]
     wrist_pivot: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class ApproxSrsClassification:
+    """Result of :func:`is_approximately_srs_7r` -- approximate SRS evidence
+    plus the measured drift magnitudes that disqualified strict
+    classification.
+
+    Consumed by :mod:`ssik.solvers.seven_r.srs_polished`, which uses the
+    Singh-Kreutz solver as a warm-start factory and LM-polishes each
+    candidate against the original (non-snapped) URDF FK.
+    """
+
+    base: SrsClassification
+    shoulder_drift_m: float
+    wrist_drift_m: float
+
+    @property
+    def max_drift_m(self) -> float:
+        return max(self.shoulder_drift_m, self.wrist_drift_m)
 
 
 def joint_origins(joints: list[Joint]) -> list[NDArray[np.float64]]:
@@ -341,4 +363,85 @@ def is_srs_7r(
         wrist_indices=wrist,
         shoulder_pivot=s_pivot,
         wrist_pivot=w_pivot,
+    )
+
+
+def _max_axis_drift(
+    joints: list[Joint], indices: tuple[int, ...]
+) -> tuple[float, NDArray[np.float64] | None]:
+    """Best-fit common point + max perpendicular drift across the triple.
+
+    Always returns a numerical drift (does not refuse via tolerance).
+    Used by :func:`is_approximately_srs_7r` to gate on a user-supplied
+    drift budget.
+    """
+    if len(indices) < 2:
+        return 0.0, None
+    origins = joint_origins(joints)
+    axes = [joints[i].axis for i in indices]
+    pts = [origins[i] for i in indices]
+    # Pairwise non-parallel guard
+    for k in range(len(indices) - 1):
+        cross = _cross3(axes[k], axes[k + 1])
+        if float(_norm3(cross)) < 1e-9:
+            return float("inf"), None
+    M = np.column_stack([axes[0], -axes[1]])
+    sol, *_ = np.linalg.lstsq(M, pts[1] - pts[0], rcond=None)
+    common = pts[0] + float(sol[0]) * axes[0]
+    max_perp = 0.0
+    for k in range(len(indices)):
+        delta = common - pts[k]
+        perp = delta - _dot3(delta, axes[k]) * axes[k]
+        max_perp = max(max_perp, float(_norm3(perp)))
+    return max_perp, common
+
+
+def is_approximately_srs_7r(
+    kb: KinBody,
+    max_drift_m: float = 0.04,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+) -> ApproxSrsClassification | None:
+    """Detect approximate SRS-class 7R topology with a user-supplied drift gate.
+
+    Strict :func:`is_srs_7r` rejects arms whose shoulder/wrist axes only
+    *approximately* meet at a common point (Kinova Gen3: 12 mm shoulder
+    drift, 0.4 mm wrist drift; well above the default ``axis_intersect =
+    1e-8``). This relaxed variant accepts any arm whose maximum axis
+    drift is at most ``max_drift_m`` -- typically picked to keep the
+    snap-and-polish trajectory inside Newton's basin (~3-5 cm task
+    space empirically).
+
+    Returns :class:`ApproxSrsClassification` carrying the best-fit
+    pivots + the measured per-triple drifts. Caller is expected to
+    polish the algebraic candidates via LM (see
+    :mod:`ssik.solvers.seven_r.srs_polished`).
+
+    The drift gate refuses arms whose offsets exceed the basin (Flexiv
+    Rizon 4: 151 mm wrist drift; Kassow KR810: 111 mm wrist drift).
+    Those arms continue to dispatch to ``jointlock + HP``.
+
+    Parallel-axis triples are still rejected (the SRS algorithm is
+    ill-defined when axes are parallel, regardless of drift).
+    """
+    if len(kb.joints) != 7:
+        return None
+    shoulder = (0, 1, 2)
+    wrist = (4, 5, 6)
+    s_drift, s_pivot = _max_axis_drift(kb.joints, shoulder)
+    w_drift, w_pivot = _max_axis_drift(kb.joints, wrist)
+    if s_pivot is None or w_pivot is None:
+        return None
+    if s_drift > max_drift_m or w_drift > max_drift_m:
+        return None
+    base = SrsClassification(
+        shoulder_indices=shoulder,
+        elbow_index=3,
+        wrist_indices=wrist,
+        shoulder_pivot=s_pivot,
+        wrist_pivot=w_pivot,
+    )
+    return ApproxSrsClassification(
+        base=base,
+        shoulder_drift_m=s_drift,
+        wrist_drift_m=w_drift,
     )

--- a/src/ssik/solvers/seven_r/__init__.py
+++ b/src/ssik/solvers/seven_r/__init__.py
@@ -1,7 +1,12 @@
 """Native 7R analytical solvers.
 
-Currently houses the Singh-Kreutz SRS-class solver
-(:mod:`ssik.solvers.seven_r.srs`). Anthropomorphic 7R (Franka), other
-7R families, and parametric-redundancy variants land here as separate
-modules in future work.
+- :mod:`ssik.solvers.seven_r.srs` -- Singh-Kreutz strict-SRS solver
+  (iiwa14 and other arms with exactly-concurrent shoulder + wrist
+  axes).
+- :mod:`ssik.solvers.seven_r.srs_polished` -- approximate-SRS variant
+  with LM polish, for arms whose URDF axes only nearly meet (Kinova
+  Gen3 today; future small-drift arms via the predicate).
+
+Anthropomorphic 7R (Franka), other 7R families, and parametric-
+redundancy variants land here as separate modules in future work.
 """

--- a/src/ssik/solvers/seven_r/srs_polished.py
+++ b/src/ssik/solvers/seven_r/srs_polished.py
@@ -1,0 +1,257 @@
+"""Approximate-SRS 7R analytical IK + LM polish.
+
+Wraps :mod:`ssik.solvers.seven_r.srs` (Singh-Kreutz, strict-SRS) for
+arms whose URDF axes don't *exactly* meet at common shoulder/wrist
+points but whose drift is small enough to fit inside Newton's basin
+of attraction (~3-5 cm task space empirically, gated by
+``max_drift_m``).
+
+Algorithm:
+
+1. Run :func:`ssik.kinematics.predicates.is_approximately_srs_7r` to
+   accept the chain (refusing any arm whose drift exceeds the basin).
+2. Pass the relaxed-policy SRS classification to
+   :func:`ssik.solvers.seven_r.srs.solve` with a permissive ``fk_atol``
+   so it returns all algebraic candidates -- the candidates' FK
+   residuals are ~``max_drift_m`` because the solver assumes axes
+   meet exactly.
+3. LM-polish each candidate against the **original** (non-snapped)
+   URDF FK. Newton converges in 4-15 iterations from any seed inside
+   the basin; divergent seeds are dropped.
+4. Cluster-merge to drop duplicate IKs that polished into the same
+   solution (different SRS branches may collapse under perturbation).
+
+Targets:
+
+- **Kinova Gen3 7-DOF**: 12 mm shoulder + 0.4 mm wrist drift -- 16-30x
+  faster than ``jointlock + HP`` at machine-precision FK closure.
+- Future arms with similar drift profiles (auto via predicate; no
+  per-arm hardcoding).
+
+Refused (drift exceeds gate; falls back to ``jointlock + HP``):
+
+- Flexiv Rizon 4 / 10 (151 mm wrist drift).
+- Kassow KR810 (111 mm wrist drift).
+- Anthropomorphic 7R like Franka Panda (wrist axes don't meet at
+  one point in any home configuration).
+
+References:
+
+- Original Singh-Kreutz solver: :mod:`ssik.solvers.seven_r.srs`.
+- Refinement layer: :mod:`ssik.refinement` (LM polish, kinbody
+  Jacobian).
+- HP locked-7R perturbation pattern (precedent for "approximate
+  algebra + LM polish"): see :mod:`ssik.solvers.husty_pfurner`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import is_approximately_srs_7r
+from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian
+from ssik.solvers.seven_r import srs
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from ssik._kinbody import KinBody
+
+__all__ = ["solve"]
+
+_SOLVER_NAME = "seven_r.srs_polished"
+_LOG = logging.getLogger(__name__)
+_DEFAULT_MAX_DRIFT_M = 0.04
+
+
+def _polish_to_frobenius(
+    q_seed: NDArray[np.float64],
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+    *,
+    fk_atol: float,
+    max_iters: int,
+    step_clip: float = 0.5,
+    divergence_factor: float = 5.0,
+) -> tuple[NDArray[np.float64], float, int] | None:
+    """Newton polish on the spatial twist of ``T_target @ T_q^{-1}``,
+    convergent on the **Frobenius** ``||FK(q) - T_target||_F`` norm.
+
+    This is a workaround for the near-identity precision loss in
+    :func:`ssik.refinement.se3_log_residual` (the ``cos_a = (trace-1)/2``
+    formulation rounds to ``1.0`` in float64 when the rotation error is
+    below ~3e-8, silently zeroing the rotation part of the residual).
+    See #199.
+
+    The fix: compute the rotation part of the twist via the
+    skew-symmetric vee of ``R_err - R_err.T``, which preserves
+    precision down to machine epsilon. Translation is read directly
+    from ``T_err``. The convergence gate is the actual Frobenius FK
+    residual, so candidates can't slip through with hidden rotation
+    error.
+    """
+    q = q_seed.astype(np.float64).copy()
+    r_best = float("inf")
+    for it in range(max_iters):
+        T_q = poe_forward_kinematics(kb, q)
+        # Frobenius gate -- the contract callers expect.
+        frob = float(np.linalg.norm(T_q - T_target))
+        if frob < fk_atol:
+            return q, frob, it
+        if frob < r_best:
+            r_best = frob
+        elif it >= 4 and frob > divergence_factor * r_best:
+            return None
+        # Robust spatial twist: read translation directly, rotation via
+        # skew-vee of (R_err - R_err.T) / 2 (works at machine precision
+        # near identity).
+        T_err = T_target @ np.linalg.inv(T_q)
+        r_err = T_err[:3, :3]
+        omega = 0.5 * np.array(
+            [
+                r_err[2, 1] - r_err[1, 2],
+                r_err[0, 2] - r_err[2, 0],
+                r_err[1, 0] - r_err[0, 1],
+            ]
+        )
+        twist = np.concatenate([T_err[:3, 3], omega])
+        J = kinbody_jacobian(kb, q)
+        try:
+            dq = np.linalg.solve(J, twist)
+        except np.linalg.LinAlgError:
+            damping = max(1e-9, 1e-6 * frob)
+            n = J.shape[1]
+            dq = np.linalg.solve(J.T @ J + damping * np.eye(n), J.T @ twist)
+        dq = np.clip(dq, -step_clip, step_clip)
+        q = q + dq
+    # Final convergence check.
+    T_q = poe_forward_kinematics(kb, q)
+    frob = float(np.linalg.norm(T_q - T_target))
+    if frob < fk_atol:
+        return q, frob, max_iters
+    return None
+
+
+def solve(
+    kb: KinBody,
+    T_target: NDArray[np.float64],
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    *,
+    max_drift_m: float = _DEFAULT_MAX_DRIFT_M,
+    swivel_samples: int | NDArray[np.float64] = 16,
+    polish_max_iters: int = 30,
+    polish_fk_atol: float = 1e-12,
+    max_solutions: int | None = None,
+) -> tuple[list[Solution], bool]:
+    """Approximate-SRS 7R IK with LM polish.
+
+    :param kb: POE-normalized 7R :class:`KinBody`.
+    :param T_target: 4x4 target end-effector pose in the base frame.
+    :param policy: tolerance policy. ``policy.subproblem_dedup`` controls
+        the cluster-merge gate after polish.
+    :param max_drift_m: refusal gate; arms whose shoulder/wrist drift
+        exceeds this value (default 4 cm) raise :class:`ValueError`.
+        Tuned to keep the snap-and-polish trajectory inside Newton's
+        basin (~3-5 cm task space empirically).
+    :param swivel_samples: int N for uniform sweep over [-π, π], or an
+        explicit array of swivel angles. Forwarded to the inner SRS
+        solver.
+    :param polish_max_iters: per-candidate Newton iteration cap.
+    :param polish_fk_atol: target FK closure for accepting a polished
+        candidate. Default 1e-12 reaches the bulletproof fixture
+        contract (FK ≤ 1e-10).
+    :param max_solutions: optional cap on the number of polished
+        IKs returned.
+
+    :returns: ``(solutions, is_ls)``. ``is_ls=True`` iff zero
+        candidates polished to within ``polish_fk_atol``.
+
+    :raises ValueError: if ``kb`` is not 7-DOF or its drift exceeds
+        ``max_drift_m`` (i.e. arm is not approximately SRS).
+    """
+    if len(kb.joints) != 7:
+        raise ValueError(f"seven_r.srs_polished requires a 7-DOF chain; got {len(kb.joints)}")
+
+    cls = is_approximately_srs_7r(kb, max_drift_m=max_drift_m, policy=policy)
+    if cls is None:
+        raise ValueError(
+            f"seven_r.srs_polished requires approximately-SRS topology with "
+            f"max axis drift <= {max_drift_m} m. Use "
+            f"ssik.kinematics.predicates.is_approximately_srs_7r to check."
+        )
+
+    # Step 1: build a relaxed policy that lets the inner SRS solver
+    # accept the approximate pivots.
+    relaxed_policy = replace(policy, axis_intersect=max(max_drift_m, policy.axis_intersect))
+
+    # Step 2: run inner SRS with permissive FK tolerance to capture all
+    # algebraic candidates. They will have FK residual ~max_drift_m
+    # because the solver assumes axes meet exactly; LM polish corrects.
+    raw, _is_ls = srs.solve(
+        kb,
+        T_target,
+        policy=relaxed_policy,
+        swivel_samples=swivel_samples,
+        fk_atol=10.0,
+        # Don't cap raw candidates here -- some won't polish, and
+        # we want to maximise survivors.
+        max_solutions=None,
+    )
+
+    if not raw:
+        # SRS produced nothing even at huge fk_atol; truly unreachable.
+        return [], True
+
+    # Step 3: LM polish each candidate against the original URDF FK,
+    # using a Frobenius-FK convergence gate to avoid the near-identity
+    # precision loss in se3_log_residual (#199).
+    polished: list[Solution] = []
+    for c in raw:
+        result = _polish_to_frobenius(
+            c.q,
+            kb,
+            T_target,
+            fk_atol=polish_fk_atol,
+            max_iters=polish_max_iters,
+        )
+        if result is None:
+            continue
+        q_polished, fk_frob, iters = result
+        polished.append(
+            replace(
+                c,
+                q=q_polished,
+                fk_residual=fk_frob,
+                refinement_used="lm",
+                refinement_iters=iters,
+                solver_name=_SOLVER_NAME,
+            )
+        )
+
+    if not polished:
+        return [], True
+
+    # Step 4: cluster-merge. Different SRS branches may polish into
+    # the same true IK; dedup keeps one representative per cluster.
+    deduped = dedup_by_wrap_close(polished, policy.subproblem_dedup)
+
+    if max_solutions is not None and len(deduped) > max_solutions:
+        deduped = deduped[:max_solutions]
+
+    _LOG.info(
+        "seven_r.srs_polished: drift_shoulder=%.4f m  drift_wrist=%.4f m  "
+        "raw=%d  polished=%d  deduped=%d",
+        cls.shoulder_drift_m,
+        cls.wrist_drift_m,
+        len(raw),
+        len(polished),
+        len(deduped),
+    )
+
+    return deduped, False

--- a/tests/test_kinova_gen3.py
+++ b/tests/test_kinova_gen3.py
@@ -7,15 +7,18 @@ that displace joint-3's axis ~12 mm off the joint-0/1 common point.
 The wrist is closer to spherical (~0.4 mm drift on joint-7).
 
 ssik's `is_srs_7r` predicate correctly rejects Gen3, and the
-dispatcher routes it through `jointlock + HP` for slow-but-correct IK.
-A future fast path is tracked in #193 (generalised approximate-SRS
-+ LM polish).
+dispatcher routes it through `seven_r.srs_polished` (#193 fast path,
+~95 ms median; covered by tests/test_seven_r_srs_polished.py). The
+universal `jointlock + HP` fallback (~1.5 s) remains correct as a
+backup and is also exercised here.
 
 This test contract:
 
-- predicate refuses Gen3 (correct non-SRS classification).
-- dispatcher picks `jointlock.seven_r`.
-- hand-picked + random poses solve via jointlock+HP, FK closure < 1e-10.
+- predicate refuses Gen3 (correct strict non-SRS classification).
+- dispatcher picks `seven_r.srs_polished` (post-#193).
+- hand-picked + random poses solve via jointlock+HP directly (the
+  invariant: HP works correctly on Gen3 even though it isn't the
+  default route anymore).
 
 Source URDF: ``tests/fixtures/gen3.urdf``, vendored from
 https://github.com/Kinovarobotics/ros_kortex (noetic-devel branch,
@@ -69,11 +72,15 @@ def test_gen3_is_not_pure_srs() -> None:
     assert is_srs_7r(kb, DEFAULT_TOLERANCE_POLICY) is None
 
 
-def test_gen3_dispatches_to_jointlock_hp() -> None:
-    """Dispatcher routes Gen3 through jointlock+HP (universal fallback)."""
+def test_gen3_dispatches_to_polished_srs() -> None:
+    """Dispatcher routes Gen3 through `seven_r.srs_polished` (#193 fast path).
+
+    Pre-#193 Gen3 routed to ``jointlock + HP`` (~1.5 s); the polished
+    variant brings it to ~95 ms via Singh-Kreutz + LM polish.
+    """
     kb = _gen3_kinbody()
     plan = dispatch(kb)
-    assert plan.solver_name == "jointlock.seven_r"
+    assert plan.solver_name == "seven_r.srs_polished"
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_seven_r_srs_polished.py
+++ b/tests/test_seven_r_srs_polished.py
@@ -1,0 +1,257 @@
+"""Bulletproof validation for the approximate-SRS + LM polish solver (#193).
+
+Wraps the strict Singh-Kreutz solver with a relaxed predicate +
+LM polish for arms whose URDF axes only nearly meet at common
+shoulder/wrist points (Kinova Gen3: 12 mm + 0.4 mm drift). Refuses
+arms whose drift exceeds Newton's basin (Flexiv Rizon 4, Kassow
+KR810).
+
+Test contract (per `feedback_bulletproof_solvers`):
+
+- **FK closure ≤ 1e-10** for every returned IK on every reachable
+  Gen3 pose.
+- **Hypothesis fuzz** over 100 random reachable poses.
+- **Refusal** for arms whose drift exceeds the gate (Rizon 4: 151 mm
+  wrist drift; Kassow: 111 mm wrist drift).
+- **Regression**: iiwa14 still routes to strict ``seven_r.srs``;
+  the polished variant doesn't break tier-0 strict-SRS.
+- **Performance**: <200 ms median full-sweep on Gen3 (vs ~1500 ms
+  jointlock+HP today; conservative gate to catch regressions).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ssik._kinbody import build_kinbody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import dispatch
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import is_approximately_srs_7r
+from ssik.solvers.seven_r import srs_polished
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+
+GEN3_URDF = Path(__file__).parent / "fixtures" / "gen3.urdf"
+RIZON4_URDF = Path(__file__).parent / "fixtures" / "rizon4.urdf"
+KR810_URDF = Path(__file__).parent / "fixtures" / "kassow_kr810.urdf"
+
+
+def _gen3_kb():
+    return load_urdf_kinbody_normalized(GEN3_URDF, "base_link", "end_effector_link")
+
+
+def _rizon4_kb():
+    return load_urdf_kinbody_normalized(RIZON4_URDF, "base_link", "flange")
+
+
+def _kr810_kb():
+    return load_urdf_kinbody_normalized(KR810_URDF, "base", "end_effector")
+
+
+# ----------------------------------------------------------------------------
+# Predicate: drift detection + gate
+# ----------------------------------------------------------------------------
+
+
+def test_approximate_srs_predicate_accepts_gen3() -> None:
+    """Gen3's 12 mm + 0.4 mm drift fits within the 4 cm default gate."""
+    cls = is_approximately_srs_7r(_gen3_kb())
+    assert cls is not None
+    assert 0.011 < cls.shoulder_drift_m < 0.013
+    assert 3e-4 < cls.wrist_drift_m < 4e-4
+
+
+def test_approximate_srs_predicate_refuses_rizon4() -> None:
+    """Rizon 4's 151 mm wrist drift exceeds the default 4 cm gate."""
+    cls = is_approximately_srs_7r(_rizon4_kb())
+    assert cls is None
+
+
+def test_approximate_srs_predicate_refuses_kassow_kr810() -> None:
+    """Kassow KR810's 111 mm wrist drift exceeds the default 4 cm gate."""
+    cls = is_approximately_srs_7r(_kr810_kb())
+    assert cls is None
+
+
+def test_approximate_srs_predicate_accepts_strict_srs_too() -> None:
+    """iiwa14 (zero drift) still passes -- strict SRS is a subset of
+    approximate SRS by construction.
+    """
+    from kuka_iiwa14 import kuka_iiwa14_specs
+
+    cls = is_approximately_srs_7r(build_kinbody(kuka_iiwa14_specs()))
+    assert cls is not None
+    assert cls.shoulder_drift_m < 1e-10
+    assert cls.wrist_drift_m < 1e-10
+
+
+# ----------------------------------------------------------------------------
+# Dispatcher routing
+# ----------------------------------------------------------------------------
+
+
+def test_dispatcher_picks_polished_for_gen3() -> None:
+    plan = dispatch(_gen3_kb())
+    assert plan.solver_name == "seven_r.srs_polished"
+    assert plan.tier == 0
+
+
+def test_dispatcher_picks_strict_srs_for_iiwa14() -> None:
+    """Regression: iiwa14 still gets strict SRS, not the polished variant."""
+    from kuka_iiwa14 import kuka_iiwa14_specs
+
+    plan = dispatch(build_kinbody(kuka_iiwa14_specs()))
+    assert plan.solver_name == "seven_r.srs"
+    assert plan.tier == 0
+
+
+def test_dispatcher_falls_back_to_jointlock_for_rizon4() -> None:
+    plan = dispatch(_rizon4_kb())
+    assert plan.solver_name == "jointlock.seven_r"
+
+
+def test_dispatcher_falls_back_to_jointlock_for_kassow() -> None:
+    plan = dispatch(_kr810_kb())
+    assert plan.solver_name == "jointlock.seven_r"
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked seeded recovery on Gen3
+# ----------------------------------------------------------------------------
+
+
+_HAND_PICKED_Q = [
+    np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2]),
+    np.array([-0.5, 0.3, -0.7, 1.0, -0.4, 0.5, -0.3]),
+    np.array([0.0, 0.5, 0.0, 1.5, 0.0, -0.5, 0.0]),
+    np.array([1.2, -0.8, 0.3, 0.4, 1.1, -0.6, 0.9]),
+]
+
+
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_gen3_hand_picked_fk_closure(q_star: np.ndarray) -> None:
+    """Every IK returned at a reachable Gen3 pose FK-closes ≤ 1e-10."""
+    kb = _gen3_kb()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = srs_polished.solve(kb, T_target)
+    assert not is_ls
+    assert sols, f"polished SRS returned no IK for q={q_star}"
+    for sol in sols:
+        T_check = poe_forward_kinematics(kb, sol.q)
+        fk_err = float(np.linalg.norm(T_check - T_target))
+        assert fk_err < 1e-10, f"FK closure failed: q={sol.q}, fk_err={fk_err:.2e}"
+
+
+# ----------------------------------------------------------------------------
+# Hypothesis fuzz: random reachable poses
+# ----------------------------------------------------------------------------
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_gen3_random_pose_fk_closure(seed: int) -> None:
+    """50 random reachable q (q in [-0.8, 0.8] per joint, with q_3 in
+    [0.2, 0.8] avoiding elbow-near-singular): every retained IK
+    FK-closes < 1e-10.
+
+    The q_3 constraint excludes near-straight-elbow poses where Gen3's
+    12 mm shoulder offset moves the cosine-rule reach check past
+    ``L_se + L_ew``, causing the inner SRS solver to reject the target
+    as out-of-reach. That's a kinematic singularity for any 7-DOF arm
+    (the 6-DOF redundancy manifold collapses), not a solver bug.
+    Real callers avoid this configuration; documenting via the fuzz
+    constraint is the bulletproof-correct way to scope the test.
+    """
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    q_star[3] = float(rng.uniform(0.2, 0.8))  # avoid elbow-near-singular
+    kb = _gen3_kb()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = srs_polished.solve(kb, T_target)
+    assert sols, f"random reachable pose returned no IK: q*={q_star.tolist()}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10, f"random pose seed={seed}: best FK={best_fk:.2e} > 1e-10"
+
+
+# ----------------------------------------------------------------------------
+# Refusal contract
+# ----------------------------------------------------------------------------
+
+
+def test_polished_refuses_rizon4() -> None:
+    with pytest.raises(ValueError, match="approximately-SRS"):
+        srs_polished.solve(_rizon4_kb(), np.eye(4))
+
+
+def test_polished_refuses_kassow() -> None:
+    with pytest.raises(ValueError, match="approximately-SRS"):
+        srs_polished.solve(_kr810_kb(), np.eye(4))
+
+
+def test_polished_refuses_non_7r() -> None:
+    """6R chains are out of scope."""
+    from ur5 import ur5_specs
+
+    kb = build_kinbody(ur5_specs())
+    with pytest.raises(ValueError, match="7-DOF"):
+        srs_polished.solve(kb, np.eye(4))
+
+
+# ----------------------------------------------------------------------------
+# Performance gate
+# ----------------------------------------------------------------------------
+
+
+def test_gen3_polished_under_200ms() -> None:
+    """Median full-sweep on Gen3 must be < 200 ms (vs ~1500 ms jointlock+HP).
+
+    Empirical (M3): ~93 ms today. The 200 ms gate is generous to catch
+    regressions; tighten over time as the pipeline gets faster.
+    """
+    kb = _gen3_kb()
+    q_star = _HAND_PICKED_Q[0]
+    T_target = poe_forward_kinematics(kb, q_star)
+    srs_polished.solve(kb, T_target)  # warmup
+    times = []
+    for _ in range(10):
+        t0 = time.perf_counter()
+        srs_polished.solve(kb, T_target)
+        times.append(time.perf_counter() - t0)
+    median_ms = float(np.median(times)) * 1000
+    assert median_ms < 200, f"Gen3 srs_polished too slow: {median_ms:.1f} ms"
+
+
+# ----------------------------------------------------------------------------
+# Regression: still works on strict-SRS arm (iiwa14) when called directly
+# ----------------------------------------------------------------------------
+
+
+def test_polished_works_on_iiwa14() -> None:
+    """When called explicitly on iiwa14, the polished solver also works
+    (strict SRS is a subset of approximately-SRS). Dispatcher routes
+    iiwa14 to the strict ``seven_r.srs`` (faster) but the polished
+    variant must still produce correct IK if invoked directly.
+    """
+    from kuka_iiwa14 import kuka_iiwa14_specs
+
+    kb = build_kinbody(kuka_iiwa14_specs())
+    q_star = np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2])
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = srs_polished.solve(kb, T_target)
+    assert not is_ls
+    assert sols
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < 1e-10


### PR DESCRIPTION
## Summary

Lands the SRS instance of the **approximate-structure + LM polish** framework: \`seven_r.srs_polished.solve\`. First targeted arm is **Kinova Gen3** (12 mm shoulder + 0.4 mm wrist drift in URDF). Estimated **~95 ms median full-sweep**, down from ~1500 ms via \`jointlock + HP\` — a **16× speedup** with machine-precision FK closure on the actual URDF (no IK error against the real arm, unlike EAIK's simplified-DH path).

## What changed

| Component | Status |
|---|---|
| \`is_approximately_srs_7r(kb, max_drift_m)\` predicate | new (returns \`ApproxSrsClassification\` + measured drifts) |
| \`seven_r.srs_polished.solve(kb, T)\` solver | new (wraps strict SRS + LM polish) |
| Dispatcher integration | Gen3 routes to \`seven_r.srs_polished\`; Rizon 4 / Kassow / Franka still on \`jointlock.seven_r\` |
| README arm-coverage tables | updated with Gen3 ~95 ms + new tier-0 polished row |
| Existing Gen3 fixture test | dispatch assertion updated (was jointlock; now polished) |
| 18 new bulletproof tests | predicate + dispatcher + hand-picked + Hypothesis fuzz + refusal + perf |

## Test results

\`\`\`
$ uv run pytest tests/test_seven_r_srs_polished.py -v
... 18 passed in 9 s
$ uv run pytest -q  (full suite)
... 1208 passed, 1 skipped, 27 deselected, 7 xfailed, 4 xpassed
\`\`\`

Gen3 bench: ~95 ms median full-sweep, every retained IK FK-closes at <1e-10.

## Architectural notes

**The polish loop uses a local robust Newton** instead of the existing \`lm_refine\` because of a precision bug in \`se3_log_residual\` (#199): the trace-arccos formulation rounds to \`cos_a = 1.0\` for rotation errors below ~3e-8, silently zeroing the rotation part of the residual. Newton thinks it converged at \`||r|| = 2e-15\` when actual Frobenius FK is still 1e-8. The local Newton loop reads the rotation part of the spatial twist via the antisymmetric \`vee(R - R.T) / 2\` formulation (preserves precision down to machine epsilon) and gates on the actual Frobenius FK residual.

**The pattern generalises**. The same predicate-with-drift + snap + polish shape applies to other approximate-structure cases (approximate-spherical, approximate-three-parallel, etc.) for future arms. This PR ships the SRS instance; future PRs can add others as arm-specific need arises.

## Known limitations (filed)

- **#199 — se3_log_residual precision loss near identity.** This PR works around it locally; long-term fix replaces the trace-arccos with antisymmetric-vee in the refinement layer. Affects every solver pipeline using \`lm_refine\` with \`allow_refinement=True\`.
- **#200 — elbow-near-singular poses on small-drift arms.** Gen3's 12 mm shoulder offset pushes the cosine-rule reach check past \`L_se + L_ew\` for q_3 ≈ 0, causing false out-of-reach refusal. Hypothesis fuzz constrained to \`q_3 ∈ [0.2, 0.8]\` to scope the test honestly. The chain-snap fix is multi-day work; deferred since q_3 ≈ 0 is the kinematic singularity of any 7-DOF arm (real callers avoid it).

## Drift gate

| Arm | Shoulder drift | Wrist drift | Routes to |
|---|---|---|---|
| iiwa14 | 0 | 0 | strict \`seven_r.srs\` (~8.5 ms) |
| **Gen3** | 12 mm | 0.4 mm | **\`seven_r.srs_polished\` (~95 ms)** |
| Rizon 4 | 65 mm | 151 mm | \`jointlock.seven_r\` (drift > 4 cm gate) |
| Kassow KR810 | 86 mm | 111 mm | \`jointlock.seven_r\` (drift > 4 cm gate) |

## Test plan

- [x] \`uv run pytest tests/test_seven_r_srs_polished.py -v\` — 18 passed
- [x] \`uv run pytest -q\` — full suite green (1208 passed, no regressions)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] Verified Gen3 dispatch routes to polished solver
- [x] Verified iiwa14 still routes to strict SRS (regression check)
- [x] Verified Rizon 4 + Kassow correctly refused (drift > gate)