### PR TITLE
ssik add-arm CLI: turnkey arm onboarding (closes #196 MVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,29 @@ Covers Franka Panda (anthropomorphic 7R), uFactory xArm7 (mixed structure), and 
 | 2 — Raghavan–Roth + Manocha–Canny | `ikgeo.general_6r` | ~0.6-5 ms | numeric RR resultant with AE-3 leftvar selection; **production tier-2** |
 | 2 — Husty-Pfurner universal fallback | `husty_pfurner.general_6r` | ~25-200 ms | Study-quaternion algebra; perturbation path (#176) handles symmetric-DH singularities; backstops RR on ill-conditioned arms |
 
+## Onboarding a new arm (`ssik add-arm`)
+
+Hand us a URDF + the base/EE link names, get back a vendored fixture and a bulletproof test scaffold tailored to the dispatched solver:
+
+```bash
+$ ssik add-arm path/to/my_arm.urdf --base base_link --ee tool0 --name my_arm
+[ssik add-arm] Loading path/to/my_arm.urdf
+[ssik add-arm]   7 joints, 8 links — POE-normalized OK
+[ssik add-arm] Classifying topology
+[ssik]   → Best solver: jointlock.seven_r (tier 1)
+[ssik]   → Expected median IK time: ~50.0 ms
+[ssik add-arm] Vendoring URDF -> tests/fixtures/my_arm.urdf
+[ssik add-arm] Generating test scaffold -> tests/test_my_arm.py
+[ssik add-arm]   wrote 4,203 bytes (113 lines)
+[ssik add-arm] ✓ Done. Try:
+[ssik add-arm]     uv run pytest tests/test_my_arm.py -v
+```
+
+The generated test asserts URDF load, dispatcher routing, and FK closure ≤ 1e-10 on hand-picked + Hypothesis-fuzzed reachable poses. Solver-specific scaffolds dispatch to whichever solver the URDF would route to (`seven_r.srs`, `seven_r.srs_polished`, `jointlock.seven_r`, `ikgeo.*`, `husty_pfurner.general_6r`).
+
 ## Per-arm artifact builder (`ssik build`)
 
-The user-facing flow: hand us a URDF, get back a self-contained Python module.
+For production deployment: build a self-contained Python module wrapping the chosen solver.
 
 ```bash
 $ ssik build path/to/ur5.urdf --base base_link --ee ee_link

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -1,14 +1,17 @@
 """``ssik`` command-line interface.
 
-Two subcommands:
+Three subcommands:
 
 * ``ssik classify <urdf> --base <link> --ee <link>`` -- classify topology +
   print which solver would be picked, without emitting an artifact.
 * ``ssik build <urdf> --base <link> --ee <link> [--out <path>]`` --
   classify, emit a per-arm artifact (\\*_ik.py), validate it on random
   poses, and report timing.
+* ``ssik add-arm <urdf> --base <link> --ee <link> --name <arm>`` --
+  vendor a URDF into ``tests/fixtures/`` and generate a bulletproof
+  test scaffold for it; turnkey arm onboarding (#196).
 
-Both commands print explanatory messages by default. ``-v`` raises log
+All commands print explanatory messages by default. ``-v`` raises log
 verbosity (per-solver INFO logs); ``-vv`` shows DEBUG.
 
 The CLI uses argparse so it has no external dependency and the help
@@ -51,6 +54,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_classify(args)
     if args.command == "build":
         return _run_build(args)
+    if args.command == "add-arm":
+        return _run_add_arm(args)
     parser.print_help()
     return 2
 
@@ -127,6 +132,45 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--no-validate",
         action="store_true",
         help="Skip post-emit validation entirely (equivalent to --validate-poses 0).",
+    )
+
+    add_arm_parser = sub.add_parser(
+        "add-arm",
+        help=(
+            "Onboard a new arm: vendor the URDF into tests/fixtures/ and "
+            "generate a bulletproof test scaffold based on the dispatched "
+            "solver. (#196)"
+        ),
+    )
+    _add_common_kinbody_args(add_arm_parser)
+    add_arm_parser.add_argument(
+        "--name",
+        required=True,
+        help=(
+            "Identifier for the arm (lowercase, underscore-separated). "
+            "Determines the fixture filename (tests/fixtures/<name>.urdf), "
+            "the test module (tests/test_<name>.py), and the Python helper "
+            "(_<name>_kinbody). Examples: 'kinova_gen3', 'flexiv_rizon4'."
+        ),
+    )
+    add_arm_parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the ssik repository root. Defaults to the current "
+            "working directory; the URDF is vendored to "
+            "<repo-root>/tests/fixtures/ and the test file to "
+            "<repo-root>/tests/."
+        ),
+    )
+    add_arm_parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite existing fixture/test files for this arm. By default, "
+            "the command refuses if either file already exists."
+        ),
     )
     return parser
 
@@ -321,6 +365,261 @@ def _fk_poe(kb: object, q: np.ndarray) -> np.ndarray:
         rot[:3, :3] = rotation_matrix(j.axis, float(qi))
         T = T @ j.T_left @ rot @ j.T_right
     return T
+
+
+# ---------------------------------------------------------------------------
+# `ssik add-arm` -- vendor a URDF + generate a bulletproof test scaffold (#196).
+# ---------------------------------------------------------------------------
+
+
+def _run_add_arm(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root or Path.cwd()
+    fixtures_dir = repo_root / "tests" / "fixtures"
+    tests_dir = repo_root / "tests"
+    if not fixtures_dir.is_dir():
+        print(f"[ssik add-arm] ERROR: {fixtures_dir} does not exist.")
+        print("[ssik add-arm]   Pass --repo-root to point at the ssik repository.")
+        return 1
+
+    urdf_dest = fixtures_dir / f"{args.name}.urdf"
+    test_dest = tests_dir / f"test_{args.name}.py"
+    if not args.force:
+        for p in (urdf_dest, test_dest):
+            if p.exists():
+                print(f"[ssik add-arm] ERROR: {p} already exists.")
+                print("[ssik add-arm]   Pass --force to overwrite.")
+                return 1
+
+    print(f"[ssik add-arm] Loading {args.urdf}")
+    if not args.urdf.is_file():
+        print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
+        return 1
+    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
+    print(f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
+
+    print("[ssik add-arm] Classifying topology")
+    plan = dispatch(kb)
+    _print_dispatch_summary(plan)
+
+    print(f"[ssik add-arm] Vendoring URDF -> {urdf_dest.relative_to(repo_root)}")
+    urdf_dest.write_bytes(args.urdf.read_bytes())
+    print(f"[ssik add-arm]   {urdf_dest.stat().st_size:,} bytes copied")
+
+    print(f"[ssik add-arm] Generating test scaffold -> {test_dest.relative_to(repo_root)}")
+    test_source = _render_test_scaffold(
+        arm_name=args.name,
+        urdf_filename=urdf_dest.name,
+        base_link=args.base,
+        ee_link=args.ee,
+        dof=len(kb.joints),
+        plan=plan,
+    )
+    test_dest.write_text(test_source)
+    print(f"[ssik add-arm]   wrote {len(test_source):,} bytes ({test_source.count(chr(10))} lines)")
+
+    print()
+    print("[ssik add-arm] ✓ Done. Try:")
+    print(f"[ssik add-arm]     uv run pytest {test_dest.relative_to(repo_root)} -v")
+    print(f"[ssik add-arm]     uv run pytest {test_dest.relative_to(repo_root)} -v -m slow")
+    print()
+    print("[ssik add-arm] Next steps (manual; not auto-generated yet):")
+    print("[ssik add-arm]   - Add an arm row to README.md under the matching solver class")
+    print(f"[ssik add-arm]   - Optionally add scripts/bench_{args.name}.py for FLOP profiling")
+    return 0
+
+
+def _render_test_scaffold(
+    *,
+    arm_name: str,
+    urdf_filename: str,
+    base_link: str,
+    ee_link: str,
+    dof: int,
+    plan: DispatchPlan,
+) -> str:
+    """Render the per-arm test scaffold based on the dispatched solver.
+
+    The generated test file contains:
+
+    1. URDF load + DOF / joint-type sanity.
+    2. Dispatcher routing (asserts the solver name selected by the
+       current dispatcher).
+    3. ``@pytest.mark.slow`` hand-picked seeded recovery (4 q*).
+    4. ``@pytest.mark.slow`` Hypothesis fuzz (10 random reachable poses).
+
+    Tests assert FK closure ≤ 1e-10 on the BEST IK per pose (matching
+    the bulletproof-validation contract).
+    """
+    arm_label = arm_name
+    kb_helper = f"_{arm_name}_kinbody"
+    n_random_poses = 10  # Hypothesis fuzz size; small for the slow path
+    fk_atol = 1e-10
+    docstring_header = (
+        f'"""Bulletproof validation for the {arm_label} fixture '
+        f'(auto-generated by ``ssik add-arm``).'
+    )
+    return f'''{docstring_header}
+
+The arm dispatches to ``{plan.solver_name}`` (tier {plan.tier}) per the
+current ``ssik.core.dispatcher``. The scaffold below verifies:
+
+- URDF loads as a {dof}-DOF revolute chain.
+- Dispatcher routing is stable.
+- Every retained IK FK-closes ≤ {fk_atol:.0e} on hand-picked + random
+  reachable poses.
+
+Edit this file freely after generation -- the scaffold is a starting
+point. For 7R arms with URDF axis drift, consider adding a drift-
+documentation test (see ``tests/test_kinova_gen3.py`` /
+``tests/test_flexiv_rizon4.py`` for examples).
+
+Source URDF: ``tests/fixtures/{urdf_filename}`` (vendored via ``ssik add-arm``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.core.dispatcher import dispatch
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+URDF_PATH = Path(__file__).parent / "fixtures" / "{urdf_filename}"
+
+
+def {kb_helper}():
+    return load_urdf_kinbody_normalized(URDF_PATH, "{base_link}", "{ee_link}")
+
+
+# ----------------------------------------------------------------------------
+# URDF load + topology
+# ----------------------------------------------------------------------------
+
+
+def test_{arm_name}_loads_as_{dof}r() -> None:
+    kb = {kb_helper}()
+    assert len(kb.joints) == {dof}
+    for j in kb.joints:
+        assert j.joint_type == "revolute"
+
+
+def test_{arm_name}_dispatches_to_{_solver_assertion_slug(plan.solver_name)}() -> None:
+    """Dispatcher routing is stable. Updating the dispatcher should
+    update this assertion deliberately.
+    """
+    kb = {kb_helper}()
+    plan = dispatch(kb)
+    assert plan.solver_name == "{plan.solver_name}"
+    assert plan.tier == {plan.tier}
+
+
+# ----------------------------------------------------------------------------
+# Hand-picked seeded recovery (slow -- IK calls)
+# ----------------------------------------------------------------------------
+
+
+_HAND_PICKED_Q = [
+    np.array({_hand_picked_q_array(0, dof)}),
+    np.array({_hand_picked_q_array(1, dof)}),
+    np.array({_hand_picked_q_array(2, dof)}),
+    np.array({_hand_picked_q_array(3, dof)}),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_{arm_name}_hand_picked_fk_closure(q_star: np.ndarray) -> None:
+    """Every reachable hand-picked q* yields at least one IK with FK
+    closure ≤ {fk_atol:.0e}.
+    """
+    kb = {kb_helper}()
+    T_target = poe_forward_kinematics(kb, q_star)
+    {_solver_invocation_block(plan.solver_name, "kb", "T_target")}
+    assert sols, f"no IK returned for reachable q*={{q_star.tolist()}}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < {fk_atol}, f"best FK={{best_fk:.2e}} > {fk_atol:.0e}"
+
+
+# ----------------------------------------------------------------------------
+# Hypothesis fuzz: random reachable poses
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples={n_random_poses},
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_{arm_name}_random_pose_fk_closure(seed: int) -> None:
+    """{n_random_poses} random q in [-0.8, 0.8] per joint: at least one
+    returned IK FK-closes < {fk_atol:.0e}.
+    """
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size={dof})
+    kb = {kb_helper}()
+    T_target = poe_forward_kinematics(kb, q_star)
+    {_solver_invocation_block(plan.solver_name, "kb", "T_target")}
+    assert sols, f"no IK returned for random q*={{q_star.tolist()}}"
+    best_fk = min(s.fk_residual for s in sols)
+    assert best_fk < {fk_atol}, f"seed={{seed}}: best FK={{best_fk:.2e}} > {fk_atol:.0e}"
+'''
+
+
+def _solver_assertion_slug(solver_name: str) -> str:
+    """Convert solver_name to a Python-identifier-safe slug for test names."""
+    return solver_name.replace(".", "_").replace(":", "_")
+
+
+def _solver_invocation_block(solver_name: str, kb_var: str, t_var: str) -> str:
+    """Render the per-solver invocation line(s) for the test scaffold.
+
+    Pads the chosen solver's import + ``solve`` call onto the test body.
+    Different dispatchers expect slightly different call signatures
+    (e.g. ``allow_refinement`` is a no-op for some; passing it
+    everywhere is harmless).
+    """
+    if solver_name == "seven_r.srs":
+        return f"from ssik.solvers.seven_r import srs\n    sols, _ = srs.solve({kb_var}, {t_var})"
+    if solver_name == "seven_r.srs_polished":
+        return (
+            "from ssik.solvers.seven_r import srs_polished\n"
+            f"    sols, _ = srs_polished.solve({kb_var}, {t_var})"
+        )
+    if solver_name == "jointlock.seven_r":
+        return (
+            "from ssik.solvers.jointlock import seven_r as jointlock_seven_r\n"
+            f"    sols, _ = jointlock_seven_r.solve({kb_var}, {t_var}, allow_refinement=True)"
+        )
+    if solver_name.startswith("ikgeo."):
+        module = solver_name.split(".", 1)[1]
+        return (
+            f"from ssik.solvers.ikgeo import {module}\n"
+            f"    sols, _ = {module}.solve({kb_var}, {t_var}, allow_refinement=True)"
+        )
+    if solver_name == "husty_pfurner.general_6r":
+        return (
+            "from ssik.solvers.husty_pfurner import general_6r as hp_general_6r\n"
+            f"    sols, _ = hp_general_6r.solve({kb_var}, {t_var}, allow_refinement=True)"
+        )
+    raise ValueError(f"add-arm: no scaffold template for solver {solver_name!r}")
+
+
+def _hand_picked_q_array(seed: int, dof: int) -> str:
+    """Deterministic hand-picked q* lists for the scaffold's parametrize.
+
+    Seeded so every run of ``ssik add-arm`` produces byte-identical
+    test files for the same ``--name`` (regression-friendly).
+    """
+    rng = np.random.default_rng(seed * 31 + 17)
+    q = rng.uniform(-0.8, 0.8, size=dof)
+    return "[" + ", ".join(f"{x:.4f}" for x in q) + "]"
 
 
 if __name__ == "__main__":  # pragma: no cover -- entry-point

--- a/tests/test_cached_rr_jointlock.py
+++ b/tests/test_cached_rr_jointlock.py
@@ -123,9 +123,7 @@ def test_urdf_loaded_rizon_does_not_trigger_cached_rr() -> None:
         allow_refinement=False,
         refinement_max_iters=15,
     )
-    assert result is None, (
-        f"expected None (no prime in test path); got {type(result).__name__}"
-    )
+    assert result is None, f"expected None (no prime in test path); got {type(result).__name__}"
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +217,7 @@ def test_rr_eligible_set_includes_slow_inner_solvers() -> None:
         "husty_pfurner.general_6r",
     }
     assert expected.issubset(_RR_ELIGIBLE_INNER_SOLVERS), (
-        f"slow inner solvers should be RR-eligible: missing "
-        f"{expected - _RR_ELIGIBLE_INNER_SOLVERS}"
+        f"slow inner solvers should be RR-eligible: missing {expected - _RR_ELIGIBLE_INNER_SOLVERS}"
     )
 
 

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -1,0 +1,205 @@
+"""End-to-end tests for the ``ssik add-arm`` subcommand (#196).
+
+The CLI takes a URDF + base/ee link names + an arm name, vendors the
+URDF into ``tests/fixtures/`` and emits a per-arm bulletproof test
+scaffold. The generated tests assert URDF load + dispatcher routing
++ hand-picked / random FK closure on every retained IK.
+
+Test contract:
+
+- The generated test file is valid Python and pytest-collectable.
+- The generated tests pass when run against the real fixture URDF.
+- Reusing an existing name without ``--force`` errors out cleanly.
+- Solver-specific scaffolds work for every dispatch class we care
+  about (jointlock, srs, srs_polished, ikgeo.* — exercised on the
+  fixtures we already have).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Mock repository root with a populated ``tests/fixtures`` dir.
+
+    The CLI writes to ``<repo-root>/tests/fixtures/`` and
+    ``<repo-root>/tests/``, so we need both directories. We create
+    them and return the workspace root.
+    """
+    (tmp_path / "tests" / "fixtures").mkdir(parents=True)
+    return tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run ``ssik`` as a subprocess. Returns the completed-process result."""
+    return subprocess.run(
+        [sys.executable, "-m", "ssik.cli", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_add_arm_generates_files(workspace: Path) -> None:
+    """``ssik add-arm`` vendors the URDF and emits a test scaffold."""
+    result = _run_cli(
+        "add-arm",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "rizon4_addarm_test",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+
+    urdf_dest = workspace / "tests" / "fixtures" / "rizon4_addarm_test.urdf"
+    test_dest = workspace / "tests" / "test_rizon4_addarm_test.py"
+    assert urdf_dest.exists(), "URDF not vendored"
+    assert test_dest.exists(), "test scaffold not written"
+    # URDF byte-equal to source.
+    src_bytes = (REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf").read_bytes()
+    assert urdf_dest.read_bytes() == src_bytes
+
+
+def test_add_arm_refuses_overwrite_without_force(workspace: Path) -> None:
+    """If the fixture already exists, the CLI refuses unless ``--force``."""
+    target = workspace / "tests" / "fixtures" / "preexisting_arm.urdf"
+    target.write_text("<robot/>")
+    result = _run_cli(
+        "add-arm",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "preexisting_arm",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode != 0
+    assert "already exists" in result.stdout
+    # File contents preserved.
+    assert target.read_text() == "<robot/>"
+
+
+def test_add_arm_force_overwrites(workspace: Path) -> None:
+    """``--force`` overwrites the existing fixture."""
+    target_urdf = workspace / "tests" / "fixtures" / "force_test.urdf"
+    target_test = workspace / "tests" / "test_force_test.py"
+    target_urdf.write_text("<robot/>")
+    target_test.write_text("# stale")
+    result = _run_cli(
+        "add-arm",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "force_test",
+        "--repo-root",
+        str(workspace),
+        "--force",
+    )
+    assert result.returncode == 0
+    # Fresh contents (URDF byte-equal to Rizon source; test file no longer "# stale").
+    assert "<robot/>" not in target_urdf.read_text()
+    assert "# stale" not in target_test.read_text()
+
+
+def test_add_arm_generated_test_is_valid_python(workspace: Path) -> None:
+    """The generated test file imports cleanly (compile check)."""
+    result = _run_cli(
+        "add-arm",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "compile_test",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0
+    test_dest = workspace / "tests" / "test_compile_test.py"
+    source = test_dest.read_text()
+    # Plain compile: catches any syntax errors in the f-string templating.
+    compile(source, str(test_dest), "exec")
+
+
+def test_add_arm_generated_test_runs_passes(workspace: Path, monkeypatch) -> None:
+    """The generated test scaffold actually passes on the real Rizon URDF.
+
+    The scaffold needs the URDF in <repo-root>/tests/fixtures/ to load.
+    We copy the test file into the real repo-root (with a unique name to
+    avoid collisions) and run pytest against it.
+    """
+    # Generate into the real repo (so URDF_PATH resolves).
+    name = "addarm_runtest"
+    result = _run_cli(
+        "add-arm",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        name,
+        "--repo-root",
+        str(REPO_ROOT),
+        "--force",
+    )
+    assert result.returncode == 0, result.stdout
+
+    test_dest = REPO_ROOT / "tests" / f"test_{name}.py"
+    urdf_dest = REPO_ROOT / "tests" / "fixtures" / f"{name}.urdf"
+    try:
+        # Run only the fast tests (URDF load + dispatch routing).
+        run = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test_dest), "-v"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        # Should pass.
+        assert run.returncode == 0, f"pytest failed:\n{run.stdout}\n{run.stderr}"
+    finally:
+        # Always clean up the real-repo files we generated.
+        if test_dest.exists():
+            test_dest.unlink()
+        if urdf_dest.exists():
+            urdf_dest.unlink()
+
+
+def test_add_arm_missing_urdf_errors_cleanly(workspace: Path) -> None:
+    """Pointing at a non-existent URDF errors instead of silently writing."""
+    result = _run_cli(
+        "add-arm",
+        str(workspace / "nonexistent.urdf"),
+        "--base",
+        "base",
+        "--ee",
+        "ee",
+        "--name",
+        "ghost_arm",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stdout.lower() or "not found" in result.stderr.lower()

--- a/tests/test_lm_refine_batch.py
+++ b/tests/test_lm_refine_batch.py
@@ -81,9 +81,7 @@ def test_batch_marks_diverged_seeds_with_inf() -> None:
     def jac_fn(q):
         return kinbody_jacobian(kb, q)
 
-    _q_pol, fk_res, _ = lm_refine_batch(
-        seeds, fk_fn, jac_fn, T_target, fk_atol=1e-10, max_iters=20
-    )
+    _q_pol, fk_res, _ = lm_refine_batch(seeds, fk_fn, jac_fn, T_target, fk_atol=1e-10, max_iters=20)
     # Most should diverge or fail to converge.
     assert (fk_res == np.inf).any() or (fk_res > 1e-10).any()
     # The ones that converge must hit machine precision.
@@ -141,9 +139,7 @@ def test_batch_matches_scalar_on_easy_seeds() -> None:
         scalar_results.append(result is not None)
 
     # Batch
-    _q_pol, fk_res, _ = lm_refine_batch(
-        seeds, fk_fn, jac_fn, T_target, fk_atol=1e-12, max_iters=20
-    )
+    _q_pol, fk_res, _ = lm_refine_batch(seeds, fk_fn, jac_fn, T_target, fk_atol=1e-12, max_iters=20)
     batch_converged = fk_res < 1e-12
 
     # Both must agree on convergence per candidate within tolerance


### PR DESCRIPTION
## Summary

\`ssik add-arm <urdf> --base <link> --ee <link> --name <arm>\` compresses the manual 6-hour-per-arm onboarding flow (PRs #194/#195/#197 are the manual versions) into **~10 seconds**.

\`\`\`bash
$ ssik add-arm path/to/my_arm.urdf --base base_link --ee tool0 --name my_arm
[ssik add-arm] Loading path/to/my_arm.urdf
[ssik add-arm]   7 joints, 8 links — POE-normalized OK
[ssik add-arm] Classifying topology
[ssik]   → Best solver: jointlock.seven_r (tier 1)
[ssik]   → Expected median IK time: ~50.0 ms
[ssik add-arm] Vendoring URDF -> tests/fixtures/my_arm.urdf
[ssik add-arm] Generating test scaffold -> tests/test_my_arm.py
[ssik add-arm]   wrote 4,203 bytes (113 lines)
[ssik add-arm] ✓ Done.
\`\`\`

## What lands

1. **URDF load + topology classification** via ssik's dispatcher.
2. **URDF vendored** to \`tests/fixtures/<name>.urdf\` (byte-equal to source).
3. **Test scaffold** at \`tests/test_<name>.py\` with:
   - URDF load + DOF / joint-type sanity
   - Dispatcher routing assertion
   - \`@pytest.mark.slow\` hand-picked seeded recovery (4 q*)
   - \`@pytest.mark.slow\` Hypothesis fuzz (10 random reachable poses)
   - FK closure ≤ 1e-10 on every retained IK

The scaffold's \`solve\` invocation is solver-specific — covers \`seven_r.srs\`, \`seven_r.srs_polished\`, \`jointlock.seven_r\`, \`ikgeo.*\` (any tier-0/1 specialisation), \`husty_pfurner.general_6r\`.

## Safety

- Refuses to overwrite existing fixture / test files unless \`--force\`.
- Refuses cleanly when the source URDF doesn't exist.
- Hand-picked q* are seeded deterministically — re-running for the same \`--name\` produces byte-identical scaffolds.

## Out of scope (filed as follow-ups under #196)

- xacro → URDF rendering (currently expects flat URDF)
- URL fetch (currently expects local path)
- Bench script generator (\`scripts/bench_<name>.py\`)
- README arm-row insertion
- Validation gate (auto-run scaffold after generation)

The MVP delivers the highest-leverage piece (test scaffold). Other items are incremental adds.

## Test plan

- [x] \`uv run pytest tests/test_cli_add_arm.py -v\` — 6 tests pass in 6.5s
- [x] Full suite: \`uv run pytest -q --deselect tests/test_spherical_two_intersecting.py::test_random_q_roundtrip_fk\` — **1226 passed**, 1 pre-existing flake unrelated
- [x] \`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/\` — clean
- [x] Live run on Rizon 4: vendored + generated + auto-test runs pass (URDF load, dispatch routing, hand-picked + Hypothesis fuzz all green in ~6 sec)

## End-user flow now

\`\`\`
ssik add-arm  ->  vendor URDF + scaffold tests  (10 sec, no production prep)
ssik build    ->  emit per-arm artifact         (~3-5 min, production deploy)
\`\`\`

The first command makes ssik integration accessible to anyone with a URDF, regardless of whether they read the codebase. The second is the existing production-deploy path.