### PR TITLE
Vectorise seven_r.srs inner loop: 1.99x on iiwa14 strict (closes #217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Analytical inverse kinematics for non-Pieper 6R arms — the **EAIK gap**. The a
 |---|---|---|---|
 | Pieper-class (UR5, Puma 560, Fanuc, KUKA KR) | ~0.2 ms | ~20 ms | ~1-2 ms |
 | Non-Pieper 6R (JACO 2, Piper) | not supported | ~20 ms | **~0.6 ms median** |
-| SRS-class 7R (KUKA iiwa LBR) | sub-ms | ~30 ms | **~8.5 ms (128 IKs)** |
+| SRS-class 7R (KUKA iiwa LBR) | sub-ms | ~30 ms | **~4.3 ms (128 IKs)** |
 | Approximate-SRS 7R (Kinova Gen3) | sub-ms (with mm-scale IK error vs URDF) | ~30 ms | **~56 ms (machine-precision FK on URDF, batched LM polish)** |
 | Non-Pieper 7R (Flexiv Rizon 4, Kassow KR810) | sub-ms (with cm-scale IK error) | ~30 ms | **~17-18 ms (cached-RR per #210; 30-45 IKs)** |
 | Anthropomorphic 7R (Franka Panda, FR3, xArm7) | sub-ms | ~30 ms | **~42 ms (48-64 IKs) via joint-locking** |
@@ -50,8 +50,8 @@ Closed-form Singh-Kreutz 1989 algorithm for arms with shoulder-spherical + wrist
 
 | Arm | Full-sweep speed | Status |
 |-----|:---:|:---:|
-| **KUKA iiwa LBR 14** | **~8.5 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
-| KUKA iiwa LBR 7 (R820 / R14) | expected ~8.5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
+| **KUKA iiwa LBR 14** | **~4.3 ms (128 IKs, FK ≤ 1e-13)** | ✅ in [`tests/fixtures/`](tests/fixtures/) |
+| KUKA iiwa LBR 7 (R820 / R14) | expected ~4.3 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
 
 ### 7R redundant arms — approximately-SRS with LM polish (`seven_r.srs_polished`)
 
@@ -82,7 +82,7 @@ Covers Franka Panda (anthropomorphic 7R), uFactory xArm7 (mixed structure), and 
 | Tier | Solver modules | Typical IK time | Algorithm |
 |---|---|---|---|
 | 0 — closed-form 6R | `three_parallel`, `spherical_two_parallel`, `spherical_two_intersecting`, `spherical` | ~1 ms | SP1–SP6 composition; one branch per Pieper specialisation |
-| 0 — closed-form 7R (SRS) | `seven_r.srs` | ~8.5 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs |
+| 0 — closed-form 7R (SRS) | `seven_r.srs` | ~4.3 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs (vectorised inner loop, #217) |
 | 0 — approximate SRS + LM polish | `seven_r.srs_polished` | ~56 ms full sweep | Relaxed Singh-Kreutz (small-drift arms) + batched LM polish to machine precision against the original URDF FK |
 | 1 — univariate search | `two_parallel`, `two_intersecting` | ~100 ms – 2 s | tan-half-angle reduction + 200-sample search + Newton polish |
 | 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms tier-0 inner; **~17 ms with cached-RR (#210)** when artifact-built | lock one joint, dispatch inner 6R, sweep 16 lock samples; Raghavan-Roth pre-baked at codegen for non-Pieper sub-chains |

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -67,8 +67,6 @@ from ssik.kinematics.predicates import (
     joint_origins,
 )
 from ssik.refinement import dedup_by_wrap_close
-from ssik.subproblems import sp1
-from ssik.subproblems._rotation import rotation_matrix
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from ssik._kinbody import KinBody
@@ -108,150 +106,65 @@ def _swivel_basis(
 
 
 # ---------------------------------------------------------------------------
-# FK helpers (branch verification + per-branch consistency).
+# Vectorised helpers (batch over swivel axis).
 # ---------------------------------------------------------------------------
 
 
-def _frame_at_joint(
-    kb: KinBody, q: NDArray[np.float64], joint_idx: int
-) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Return ``(R, p)`` -- the world frame at joint ``joint_idx`` BEFORE its
-    own rotation (i.e., after joints ``0..joint_idx-1`` and joint
-    ``joint_idx``'s ``T_left``).
-
-    Tracks rotation and position separately to avoid 4x4 matmul overhead.
-    POE-normalized chains have pure-translation ``T_left`` and (for non-final
-    joints) pure-translation ``T_right``, so position propagation reduces to
-    ``p_new = p + R @ t`` and rotation propagation to one matmul per joint.
-
-    Replaces the older ``_joint_origin_at_q`` + ``_orientation_up_to_joint``
-    helpers with a single 2-3x faster version.
+def _rodrigues_batch(axis: NDArray[np.float64], angles: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Batched Rodrigues: ``(N,)`` angles around fixed ``axis`` -> ``(N, 3, 3)``
+    rotation matrices. Used by :func:`_frame_at_joint_batch` to apply each
+    joint's rotation to the whole swivel batch in a single broadcast.
     """
-    R = np.eye(3)
-    p = np.zeros(3)
+    c = np.cos(angles)
+    s = np.sin(angles)
+    one_minus_c = 1.0 - c
+    ax, ay, az = float(axis[0]), float(axis[1]), float(axis[2])
+    K = np.array([[0.0, -az, ay], [az, 0.0, -ax], [-ay, ax, 0.0]], dtype=np.float64)
+    K2 = K @ K
+    eye = np.eye(3, dtype=np.float64)
+    return (
+        eye[None, :, :]
+        + s[:, None, None] * K[None, :, :]
+        + one_minus_c[:, None, None] * K2[None, :, :]
+    )
+
+
+def _frame_at_joint_batch(
+    kb: KinBody,
+    q_batch: NDArray[np.float64],
+    joint_idx: int,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Batched frame-at-joint walk. ``q_batch`` is ``(N, 7)``; returns
+    ``(R: (N, 3, 3), p: (N, 3))`` -- the world frame at ``joint_idx`` BEFORE
+    its own rotation, evaluated for each row of ``q_batch``.
+
+    Walks the chain joint-by-joint, applying each joint's rotation and
+    translation as a batched ``(N, 3, 3)`` / ``(N, 3)`` op. Eliminates the
+    ~6 ms Python interpretation overhead that the per-call scalar variant
+    incurred on the 16-swivel sweep (~1.9x speedup on iiwa14 strict).
+    """
+    n = q_batch.shape[0]
+    R = np.broadcast_to(np.eye(3), (n, 3, 3)).copy()
+    p = np.zeros((n, 3), dtype=np.float64)
     for i, j in enumerate(kb.joints):
-        # Apply T_left's translation (rotation block of T_left is identity
-        # in POE-normalized chains).
+        # T_left translation (rotation block is I in POE-normalised chains).
         p = p + R @ j.T_left[:3, 3]
         if i == joint_idx:
             return R, p
-        # Apply joint i's rotation.
-        R = R @ rotation_matrix(j.axis, float(q[i]))
-        # Apply T_right (translation always; rotation only matters on the
-        # last joint but applying R @ I on the others is cheap and avoids
-        # an expensive `array_equal` test in the hot loop).
+        # Joint rotation: batched Rodrigues over the (N,) angle slice.
+        Ri = _rodrigues_batch(j.axis, q_batch[:, i])
+        R = R @ Ri
+        # T_right -- rotation block only matters on the last joint, but the
+        # frame-at-joint contract returns BEFORE the joint at ``joint_idx``,
+        # so ``joint_idx <= 5`` callers never reach the final joint's
+        # ``T_right`` rotation block. Skip the identity-multiplication
+        # branch test here for speed.
         T_right = j.T_right
-        R = R @ T_right[:3, :3]
+        Rt_block = T_right[:3, :3]
+        if not np.array_equal(Rt_block, np.eye(3)):
+            R = R @ Rt_block
         p = p + R @ T_right[:3, 3]
     return R, p
-
-
-# ---------------------------------------------------------------------------
-# Per-branch solver (one swivel angle, one elbow branch, one shoulder branch,
-# one wrist branch).
-# ---------------------------------------------------------------------------
-
-
-def _solve_pre_wrist(
-    kb: KinBody,
-    cls: SrsClassification,
-    L_se: float,
-    R_target: NDArray[np.float64],
-    W_t: NDArray[np.float64],
-    swivel_data: tuple[NDArray[np.float64], float, float, NDArray[np.float64], NDArray[np.float64]],
-    swivel: float,
-    q_3_signed: float,
-    q_1_sign: int,
-    policy: TolerancePolicy,
-) -> tuple[float, float, float, NDArray[np.float64]] | None:
-    """Solve the SHOULDER + ELBOW triple (q_0, q_1, q_2, q_3) at given swivel
-    + branch signs. Returns (q_0, q_1, q_2, R_pre_wrist) where R_pre_wrist
-    is the world orientation of joint 4's pre-rotation frame (joints 0..3
-    applied + joint 4's ``T_left``). Wrist branches share these.
-
-    This is the part of the algorithm that doesn't depend on the wrist
-    branch sign (q_5 sign), so we factor it out to compute it once per
-    swivel x q_3 x q_1 combination instead of once per full branch.
-
-    Reuses subproblem-composition style from
-    :mod:`ssik.solvers.ikgeo.spherical`: the shoulder + elbow analytical
-    closed-form, then a single ``sp1`` for q_2 from the wrist-pivot
-    constraint.
-    """
-    u_sw, x_c, r_circle, u_perp1, u_perp2 = swivel_data
-    S = cls.shoulder_pivot
-
-    # Step 4a: elbow position on the swivel circle.
-    E_t = S + x_c * u_sw + r_circle * (np.cos(swivel) * u_perp1 + np.sin(swivel) * u_perp2)
-
-    # Step 4b: recover (q_0, q_1) from elbow direction analytically.
-    # For ZY shoulder: d = R_z(q_0) R_y(q_1) (0, 0, 1) =
-    #   (sin(q_1) cos(q_0), sin(q_1) sin(q_0), cos(q_1)).
-    d = (E_t - S) / L_se
-    cos_q1 = float(np.clip(d[2], -1.0, 1.0))
-    q_1 = q_1_sign * np.arccos(cos_q1)
-    sin_q1 = np.sin(q_1)
-    if abs(sin_q1) > 1e-9:  # noqa: SIM108
-        q_0 = np.arctan2(d[1] / sin_q1, d[0] / sin_q1)
-    else:
-        # Gimbal lock: elbow on the shoulder z-axis. q_0 is free; pick 0.
-        q_0 = 0.0
-
-    # Step 5: recover q_2 from wrist pivot constraint via a single SP1.
-    # The "q_2 = 0 wrist pivot" is computed by partial FK once at q_2 = 0;
-    # the SP1 then rotates that pivot offset (in plane perp to upper arm)
-    # to align with the target wrist pivot. q_2 is unique up to a 2π
-    # ambiguity that SP1 resolves.
-    q_partial = np.array([q_0, q_1, 0.0, q_3_signed, 0.0, 0.0, 0.0], dtype=np.float64)
-    _, W_at_q2_zero = _frame_at_joint(kb, q_partial, 5)
-
-    u_upper = (E_t - S) / L_se  # upper arm direction
-    p_from = W_at_q2_zero - E_t  # from elbow to q_2=0 wrist pivot
-    p_to = W_t - E_t  # from elbow to target wrist pivot
-    if np.linalg.norm(p_from) < 1e-9 or np.linalg.norm(p_to) < 1e-9:
-        return None
-    q_2, _ = sp1.solve(u_upper, p_from, p_to, policy)
-
-    # Compute the world orientation of joint 4's pre-rotation frame (used
-    # by the wrist triple; doesn't depend on q_5 sign so we cache it).
-    q_post = np.array([q_0, q_1, q_2, q_3_signed, 0.0, 0.0, 0.0], dtype=np.float64)
-    R_pre_wrist, _ = _frame_at_joint(kb, q_post, 4)
-
-    return q_0, q_1, q_2, R_pre_wrist
-
-
-def _solve_wrist_triple(
-    kb: KinBody,
-    R_target: NDArray[np.float64],
-    R_pre_wrist: NDArray[np.float64],
-    q_5_sign: int,
-) -> tuple[float, float, float] | None:
-    """Solve (q_4, q_5, q_6) from the residual rotation via ZYZ Euler.
-
-    For SRS arms with canonical wrist axes (z, y, z) in the body frame at
-    joint 4 (post joint-4-T_left), the residual rotation
-    ``R_res = R_pre_wrist^T @ R_target @ R_post_wrist^T`` factorises as
-    ``R_z(q_4) R_y(q_5) R_z(q_6) = R_res``. The two branches via the sign
-    of ``q_5`` are enumerated by the caller.
-    """
-    R_post_wrist = kb.joints[6].T_right[:3, :3]
-    R_res = R_pre_wrist.T @ R_target @ R_post_wrist.T
-
-    cos_q5 = float(np.clip(R_res[2, 2], -1.0, 1.0))
-    q_5 = q_5_sign * np.arccos(cos_q5)
-    sin_q5 = np.sin(q_5)
-    if abs(sin_q5) > 1e-9:
-        q_4 = np.arctan2(q_5_sign * R_res[1, 2], q_5_sign * R_res[0, 2])
-        q_6 = np.arctan2(q_5_sign * R_res[2, 1], q_5_sign * -R_res[2, 0])
-    else:
-        # Gimbal lock at q_5 = 0 or π: q_4 + q_6 (or q_4 - q_6) is
-        # determined but the split is arbitrary; pick q_4 = 0.
-        q_4 = 0.0
-        if cos_q5 > 0:
-            q_6 = float(np.arctan2(-R_res[0, 1], R_res[0, 0]))
-        else:
-            q_6 = float(np.arctan2(R_res[0, 1], -R_res[0, 0]))
-    return q_4, q_5, q_6
 
 
 # ---------------------------------------------------------------------------
@@ -335,42 +248,105 @@ def solve(
 
     fk_threshold = fk_atol if fk_atol is not None else policy.subproblem_numerical
 
+    # Vectorised inner loop: batch all swivel-derived geometry into (N,)-shaped
+    # arrays so the q_0/q_1/q_2 + R_pre_wrist + wrist-triple computation runs
+    # under one numpy broadcast per (q_3_signed, q_1_sign, q_5_sign) outer
+    # iteration -- 8 outer iterations vs the old 16 * 2 * 2 * 2 = 128. The
+    # frame_at_joint walk happens in batched form (_frame_at_joint_batch). The
+    # per-candidate FK closure check is still per-row because Cython's
+    # ``poe_forward_kinematics`` is already optimised at ~12 us per call.
+    u_sw, x_c, r_circle, u_perp1, u_perp2 = swivel_data
+    N = swivels.shape[0]
+    cs = np.cos(swivels)
+    sn = np.sin(swivels)
+    S = cls.shoulder_pivot
+    E_t = (
+        S
+        + x_c * u_sw
+        + r_circle * (cs[:, None] * u_perp1[None, :] + sn[:, None] * u_perp2[None, :])
+    )  # (N, 3)
+    R_post_wrist = kb.joints[6].T_right[:3, :3]
+
+    # Elbow direction d (N, 3) -- same for both q_1 signs because cos(q_1)
+    # depends only on d[:, 2].
+    d = (E_t - S) / L_se
+    cos_q1_raw = np.clip(d[:, 2], -1.0, 1.0)
+
     candidates: list[Solution] = []
     branch_id = 0
-    for swivel in swivels:
-        for q_3_signed in q_3_branches:
-            for q_1_sign in (+1, -1):
-                # Solve the shoulder + elbow + q_2 once per (swivel, q_3, q_1)
-                # since the wrist branch sign doesn't affect them.
-                pre_wrist = _solve_pre_wrist(
-                    kb,
-                    cls,
-                    L_se,
-                    R_target,
-                    W_t,
-                    swivel_data,
-                    float(swivel),
-                    q_3_signed,
-                    q_1_sign,
-                    policy,
+
+    for q_3_signed in q_3_branches:
+        for q_1_sign in (+1, -1):
+            q_1 = q_1_sign * np.arccos(cos_q1_raw)
+            sin_q1 = np.sin(q_1)
+            q_0 = np.zeros(N, dtype=np.float64)
+            non_gimbal_q1 = np.abs(sin_q1) > 1e-9
+            if non_gimbal_q1.any():
+                q_0[non_gimbal_q1] = np.arctan2(
+                    d[non_gimbal_q1, 1] / sin_q1[non_gimbal_q1],
+                    d[non_gimbal_q1, 0] / sin_q1[non_gimbal_q1],
                 )
-                if pre_wrist is None:
-                    continue
-                q_0, q_1, q_2, R_pre_wrist = pre_wrist
-                for q_5_sign in (+1, -1):
-                    wrist = _solve_wrist_triple(kb, R_target, R_pre_wrist, q_5_sign)
-                    if wrist is None:
-                        continue
-                    q_4, q_5, q_6 = wrist
-                    q = np.array([q_0, q_1, q_2, q_3_signed, q_4, q_5, q_6], dtype=np.float64)
-                    # FK closure check
-                    T_fk = poe_forward_kinematics(kb, q)
+
+            # Frame at joint 5 with q_partial = (q_0, q_1, 0, q_3, 0, 0, 0).
+            q_partial = np.zeros((N, 7), dtype=np.float64)
+            q_partial[:, 0] = q_0
+            q_partial[:, 1] = q_1
+            q_partial[:, 3] = q_3_signed
+            _, W_at_q2_zero = _frame_at_joint_batch(kb, q_partial, 5)
+
+            # SP1 vectorised: q_2 around upper-arm axis maps q_2=0 wrist pivot
+            # into target W_t. Closed-form: q = atan2(u . (p1 x p2), p1.p2 - (u.p1)(u.p2)).
+            u_upper = d  # (N, 3)
+            p_from = W_at_q2_zero - E_t
+            p_to = W_t - E_t  # (3,) -> broadcasts to (N, 3) below
+            up_dot_pf = (u_upper * p_from).sum(axis=1)
+            up_dot_pt = (u_upper * p_to).sum(axis=1)
+            cross_pf_pt = np.cross(p_from, p_to)
+            num = (u_upper * cross_pf_pt).sum(axis=1)
+            den = (p_from * p_to).sum(axis=1) - up_dot_pf * up_dot_pt
+            q_2 = np.arctan2(num, den)
+
+            # Frame at joint 4 with q_full_pre = (q_0, q_1, q_2, q_3, 0, 0, 0).
+            q_post = q_partial.copy()
+            q_post[:, 2] = q_2
+            R_pre_wrist, _ = _frame_at_joint_batch(kb, q_post, 4)
+
+            # Wrist triple via ZYZ Euler -- vectorised. R_res = R_pre^T R_target R_post^T.
+            R_res = R_pre_wrist.transpose(0, 2, 1) @ R_target @ R_post_wrist.T
+            cos_q5_raw = np.clip(R_res[:, 2, 2], -1.0, 1.0)
+
+            for q_5_sign in (+1, -1):
+                q_5 = q_5_sign * np.arccos(cos_q5_raw)
+                sin_q5 = np.sin(q_5)
+                q_4 = np.zeros(N, dtype=np.float64)
+                q_6 = np.zeros(N, dtype=np.float64)
+                ng = np.abs(sin_q5) > 1e-9
+                if ng.any():
+                    q_4[ng] = np.arctan2(q_5_sign * R_res[ng, 1, 2], q_5_sign * R_res[ng, 0, 2])
+                    q_6[ng] = np.arctan2(q_5_sign * R_res[ng, 2, 1], q_5_sign * -R_res[ng, 2, 0])
+                gimbal = ~ng
+                if gimbal.any():
+                    # Gimbal lock at q_5 = 0 or π: q_4 + q_6 (or q_4 - q_6) is
+                    # determined; pick q_4 = 0 and recover q_6 from R_res[:2, :2].
+                    cos_q5_pos = cos_q5_raw[gimbal] > 0
+                    R_gimbal = R_res[gimbal]
+                    q_6_g = np.where(
+                        cos_q5_pos,
+                        np.arctan2(-R_gimbal[:, 0, 1], R_gimbal[:, 0, 0]),
+                        np.arctan2(R_gimbal[:, 0, 1], -R_gimbal[:, 0, 0]),
+                    )
+                    q_6[gimbal] = q_6_g
+
+                # Build q-array (N, 7) and FK-verify each row.
+                q_full = np.column_stack([q_0, q_1, q_2, np.full(N, q_3_signed), q_4, q_5, q_6])
+                for i in range(N):
+                    T_fk = poe_forward_kinematics(kb, q_full[i])
                     fk_residual = float(np.linalg.norm(T_fk - t_target))
                     if fk_residual > fk_threshold:
                         continue
                     candidates.append(
                         Solution(
-                            q=q,
+                            q=q_full[i],
                             fk_residual=fk_residual,
                             refinement_used="none",
                             refinement_iters=0,
@@ -380,8 +356,6 @@ def solve(
                     )
                     branch_id += 1
                     if max_solutions is not None and len(candidates) >= max_solutions:
-                        # Early-exit AFTER dedup so the user gets up to
-                        # max_solutions UNIQUE IKs.
                         deduped = dedup_by_wrap_close(candidates, policy.subproblem_dedup)
                         if len(deduped) >= max_solutions:
                             return deduped[:max_solutions], False


### PR DESCRIPTION
## Summary

\`seven_r.srs.solve\` spent **~75% of its time in Python interpretation overhead** on the 128-iteration nested loop, not numerical work. Replaced the nested \`for swivel: for q_3: for q_1: for q_5\` with a vectorised path that batches all swivel-derived geometry through numpy broadcasts.

## Bench (200 random reachable poses)

| Arm | Before | After | Speedup | IK count |
|---|---|---|---|---|
| **iiwa14 srs strict** | 8.62 ms | **4.34 ms** | **1.99×** | 128 → 128 |
| **Gen3 srs_polished** | 63.65 ms | 60.30 ms | 1.06× | 42 → 40 (±2) |
| Gen3 algebraic-only | 8.34 ms | 4.45 ms | 1.88× | unchanged |

Gen3 srs_polished is LM-polish-dominated (~50 ms); the vectorised algebraic loop only saves ~4 ms there.

## Implementation

- New \`_frame_at_joint_batch(kb, q_batch, joint_idx)\` walks the chain via batched Rodrigues over \`(N,)\`-shaped angle arrays.
- New \`_rodrigues_batch(axis, angles)\` returns \`(N, 3, 3)\` rotation matrices in one broadcast.
- All q_0 / q_1 / q_2 / wrist-triple computation as numpy ops over the swivel axis (\`(N,)\`-shaped).
- 8 outer iterations (q_3 × q_1 × q_5) instead of 128.
- Per-candidate FK closure stays per-row — Cython \`poe_forward_kinematics\` is already optimal at ~12 µs/call.

## Removed dead code

- \`_solve_pre_wrist\` (replaced by inline vectorised SP1 in \`solve\`).
- \`_solve_wrist_triple\` (replaced by inline vectorised ZYZ Euler).
- \`_frame_at_joint\` (only the batched variant is reachable now).
- \`from ssik.subproblems import sp1\` import.
- \`from ssik.subproblems._rotation import rotation_matrix\` import.

Net: -26 lines.

## Test plan

- [x] All SRS tests pass (test_seven_r_srs.py + test_seven_r_srs_polished.py + test_kinova_gen3.py + test_kuka_iiwa14_fixture.py): **47 passed**.
- [x] Full suite: **1247 passed**, 1 deselected (pre-existing flake #215).
- [x] FK closure on iiwa14: max residual **2.74e-12** (vectorized) vs 3.89e-12 (baseline) — actually slightly tighter.
- [x] FK closure on Gen3 polished: max residual **9.90e-13** (vectorized) — machine-precision preserved.
- [x] iiwa14 IK count match: 128 == 128 across 100 random poses.
- [x] Lint clean.

## Behavioral notes

- **Gen3 polished count varies ±2** between baseline and vectorised. The algebraic seeds differ in q-representative (π-equivalent branches from different \`arccos\`/\`atan2\` paths), and LM polish converging from those seeds can land in slightly-different cluster representatives. **Every returned IK still passes FK at 1e-13** — the variation is dedup boundary, not solver correctness.

## Driven by negative result on #206

Issue #217 (and this PR) were filed after the #206 spike showed adaptive coarse-to-fine swivel sampling didn't apply (every swivel produces ~7.6 valid IKs; no \"no-FK valleys\" to skip). Profiling redirected to Python loop overhead, which turned out to be a 1.99× win.