### PR TITLE
Fix se3_log_residual precision loss near identity (closes #199)

### DIFF
--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -60,24 +60,61 @@ def se3_log_residual(t_err: NDArray[np.float64]) -> NDArray[np.float64]:
 
     For ``t_err = T_target @ FK(q)^{-1}``, returns the local twist
     coordinate that drives ``q`` toward the target. Translation is read
-    directly; rotation is via Rodrigues' formula ``log(R) -> axis*angle``
-    with cosine clamping for numerical safety near identity.
+    directly; rotation uses the antisymmetric ``vee((R - R.T) / 2) =
+    sin(angle) * axis`` formulation (precise at all scales, including
+    near identity) combined with ``atan2(sin_angle, cos_angle)`` for
+    the magnitude (well-conditioned at every angle).
+
+    Three regimes:
+
+    1. Generic (``sin_angle > 1e-9``): ``rot_err = (angle / sin_angle)
+       * skew_vec``. The scale factor is well-defined and converges to
+       1 as ``angle -> 0``.
+    2. Near identity (``sin_angle <= 1e-9`` and ``cos_angle > 0``): the
+       skew vector is itself the angle-scaled axis to first order
+       (``skew_vec ≈ angle * axis``); return as-is.
+    3. Near π (``sin_angle <= 1e-9`` and ``cos_angle < 0``): the skew
+       vector vanishes; recover the rotation axis from the dominant
+       eigenvector of ``R + I`` (which has rank 1 with eigenvalue 2
+       along the axis at exactly π).
+
+    This formulation fixes the precision-loss bug in the prior
+    ``arccos(0.5 * (trace - 1))`` implementation, which silently zeroed
+    the rotation residual when the rotation error was below ~3e-8 rad.
+    See #199 for the bug + fix discussion. Newton trajectories that
+    used to stop at ~1e-8 Frobenius FK now converge to machine
+    precision.
     """
     trans_err = t_err[:3, 3]
     r_err = t_err[:3, :3]
-    cos_a = max(-1.0, min(1.0, 0.5 * (np.trace(r_err) - 1.0)))
-    angle = float(np.arccos(cos_a))
-    if angle < 1e-9:
-        rot_err = np.zeros(3)
+
+    # vee((R - R.T) / 2) = sin(angle) * axis -- exact at all scales,
+    # since float64 captures off-diagonal differences faithfully near
+    # identity (the lossy step in the old formulation was the trace).
+    skew_vec = np.array(
+        [
+            0.5 * (r_err[2, 1] - r_err[1, 2]),
+            0.5 * (r_err[0, 2] - r_err[2, 0]),
+            0.5 * (r_err[1, 0] - r_err[0, 1]),
+        ]
+    )
+    sin_angle = float(np.linalg.norm(skew_vec))
+    cos_angle = max(-1.0, min(1.0, 0.5 * (float(np.trace(r_err)) - 1.0)))
+
+    # atan2 is well-conditioned at every angle (unlike arccos near 0 or π).
+    angle = math.atan2(sin_angle, cos_angle)
+
+    if sin_angle > 1e-9:
+        rot_err = (angle / sin_angle) * skew_vec
+    elif cos_angle > 0:
+        # Near identity: skew_vec ≈ angle * axis to leading order.
+        rot_err = skew_vec
     else:
-        s = 1.0 / (2.0 * np.sin(angle))
-        rot_err = np.array(
-            [
-                s * (r_err[2, 1] - r_err[1, 2]) * angle,
-                s * (r_err[0, 2] - r_err[2, 0]) * angle,
-                s * (r_err[1, 0] - r_err[0, 1]) * angle,
-            ]
-        )
+        # Near π: skew_vec vanished; recover axis from R + I.
+        r_plus_i = r_err + np.eye(3)
+        norms = np.linalg.norm(r_plus_i, axis=0)
+        idx = int(np.argmax(norms))
+        rot_err = (angle / norms[idx]) * r_plus_i[:, idx]
     return np.concatenate([trans_err, rot_err])
 
 

--- a/src/ssik/solvers/seven_r/srs_polished.py
+++ b/src/ssik/solvers/seven_r/srs_polished.py
@@ -57,7 +57,7 @@ from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import is_approximately_srs_7r
-from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian
+from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian, lm_refine
 from ssik.solvers.seven_r import srs
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
@@ -68,74 +68,6 @@ __all__ = ["solve"]
 _SOLVER_NAME = "seven_r.srs_polished"
 _LOG = logging.getLogger(__name__)
 _DEFAULT_MAX_DRIFT_M = 0.04
-
-
-def _polish_to_frobenius(
-    q_seed: NDArray[np.float64],
-    kb: KinBody,
-    T_target: NDArray[np.float64],
-    *,
-    fk_atol: float,
-    max_iters: int,
-    step_clip: float = 0.5,
-    divergence_factor: float = 5.0,
-) -> tuple[NDArray[np.float64], float, int] | None:
-    """Newton polish on the spatial twist of ``T_target @ T_q^{-1}``,
-    convergent on the **Frobenius** ``||FK(q) - T_target||_F`` norm.
-
-    This is a workaround for the near-identity precision loss in
-    :func:`ssik.refinement.se3_log_residual` (the ``cos_a = (trace-1)/2``
-    formulation rounds to ``1.0`` in float64 when the rotation error is
-    below ~3e-8, silently zeroing the rotation part of the residual).
-    See #199.
-
-    The fix: compute the rotation part of the twist via the
-    skew-symmetric vee of ``R_err - R_err.T``, which preserves
-    precision down to machine epsilon. Translation is read directly
-    from ``T_err``. The convergence gate is the actual Frobenius FK
-    residual, so candidates can't slip through with hidden rotation
-    error.
-    """
-    q = q_seed.astype(np.float64).copy()
-    r_best = float("inf")
-    for it in range(max_iters):
-        T_q = poe_forward_kinematics(kb, q)
-        # Frobenius gate -- the contract callers expect.
-        frob = float(np.linalg.norm(T_q - T_target))
-        if frob < fk_atol:
-            return q, frob, it
-        if frob < r_best:
-            r_best = frob
-        elif it >= 4 and frob > divergence_factor * r_best:
-            return None
-        # Robust spatial twist: read translation directly, rotation via
-        # skew-vee of (R_err - R_err.T) / 2 (works at machine precision
-        # near identity).
-        T_err = T_target @ np.linalg.inv(T_q)
-        r_err = T_err[:3, :3]
-        omega = 0.5 * np.array(
-            [
-                r_err[2, 1] - r_err[1, 2],
-                r_err[0, 2] - r_err[2, 0],
-                r_err[1, 0] - r_err[0, 1],
-            ]
-        )
-        twist = np.concatenate([T_err[:3, 3], omega])
-        J = kinbody_jacobian(kb, q)
-        try:
-            dq = np.linalg.solve(J, twist)
-        except np.linalg.LinAlgError:
-            damping = max(1e-9, 1e-6 * frob)
-            n = J.shape[1]
-            dq = np.linalg.solve(J.T @ J + damping * np.eye(n), J.T @ twist)
-        dq = np.clip(dq, -step_clip, step_clip)
-        q = q + dq
-    # Final convergence check.
-    T_q = poe_forward_kinematics(kb, q)
-    frob = float(np.linalg.norm(T_q - T_target))
-    if frob < fk_atol:
-        return q, frob, max_iters
-    return None
 
 
 def solve(
@@ -208,21 +140,34 @@ def solve(
         # SRS produced nothing even at huge fk_atol; truly unreachable.
         return [], True
 
-    # Step 3: LM polish each candidate against the original URDF FK,
-    # using a Frobenius-FK convergence gate to avoid the near-identity
-    # precision loss in se3_log_residual (#199).
+    # Step 3: LM polish each candidate against the original URDF FK.
+    # Re-using the existing closures keeps the Cython Jacobian path
+    # active (kinbody_jacobian is the analytical 6xN spatial Jacobian).
+    def fk_fn(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        return poe_forward_kinematics(kb, q)
+
+    def jac_fn(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        return kinbody_jacobian(kb, q)
+
     polished: list[Solution] = []
     for c in raw:
-        result = _polish_to_frobenius(
+        result = lm_refine(
             c.q,
-            kb,
+            fk_fn,
             T_target,
             fk_atol=polish_fk_atol,
             max_iters=polish_max_iters,
+            jacobian_fn=jac_fn,
         )
         if result is None:
             continue
-        q_polished, fk_frob, iters = result
+        q_polished, _se3_residual, iters = result
+        # Recompute the Frobenius residual: this is the user-visible
+        # ``Solution.fk_residual`` and matches the test contract. Post #199
+        # the se3_log_residual norm and Frobenius are both machine-precision
+        # consistent, but the contract is Frobenius so we materialise that.
+        T_check = poe_forward_kinematics(kb, q_polished)
+        fk_frob = float(np.linalg.norm(T_check - T_target))
         polished.append(
             replace(
                 c,

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -83,12 +83,21 @@ def test_se3_log_residual_pure_rotation_recovers_axis_angle() -> None:
     assert np.allclose(r[3:], angle * axis, atol=1e-12)
 
 
-def test_se3_log_residual_small_angle_clamped_to_zero_rotation() -> None:
-    """Below 1e-9 rad we return a zero rotation (avoids division by ~zero)."""
+def test_se3_log_residual_small_angle_recovers_actual_rotation() -> None:
+    """Below 1e-9 rad we recover the actual rotation residual (#199 fix).
+
+    The previous trace-arccos implementation rounded ``cos_a`` to
+    ``1.0`` in float64 for any rotation below ~3e-8 rad, silently
+    zeroing the rotation part. The antisymmetric-vee formulation
+    preserves precision down to machine epsilon: a 1e-12 rad rotation
+    around z maps to ``[0, 0, 1e-12]`` in the rotation residual.
+    """
     axis = np.array([0.0, 0.0, 1.0])
     T = _rot_axis(axis, 1e-12)
     r = se3_log_residual(T)
-    assert np.allclose(r[3:], 0.0, atol=1e-15)
+    assert np.allclose(r[:3], 0.0, atol=1e-15)
+    # Rotation residual recovers the small angle (was: zeroed out).
+    assert np.linalg.norm(r[3:] - 1e-12 * axis) < 1e-15
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the ``arccos(trace)`` formulation of \`se3_log_residual\` with an antisymmetric-vee + atan2 formulation that preserves precision at **all** rotation magnitudes — closes #199.

## The bug

\`\`\`python
cos_a = max(-1.0, min(1.0, 0.5 * (np.trace(r_err) - 1.0)))
angle = float(np.arccos(cos_a))
if angle < 1e-9:
    rot_err = np.zeros(3)
\`\`\`

For ``R`` with rotation magnitude ``θ`` (small), ``trace(R) ≈ 3 - θ²``, so ``cos_a ≈ 1 - θ²/2``. Float64 has ~2.2e-16 epsilon; ``θ²/2 < eps`` rounds ``cos_a`` to exactly ``1.0``, producing ``angle = arccos(1.0) = 0`` and triggering the ``< 1e-9`` guard. Critical breakpoint: ``θ ≈ 2e-8 rad``.

**Effect**: Newton trajectories thought they had converged at se3_log_norm ~1e-15 while the actual Frobenius FK was still ~1e-8. Discovered while implementing #193 polished-SRS solver — Gen3 candidates polished to "se3_log = 2e-15" but Frobenius FK was 1.3e-8, breaking the bulletproof FK ≤ 1e-10 contract.

## The fix

Antisymmetric-vee + atan2:

\`\`\`python
skew_vec = vee((R - R.T) / 2) = sin(angle) * axis    # exact at all scales
cos_angle = 0.5 * (trace(R) - 1)
angle = atan2(||skew_vec||, cos_angle)               # well-conditioned everywhere
rot_err = (angle / sin_angle) * skew_vec             # generic
\`\`\`

Three regimes:
- **Generic** (sin_angle > 1e-9): formula above.
- **Near identity** (sin_angle ≤ 1e-9, cos_angle > 0): return ``skew_vec`` directly (= angle × axis to leading order, machine-precision exact).
- **Near π** (sin_angle ≤ 1e-9, cos_angle < 0): recover axis from the dominant column of ``R + I``.

## Verification

| theta | log_norm pre-fix | log_norm post-fix |
|---|---|---|
| 1e-3 | 1.0e-3 | 1.0e-3 |
| 1e-6 | 1.0e-6 | 1.0e-6 |
| 1e-9 | **0** (silently zeroed) | 1.0e-9 |
| 1e-12 | **0** | 1.0e-12 |
| 1e-14 | **0** | 1.0e-14 |

\`lm_refine\` convergence on Gen3 candidates: now reaches **Frobenius FK < 1e-13** (was: stopped at ~1e-8).

## Cleanup

Removed the local \`_polish_to_frobenius\` workaround that #193 shipped to bypass this bug. \`seven_r.srs_polished\` now uses \`lm_refine\` directly (~70 fewer lines, simpler dependency surface).

## Affected callers (all benefit)

- HP polish path (\`husty_pfurner.general_6r\` with \`allow_refinement=True\`)
- Jointlock-7R refinement (\`jointlock.seven_r\` with \`allow_refinement=True\`)
- Polished-SRS solver (\`seven_r.srs_polished\` from #201)
- Any future solver using \`lm_refine\`

All now reach actual machine precision in their polishing paths.

## Test plan

- [x] \`uv run pytest -q\` — **1209 passed, 1 skipped, 27 deselected, 7 xfailed, 4 xpassed** (no regressions; one renamed test reflects the new correct behavior)
- [x] \`uv run python scripts/build_cython.py\` — Cython rebuild succeeds (\`refinement\` is compiled)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean