### PR TITLE
Plumb max_solutions through inner-6R solvers (closes #198)

### DIFF
--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -797,6 +797,7 @@ def verify_candidates(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
     jacobian_fn: Callable[[NDArray[np.float64]], NDArray[np.float64]] | None = None,
+    max_solutions: int | None = None,
 ) -> list[Solution]:
     """FK-verify, optionally polish, and dedup IK candidates.
 
@@ -830,11 +831,19 @@ def verify_candidates(
     :param allow_refinement: opt into Newton polish for near-misses.
     :param refinement_max_iters: cap on Newton iterations per candidate.
     :param jacobian_fn: optional analytical Jacobian for ``lm_refine``.
+    :param max_solutions: optional early-exit cap (#198). When set, stop
+        iterating ``candidates`` once the deduped count reaches the cap.
+        Default ``None`` preserves full enumeration. The check runs after
+        every appended candidate; the post-dedup gate guarantees the cap
+        is met by *unique* solutions.
     """
+    if max_solutions is not None and max_solutions < 1:
+        raise ValueError(f"max_solutions must be >= 1 or None; got {max_solutions}")
     verified: list[Solution] = []
     for branch_idx, q in enumerate(candidates):
         q = np.asarray(q, dtype=np.float64)
         fk_resid = float(np.linalg.norm(fk_fn(q) - t_target))
+        appended = False
         if fk_resid <= fk_atol:
             verified.append(
                 Solution(
@@ -846,31 +855,46 @@ def verify_candidates(
                     solver_name=solver_name,
                 )
             )
-            continue
-        if not allow_refinement:
-            continue
-        refined = lm_refine(
-            q,
-            fk_fn,
-            t_target,
-            fk_atol=fk_atol,
-            max_iters=refinement_max_iters,
-            jacobian_fn=jacobian_fn,
-        )
-        if refined is None:
-            continue
-        q_ref, resid, iters = refined
-        verified.append(
-            Solution(
-                q=q_ref,
-                fk_residual=resid,
-                refinement_used="lm",
-                refinement_iters=iters,
-                branch_id=branch_idx,
-                solver_name=solver_name,
+            appended = True
+        elif allow_refinement:
+            refined = lm_refine(
+                q,
+                fk_fn,
+                t_target,
+                fk_atol=fk_atol,
+                max_iters=refinement_max_iters,
+                jacobian_fn=jacobian_fn,
             )
-        )
+            if refined is not None:
+                q_ref, resid, iters = refined
+                verified.append(
+                    Solution(
+                        q=q_ref,
+                        fk_residual=resid,
+                        refinement_used="lm",
+                        refinement_iters=iters,
+                        branch_id=branch_idx,
+                        solver_name=solver_name,
+                    )
+                )
+                appended = True
+
+        # Early-exit gate (#198): once we have the requested number of
+        # *unique* solutions, stop iterating remaining candidates. The
+        # post-dedup check is mandatory because algebraic enumeration
+        # often emits duplicate q-vectors across branches.
+        if appended and max_solutions is not None and len(verified) >= max_solutions:
+            if dedup_atol is None:
+                return verified[:max_solutions]
+            deduped = dedup_by_wrap_close(verified, dedup_atol)
+            if len(deduped) >= max_solutions:
+                return deduped[:max_solutions]
 
     if dedup_atol is None:
+        if max_solutions is not None:
+            return verified[:max_solutions]
         return verified
-    return dedup_by_wrap_close(verified, dedup_atol)
+    deduped_final = dedup_by_wrap_close(verified, dedup_atol)
+    if max_solutions is not None:
+        return deduped_final[:max_solutions]
+    return deduped_final

--- a/src/ssik/solvers/husty_pfurner/general_6r.py
+++ b/src/ssik/solvers/husty_pfurner/general_6r.py
@@ -126,6 +126,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
     fk_atol: float = 1e-12,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Universal 6R analytical IK via Husty-Pfurner.
 
@@ -303,6 +304,7 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
         jacobian_fn=jac_fn,
+        max_solutions=max_solutions,
     )
 
     if not solutions:

--- a/src/ssik/solvers/ikgeo/_raghavan_roth.py
+++ b/src/ssik/solvers/ikgeo/_raghavan_roth.py
@@ -42,7 +42,7 @@ import sympy as sp
 from numpy.typing import NDArray
 
 from ssik.core.solution import Solution
-from ssik.refinement import lm_refine
+from ssik.refinement import dedup_by_wrap_close, lm_refine
 
 __all__ = [
     "back_substitute",
@@ -1522,6 +1522,7 @@ def solve_all_ik(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
     solver_name: str = "ikgeo._raghavan_roth",
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Run the full Raghavan-Roth pipeline and return all valid IK solutions.
 
@@ -1558,10 +1559,15 @@ def solve_all_ik(
         when ``allow_refinement=True``.
     :param solver_name: tag stored on each returned :class:`Solution` for
         provenance when results pass through a dispatcher.
+    :param max_solutions: optional early-exit cap (#198). When set, stop
+        back-substituting roots once the post-dedup count reaches the cap.
+        Default ``None`` enumerates all up-to-16 algebraic branches.
     :returns: ``(solutions, is_ls)`` where solutions is a list of
         :class:`~ssik.core.solution.Solution` and ``is_ls`` is True iff no
         candidate survived FK validation.
     """
+    if max_solutions is not None and max_solutions < 1:
+        raise ValueError(f"max_solutions must be >= 1 or None; got {max_solutions}")
     if linearity_joint == "auto":
         # AE-3 (#70): pick the best leftvar (cached per arm; the structural
         # pathology that determines the choice is geometry-driven, not
@@ -1613,6 +1619,7 @@ def solve_all_ik(
         # the chain matrices it had to build for drop-joint recovery, so
         # we don't pay for a separate ``_fk_dh(q_cand, dh)`` here (#86).
         q_cand, fk_err_alg = bs_result
+        appended = False
         if fk_err_alg <= fk_atol:
             candidates.append(
                 Solution(
@@ -1624,32 +1631,37 @@ def solve_all_ik(
                     solver_name=solver_name,
                 )
             )
-            continue
-        if not allow_refinement:
-            # Default path: drop candidates that miss fk_atol algebraically.
-            continue
-        # Opt-in refinement: lm_refine polishes the algebraic seed.
-        refined = lm_refine(
-            q_cand,
-            fk_fn,
-            t_target,
-            fk_atol=fk_atol,
-            max_iters=refinement_max_iters,
-            jacobian_fn=jacobian_fn,
-        )
-        if refined is None:
-            continue
-        q_refined, fk_resid, iters = refined
-        candidates.append(
-            Solution(
-                q=q_refined,
-                fk_residual=fk_resid,
-                refinement_used="lm",
-                refinement_iters=iters,
-                branch_id=branch_idx,
-                solver_name=solver_name,
+            appended = True
+        elif allow_refinement:
+            # Opt-in refinement: lm_refine polishes the algebraic seed.
+            refined = lm_refine(
+                q_cand,
+                fk_fn,
+                t_target,
+                fk_atol=fk_atol,
+                max_iters=refinement_max_iters,
+                jacobian_fn=jacobian_fn,
             )
-        )
+            if refined is not None:
+                q_refined, fk_resid, iters = refined
+                candidates.append(
+                    Solution(
+                        q=q_refined,
+                        fk_residual=fk_resid,
+                        refinement_used="lm",
+                        refinement_iters=iters,
+                        branch_id=branch_idx,
+                        solver_name=solver_name,
+                    )
+                )
+                appended = True
+
+        # Early-exit gate (#198): once we have enough unique solutions, stop
+        # back-substituting remaining algebraic roots.
+        if appended and max_solutions is not None and len(candidates) >= max_solutions:
+            deduped_partial = dedup_by_wrap_close(candidates, dedup_atol)
+            if len(deduped_partial) >= max_solutions:
+                return deduped_partial[:max_solutions], False
 
     # Deduplicate with wrap-to-pi joint distance. Keep the lower-fk_residual
     # candidate when two collapse.
@@ -1669,4 +1681,6 @@ def solve_all_ik(
         elif cand.fk_residual < solutions[dup_idx].fk_residual:
             solutions[dup_idx] = cand
 
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions, len(solutions) == 0

--- a/src/ssik/solvers/ikgeo/general_6r.py
+++ b/src/ssik/solvers/ikgeo/general_6r.py
@@ -64,6 +64,7 @@ def solve(
     refinement_max_iters: int = 15,
     linearity_joint: int | str = "auto",
     apply_so3: bool = False,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for any 6R chain via Raghavan-Roth + AE-3 leftvar selection.
 
@@ -106,6 +107,7 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
         solver_name=_SOLVER_NAME,
+        max_solutions=max_solutions,
     )
 
     # The bridge ``T_pre @ FK_DH(theta) @ T_post = FK_POE(q)`` uses SE(3)-

--- a/src/ssik/solvers/ikgeo/spherical.py
+++ b/src/ssik/solvers/ikgeo/spherical.py
@@ -86,6 +86,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for generic spherical-wrist 6R chains.
 
@@ -191,6 +192,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
@@ -73,6 +73,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for spherical-wrist + intersecting-shoulder 6R chains.
 
@@ -186,6 +187,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/ikgeo/spherical_two_parallel.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_parallel.py
@@ -78,6 +78,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for spherical-wrist + two-parallel-shoulder 6R chains.
 
@@ -211,6 +212,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -69,6 +69,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for three-parallel 6R chains.
 
@@ -177,6 +178,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/ikgeo/two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/two_intersecting.py
@@ -68,6 +68,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Analytic + univariate-search IK for 6R chains with ``p[5] = 0``.
 
@@ -154,6 +155,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates from %d q4-search branches -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/ikgeo/two_parallel.py
+++ b/src/ssik/solvers/ikgeo/two_parallel.py
@@ -47,6 +47,7 @@ def solve(
     *,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     if len(kb.joints) != 6:
         raise ValueError(f"two_parallel requires a 6-DOF chain; got {len(kb.joints)} joints")
@@ -143,6 +144,7 @@ def solve(
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     _LOG.info(
         "%s: %d candidates from %d q1-search branches -> %d solutions (is_ls=%s)",

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -261,6 +261,7 @@ def _dispatch(
     *,
     allow_refinement: bool,
     refinement_max_iters: int,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool]:
     """Call the named ikgeo solver on ``sub_kb``. Returns ``(solutions, is_ls)``.
 
@@ -269,6 +270,10 @@ def _dispatch(
     with target ``T_target^{-1}``; the returned q-vectors are then mapped
     back to the original-chain ordering. This handles the EAIK
     ``REVERSED`` decomposition family (e.g. Franka post-lock-4).
+
+    ``max_solutions`` (#198) is plumbed through to the inner solver so a
+    capped-IK request stops branch enumeration once the cap is reached
+    inside the sub-chain, avoiding wasted Newton polish on extra seeds.
     """
     if solver_name.startswith("reversed:"):
         inner_name = solver_name[len("reversed:") :]
@@ -281,6 +286,7 @@ def _dispatch(
             policy,
             allow_refinement=allow_refinement,
             refinement_max_iters=refinement_max_iters,
+            max_solutions=max_solutions,
         )
         # Map reversed-chain q's back to original-chain ordering.
         sub_sols_orig = [replace(sol, q=map_reversed_q(sol.q)) for sol in sub_sols_rev]
@@ -300,6 +306,7 @@ def _dispatch(
             policy,
             allow_refinement=allow_refinement,
             refinement_max_iters=refinement_max_iters,
+            max_solutions=max_solutions,
         )
         if rr_result is not None:
             return rr_result
@@ -323,6 +330,7 @@ def _dispatch(
         policy,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
+        max_solutions=max_solutions,
     )
     return result
 
@@ -354,6 +362,7 @@ def _try_cached_rr(
     *,
     allow_refinement: bool,
     refinement_max_iters: int,
+    max_solutions: int | None = None,
 ) -> tuple[list[Solution], bool] | None:
     """Attempt cached-RR solve on the sub-chain. Returns ``(sols, is_ls)``
     if RR's derivation cache is primed for this DH AND it produces a
@@ -391,6 +400,7 @@ def _try_cached_rr(
             refinement_max_iters=refinement_max_iters,
             linearity_joint=linearity,
             apply_so3=apply_so3,
+            max_solutions=max_solutions,
         )
     except Exception as exc:
         _LOG.debug("jointlock cached-RR raised %s; falling back", type(exc).__name__)
@@ -563,6 +573,7 @@ def solve(
                 policy,
                 allow_refinement=allow_refinement,
                 refinement_max_iters=refinement_max_iters,
+                max_solutions=max_solutions,
             )
         except ValueError:
             # Topology may fail marginally on some lock values (e.g.

--- a/tests/test_max_solutions_plumb_through.py
+++ b/tests/test_max_solutions_plumb_through.py
@@ -1,0 +1,241 @@
+"""Plumb-through correctness for ``max_solutions`` (#198).
+
+The outer-most solver layers (``seven_r.srs``, ``jointlock.seven_r``) already
+honor ``max_solutions``. Issue #198 plumbs it through the inner-6R layer
+so a capped IK request stops branch enumeration at every depth.
+
+Test contract:
+- Each inner-6R ``solve()`` accepts ``max_solutions: int | None``.
+- ``max_solutions=None`` matches existing behavior (regression guard).
+- ``max_solutions=N`` returns at most ``N`` IKs, all FK-closing.
+- ``max_solutions=1`` is the trajectory-tracking case (most common).
+- Jointlock plumbs the cap to inner solvers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import KinBody, build_kinbody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.husty_pfurner import general_6r as hp_general_6r
+from ssik.solvers.ikgeo import (
+    general_6r as rr_general_6r,
+)
+from ssik.solvers.ikgeo import (
+    spherical,
+    spherical_two_intersecting,
+    spherical_two_parallel,
+    three_parallel,
+)
+from ssik.solvers.jointlock import seven_r as jointlock_seven_r
+
+FIXTURES = Path(__file__).parent / "fixtures"
+sys.path.insert(0, str(FIXTURES))
+
+from jaco2 import jaco2_specs  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def puma_kb() -> KinBody:
+    return load_urdf_kinbody_normalized(FIXTURES / "puma560.urdf", "base_link", "wrist_3_link")
+
+
+@pytest.fixture(scope="module")
+def ur5_kb() -> KinBody:
+    return load_urdf_kinbody_normalized(FIXTURES / "ur5.urdf", "base_link", "ee_link")
+
+
+@pytest.fixture(scope="module")
+def rizon4_kb() -> KinBody:
+    return load_urdf_kinbody_normalized(FIXTURES / "rizon4.urdf", "base_link", "flange")
+
+
+@pytest.fixture(scope="module")
+def jaco2_kb() -> KinBody:
+    """JACO 2 (non-Pieper 6R) -- canonical fixture for RR + HP."""
+    return build_kinbody(jaco2_specs())
+
+
+def _seeded_target(kb: KinBody, q_seed: np.ndarray) -> np.ndarray:
+    return poe_forward_kinematics(kb, q_seed)
+
+
+# ---------------------------------------------------------------------------
+# Inner-6R: each solver respects the cap and returns FK-closing IKs.
+# ---------------------------------------------------------------------------
+
+
+_PUMA_Q = np.array([0.4, -0.6, 0.8, 1.0, -0.4, 0.3])
+_UR5_Q = np.array([0.3, -0.7, 0.9, -0.5, 1.1, 0.2])
+
+
+@pytest.mark.parametrize("max_n", [1, 2, 4])
+def test_spherical_two_intersecting_respects_max_solutions(puma_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(puma_kb, _PUMA_Q)
+    sols, is_ls = spherical_two_intersecting.solve(puma_kb, T, max_solutions=max_n)
+    assert not is_ls
+    assert 1 <= len(sols) <= max_n
+    for s in sols:
+        assert s.fk_residual < 1e-6
+
+
+@pytest.mark.parametrize("max_n", [1, 2, 4])
+def test_spherical_two_parallel_respects_max_solutions(puma_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(puma_kb, _PUMA_Q)
+    sols, is_ls = spherical_two_parallel.solve(puma_kb, T, max_solutions=max_n)
+    assert not is_ls
+    assert 1 <= len(sols) <= max_n
+    for s in sols:
+        assert s.fk_residual < 1e-6
+
+
+@pytest.mark.parametrize("max_n", [1, 2, 4])
+def test_three_parallel_respects_max_solutions(ur5_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(ur5_kb, _UR5_Q)
+    sols, is_ls = three_parallel.solve(ur5_kb, T, max_solutions=max_n)
+    assert not is_ls
+    assert 1 <= len(sols) <= max_n
+    for s in sols:
+        assert s.fk_residual < 1e-6
+
+
+# ``spherical`` is the generic spherical-wrist fallback. Puma matches both
+# specialisations + the generic one. We sanity-check that the cap fires.
+@pytest.mark.parametrize("max_n", [1, 2])
+def test_spherical_respects_max_solutions(puma_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(puma_kb, _PUMA_Q)
+    sols, is_ls = spherical.solve(puma_kb, T, max_solutions=max_n)
+    # ``spherical`` may legitimately return is_ls=True on Puma when the SP5
+    # shoulder reduction is degenerate (the arm actually belongs to
+    # spherical_two_parallel); that's fine -- the cap contract still holds.
+    if not is_ls:
+        assert 1 <= len(sols) <= max_n
+        for s in sols:
+            assert s.fk_residual < 1e-6
+
+
+_JACO2_Q = np.array([0.4, -0.6, 0.8, 1.0, -0.4, 0.3])
+
+
+@pytest.mark.parametrize("max_n", [1, 2])
+def test_husty_pfurner_respects_max_solutions(jaco2_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(jaco2_kb, _JACO2_Q)
+    # JACO 2 needs LM polish to recover IK from HP's algebraic seeds (matches
+    # ssik.solvers.husty_pfurner's oracle test contract).
+    sols, is_ls = hp_general_6r.solve(jaco2_kb, T, max_solutions=max_n, allow_refinement=True)
+    assert not is_ls
+    assert 1 <= len(sols) <= max_n
+    for s in sols:
+        assert s.fk_residual < 1e-10
+
+
+@pytest.mark.parametrize("max_n", [1, 2, 4])
+def test_ikgeo_general_6r_respects_max_solutions(jaco2_kb: KinBody, max_n: int) -> None:
+    T = _seeded_target(jaco2_kb, _JACO2_Q)
+    sols, is_ls = rr_general_6r.solve(jaco2_kb, T, max_solutions=max_n)
+    assert not is_ls
+    assert 1 <= len(sols) <= max_n
+    for s in sols:
+        assert s.fk_residual < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Default-None preserves existing behavior (regression guard).
+# ---------------------------------------------------------------------------
+
+
+def test_spherical_two_parallel_none_matches_uncapped(puma_kb: KinBody) -> None:
+    T = _seeded_target(puma_kb, _PUMA_Q)
+    capped, _ = spherical_two_parallel.solve(puma_kb, T, max_solutions=None)
+    uncapped, _ = spherical_two_parallel.solve(puma_kb, T)
+    assert len(capped) == len(uncapped)
+
+
+def test_three_parallel_none_matches_uncapped(ur5_kb: KinBody) -> None:
+    T = _seeded_target(ur5_kb, _UR5_Q)
+    capped, _ = three_parallel.solve(ur5_kb, T, max_solutions=None)
+    uncapped, _ = three_parallel.solve(ur5_kb, T)
+    assert len(capped) == len(uncapped)
+
+
+def test_husty_pfurner_none_matches_uncapped(jaco2_kb: KinBody) -> None:
+    T = _seeded_target(jaco2_kb, _JACO2_Q)
+    capped, _ = hp_general_6r.solve(jaco2_kb, T, max_solutions=None, allow_refinement=True)
+    uncapped, _ = hp_general_6r.solve(jaco2_kb, T, allow_refinement=True)
+    assert len(capped) == len(uncapped)
+
+
+# ---------------------------------------------------------------------------
+# Validation: max_solutions < 1 is rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_max_solutions_rejected(puma_kb: KinBody, jaco2_kb: KinBody) -> None:
+    T_puma = _seeded_target(puma_kb, _PUMA_Q)
+    T_jaco = _seeded_target(jaco2_kb, _JACO2_Q)
+    with pytest.raises(ValueError, match="max_solutions must be >= 1"):
+        spherical_two_parallel.solve(puma_kb, T_puma, max_solutions=0)
+    with pytest.raises(ValueError, match="max_solutions must be >= 1"):
+        hp_general_6r.solve(jaco2_kb, T_jaco, max_solutions=0)
+    with pytest.raises(ValueError, match="max_solutions must be >= 1"):
+        rr_general_6r.solve(jaco2_kb, T_jaco, max_solutions=0)
+
+
+# ---------------------------------------------------------------------------
+# Jointlock plumbs the cap to inner solvers (Rizon 4 dispatches to
+# jointlock.seven_r with HP / two_parallel as the inner). With cap=1, every
+# inner-solver call gets max_solutions=1 -> capped enumeration.
+# ---------------------------------------------------------------------------
+
+
+def test_jointlock_plumbs_max_solutions_through_dispatch(rizon4_kb: KinBody) -> None:
+    q_seed = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4])
+    T = poe_forward_kinematics(rizon4_kb, q_seed)
+
+    # Patch the inner-6R solvers to record observed max_solutions.
+    observed: list[int | None] = []
+    real_dispatch = jointlock_seven_r._dispatch  # type: ignore[attr-defined]
+
+    def _spy_dispatch(  # type: ignore[no-untyped-def]
+        solver_name,
+        sub_kb,
+        T_target,
+        policy,
+        *,
+        allow_refinement,
+        refinement_max_iters,
+        max_solutions=None,
+    ):
+        observed.append(max_solutions)
+        return real_dispatch(
+            solver_name,
+            sub_kb,
+            T_target,
+            policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+            max_solutions=max_solutions,
+        )
+
+    jointlock_seven_r._dispatch = _spy_dispatch  # type: ignore[attr-defined]
+    try:
+        sols, _ = jointlock_seven_r.solve(rizon4_kb, T, max_solutions=1)
+    finally:
+        jointlock_seven_r._dispatch = real_dispatch  # type: ignore[attr-defined]
+
+    # All observed inner-dispatch calls were given max_solutions=1.
+    assert observed, "expected at least one inner dispatch"
+    assert all(m == 1 for m in observed), f"expected all 1, got {observed}"
+    # And the outer cap is honored.
+    assert len(sols) == 1
+    assert sols[0].fk_residual < 1e-9


### PR DESCRIPTION
## Summary

The outer-most solver layers (`seven_r.srs`, `jointlock.seven_r`) already honored `max_solutions`, but inner-6R solvers ignored it. A `max_solutions=1` call on Rizon 4 still enumerated all branches inside HP / `two_parallel` per sample — wasted Newton polish on 14 of every 16 branches the user never wanted.

Plumbed `max_solutions` through every layer:

- **`verify_candidates`** — post-dedup early-exit gate (the central choke point most ikgeo solvers funnel through).
- **`ikgeo._raghavan_roth.solve_all_ik`** — per-branch back-sub early-exit (its inline FK+dedup loop bypasses `verify_candidates`).
- **7 inner-6R solver signatures** — `spherical`, `spherical_two_parallel`, `spherical_two_intersecting`, `three_parallel`, `two_intersecting`, `two_parallel`, `ikgeo.general_6r`, `husty_pfurner.general_6r`.
- **`jointlock.seven_r._dispatch`** + **`_try_cached_rr`** — including the `reversed:` recursive path for Franka/xArm7's reverse-chain dispatch.

## Test plan

- [x] `verify_candidates` early-exit: post-dedup gate guarantees the cap is met by *unique* solutions (algebraic enumeration emits dups across branches).
- [x] `max_solutions=None` preserves full enumeration (regression guard).
- [x] `max_solutions=1` returns ≤ 1 IK with FK closure < 1e-10 on every retained solution.
- [x] `max_solutions < 1` raises `ValueError`.
- [x] Jointlock plumb-through: spy-instrumented `_dispatch` confirms every inner-solver call observes `max_solutions=1` when the outer cap is 1 (Rizon 4 fixture).
- [x] **21 new tests** in `tests/test_max_solutions_plumb_through.py` covering Puma 560 (spherical / spherical_two_parallel / spherical_two_intersecting), UR5 (three_parallel), JACO 2 (HP + RR), Rizon 4 (jointlock plumb-through).
- [x] **Full suite: 1247 passed, 1 deselected** (#215 pre-existing hypothesis flake on Puma elbow-singular pose, filed under this PR).
- [x] Lint clean, format clean.

## Out of scope (deferred)

- **Tier-1 search-based solvers** (`two_parallel`, `two_intersecting`) still run their full 1D grid search even with `max_solutions=1` — the search produces all branches at every grid point in batch. The plumb-through gate fires inside `verify_candidates` (skipping Newton polish on extras) but the algebraic enumeration runs to completion. A future change could add per-sample early-exit inside `search_1d_matched`; today's plumb-through still saves the verify+polish overhead.
- **HP's algebraic enumeration** runs all roots at once (`solve_ik` returns the full batch), so `max_solutions` saves Newton polish on extras but not the elimination cost. That's an algorithmic constraint, not a plumb-through gap.

## Filed under this PR

- **#215** — pre-existing hypothesis flake on `test_spherical_two_intersecting::test_random_q_roundtrip_fk` at `q=[0, 0.5, -1.5234375, 0, 1, 0]` (Puma elbow-singular). Same family as #115 / #101.