### PR TITLE
Public Manipulator class + top-level exports (closes #12, #227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ Three differentiators:
 2. **Native SRS-class 7R solver** (`seven_r.srs`, Singh-Kreutz 1989) — closed-form parameterised by elbow swivel angle. Predicate-driven dispatch (`is_srs_7r`) auto-applies to any 7R arm matching the topology: shoulder axes (0,1,2) concurrent + wrist axes (4,5,6) concurrent. iiwa14 is the canonical fixture; an approximate-SRS variant (`seven_r.srs_polished`) extends the framework to small-drift arms (Kinova Gen3) via Singh-Kreutz seeds + LM polish against the original URDF FK.
 3. **Cached Raghavan-Roth for jointlock 7R** (#210). Many "literature-SRS" 7R arms (Rizon 4, Kassow KR810) have URDF offsets that break strict SRS structure and previously fell through to the universal jointlock+HP fallback at ~244-444 ms per call. `ssik build` now bakes per-arm RR symbolic derivations into the artifact; the runtime jointlock dispatch uses cached RR (~1 ms warm) instead of HP, yielding **12-25× post-import speedup**. Produces machine-precision FK closure on the actual URDF, not a simplified DH (unlike EAIK's sub-ms-with-cm-scale-error path).
 
+## Quickstart
+
+```python
+import ssik
+import numpy as np
+
+# Load any URDF: the dispatcher picks the right analytical solver automatically.
+arm = ssik.Manipulator.from_urdf("ur5.urdf", base="base_link", ee="ee_link")
+print(arm)
+# <Manipulator: 6-DOF, dispatched to ikgeo.three_parallel (tier 0)>
+
+# Forward kinematics:
+T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+
+# Inverse kinematics — full redundancy enumeration:
+sols, is_ls = arm.ik(T)
+for sol in sols:
+    print(sol.q, sol.fk_residual)
+
+# Trajectory tracking — "give me any IK", typically 10-15× faster on 7R arms:
+sols, is_ls = arm.ik(T, max_solutions=1, q_seed=q_previous)
+```
+
+That's the whole API for the common path. The Manipulator dispatches across every supported arm class — UR5 (tier-0), JACO 2 (non-Pieper 6R), iiwa14 (strict SRS), Gen3 (approximate-SRS + LM polish), Rizon 4 / Kassow / Franka / xArm7 (jointlock + cached-RR). Power users who need solver-specific knobs (`swivel_samples`, `linearity_joint`, etc.) pass them via `arm.ik(T, **solver_kwargs)`.
+
 ## Supported arms & solver coverage
 
 Status legend: ✅ in-repo URDF/MJCF fixture exercised by the test suite — 🔗 external URDF, fixture import pending — 📐 synthetic-only (no canonical commercial arm with this exact topology). Speed is typical median IK-call latency on Apple M3 single-thread, pure Python+numpy.

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -1,5 +1,19 @@
 """ssik -- pluggable analytical inverse-kinematics library for Python.
 
+Quickstart::
+
+    import ssik
+
+    arm = ssik.Manipulator.from_urdf(
+        "ur5.urdf", base="base_link", ee="ee_link"
+    )
+    T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    sols, is_ls = arm.ik(T)
+
+For trajectory tracking::
+
+    sols, is_ls = arm.ik(T_target, max_solutions=1, q_seed=q_prev)
+
 Logging: the package emits hierarchical logs under the ``ssik`` namespace
 (``ssik.solvers.ikgeo.three_parallel``, etc.). By default a ``NullHandler``
 suppresses all output, so importing ssik never produces unsolicited stderr
@@ -14,10 +28,13 @@ The ``ssik build`` CLI configures this automatically via ``--verbose``.
 
 import logging as _logging
 
+from ssik._kinbody import Joint, JointSpec, KinBody, Link, build_kinbody
 from ssik._version import __version__
 from ssik.core.dispatcher import DispatchPlan, dispatch
+from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.core.topology import TopologyReport, describe_topology
+from ssik.manipulator import Manipulator
 
 # Library best practice: prevent "No handlers could be found" warnings and
 # avoid emitting any log records unless the consuming application configures
@@ -27,9 +44,16 @@ _logging.getLogger(__name__).addHandler(_logging.NullHandler())
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",
     "DispatchPlan",
+    "Joint",
+    "JointSpec",
+    "KinBody",
+    "Link",
+    "Manipulator",
+    "Solution",
     "TolerancePolicy",
     "TopologyReport",
     "__version__",
+    "build_kinbody",
     "describe_topology",
     "dispatch",
 ]

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -1,0 +1,294 @@
+"""Public Manipulator class -- the v1.0 entry point.
+
+A :class:`Manipulator` is the user-facing handle for a robot arm. Construct
+one via :meth:`Manipulator.from_urdf`, then call :meth:`.fk` and :meth:`.ik`
+for the common path. The dispatched solver auto-routes based on the arm's
+kinematic topology; users do not need to know which solver is firing.
+
+Example::
+
+    import ssik
+
+    arm = ssik.Manipulator.from_urdf(
+        "tests/fixtures/ur5.urdf", base="base_link", ee="ee_link"
+    )
+    T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    sols, is_ls = arm.ik(T)
+    # sols is a list[Solution]; is_ls=True signals no candidate FK-closed
+    # within tolerance.
+
+The class is intentionally tiny: factory + fk + ik + a handful of properties.
+Power users who need solver-specific knobs pass them via ``solver_kwargs``;
+power users who need the underlying :class:`KinBody` can reach :attr:`kinbody`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from ssik._kinbody import KinBody
+from ssik.core.dispatcher import DispatchPlan, dispatch
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+__all__ = ["Manipulator"]
+
+
+# Map dispatcher solver names (e.g. "ikgeo.three_parallel") to the dotted
+# module path under :mod:`ssik.solvers`. Centralised so the import-path
+# convention is stated once.
+_SOLVER_MODULE_PATHS: dict[str, str] = {
+    "ikgeo.three_parallel": "ssik.solvers.ikgeo.three_parallel",
+    "ikgeo.spherical_two_parallel": "ssik.solvers.ikgeo.spherical_two_parallel",
+    "ikgeo.spherical_two_intersecting": "ssik.solvers.ikgeo.spherical_two_intersecting",
+    "ikgeo.spherical": "ssik.solvers.ikgeo.spherical",
+    "ikgeo.two_parallel": "ssik.solvers.ikgeo.two_parallel",
+    "ikgeo.two_intersecting": "ssik.solvers.ikgeo.two_intersecting",
+    "ikgeo.general_6r": "ssik.solvers.ikgeo.general_6r",
+    "husty_pfurner.general_6r": "ssik.solvers.husty_pfurner.general_6r",
+    "seven_r.srs": "ssik.solvers.seven_r.srs",
+    "seven_r.srs_polished": "ssik.solvers.seven_r.srs_polished",
+    "jointlock.seven_r": "ssik.solvers.jointlock.seven_r",
+}
+
+
+class Manipulator:
+    """Public IK + FK handle for a robot arm.
+
+    Construct via the factory classmethods (e.g. :meth:`from_urdf`), then use
+    :meth:`fk` and :meth:`ik` for the common path. The dispatched analytical
+    solver auto-routes based on the arm's kinematic topology -- users do not
+    need to import or name a specific solver.
+
+    .. note::
+        The constructor signature ``Manipulator(kinbody)`` is the escape hatch
+        for callers who already have a :class:`KinBody` (e.g. from a custom
+        loader). Most users should use :meth:`from_urdf` instead.
+    """
+
+    __slots__ = ("_kb", "_plan", "_solver_module")
+
+    def __init__(
+        self,
+        kinbody: KinBody,
+        *,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> None:
+        """Wrap a pre-built :class:`KinBody`.
+
+        :param kinbody: a POE-normalised :class:`KinBody`. If you have a URDF,
+            use :meth:`from_urdf` instead -- it builds the KinBody for you.
+        :param policy: tolerance policy used by the topology dispatcher.
+            Defaults to :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+        """
+        self._kb: KinBody = kinbody
+        self._plan: DispatchPlan = dispatch(kinbody, policy=policy)
+        self._solver_module: ModuleType = importlib.import_module(
+            _SOLVER_MODULE_PATHS[self._plan.solver_name]
+        )
+
+    # ------------------------------------------------------------------
+    # Factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_urdf(
+        cls,
+        path: str | Path,
+        *,
+        base: str,
+        ee: str,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> Manipulator:
+        """Load a URDF and build a :class:`Manipulator` for the chain
+        between ``base`` and ``ee``.
+
+        The kinematic chain is POE-normalised internally so the dispatcher
+        can match the arm's topology against the solver roster. Mesh loading
+        is lazy (the URDF parser does not load STL files unless asked).
+
+        :param path: path to the URDF file.
+        :param base: name of the base link in the URDF.
+        :param ee: name of the end-effector link in the URDF.
+        :param policy: tolerance policy. Defaults to
+            :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+
+        :raises FileNotFoundError: if ``path`` doesn't exist.
+        :raises ValueError: if ``base`` or ``ee`` are not link names in the URDF.
+        :raises ImportError: if the optional dependency ``urchin`` is not
+            installed (``pip install ssik[urdf]``).
+        """
+        # Imported lazily so the urchin dependency is only required when
+        # from_urdf is actually called (it's an optional extra).
+        from ssik._urdf import load_urdf_kinbody_normalized
+
+        # urchin raises ValueError on missing files; rewrite to the more
+        # idiomatic FileNotFoundError for the public API contract.
+        path_obj = Path(path)
+        if not path_obj.exists():
+            raise FileNotFoundError(f"URDF file not found: {path_obj}")
+
+        kb = load_urdf_kinbody_normalized(path, base, ee)
+        return cls(kb, policy=policy)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def dof(self) -> int:
+        """Number of joints in the chain."""
+        return len(self._kb.joints)
+
+    @property
+    def joint_limits(self) -> list[tuple[float, float]]:
+        """Per-joint ``(lower, upper)`` limits.
+
+        Units are radians for revolute joints, metres for prismatic. Joints
+        without explicit limits in the source URDF default to ``(-pi, +pi)``.
+        """
+        return [j.limits for j in self._kb.joints]
+
+    @property
+    def dispatch_plan(self) -> DispatchPlan:
+        """Diagnostic info on which analytical solver was selected and why.
+
+        Useful for understanding why a given arm dispatches to a particular
+        solver (the ``reason`` field is a multi-line user-facing explanation).
+        """
+        return self._plan
+
+    @property
+    def kinbody(self) -> KinBody:
+        """The underlying POE-normalised :class:`KinBody`.
+
+        Power-user escape hatch for callers who need to invoke a specific
+        solver, run codegen, or interact with the kinematics primitives
+        directly. Most users should not need this.
+        """
+        return self._kb
+
+    @property
+    def solver_name(self) -> str:
+        """Dotted name of the dispatched solver, e.g. ``"ikgeo.three_parallel"``."""
+        return self._plan.solver_name
+
+    def __repr__(self) -> str:
+        return (
+            f"<Manipulator: {self.dof}-DOF, dispatched to "
+            f"{self._plan.solver_name} (tier {self._plan.tier})>"
+        )
+
+    # ------------------------------------------------------------------
+    # Forward kinematics
+    # ------------------------------------------------------------------
+
+    def fk(self, q: ArrayLike) -> NDArray[np.float64]:
+        """Forward kinematics: return the 4x4 SE(3) pose at config ``q``.
+
+        :param q: joint vector of length :attr:`dof`. Float-castable
+            (list, tuple, numpy array all work).
+
+        :returns: 4x4 numpy array. Top-left 3x3 is the end-effector
+            rotation matrix; column 3 (rows 0..2) is the position.
+
+        :raises ValueError: if ``len(q) != dof``.
+        """
+        q_arr = np.asarray(q, dtype=np.float64)
+        if q_arr.shape != (self.dof,):
+            raise ValueError(f"fk expected q of shape ({self.dof},), got {q_arr.shape}")
+        return poe_forward_kinematics(self._kb, q_arr)
+
+    # ------------------------------------------------------------------
+    # Inverse kinematics
+    # ------------------------------------------------------------------
+
+    def ik(
+        self,
+        T_target: ArrayLike,
+        *,
+        max_solutions: int | None = None,
+        q_seed: ArrayLike | None = None,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+        allow_refinement: bool = False,
+        refinement_max_iters: int = 15,
+        **solver_kwargs: Any,
+    ) -> tuple[list[Solution], bool]:
+        """Inverse kinematics: find ``q`` such that ``fk(q) ≈ T_target``.
+
+        :param T_target: 4x4 SE(3) target pose.
+        :param max_solutions: optional cap on returned IKs. ``None`` = full
+            redundancy enumeration. ``1`` is the trajectory-tracking
+            "give me any IK" mode (typically 10-15x faster than full sweep
+            on 7R arms). The cap is honored at every layer of the dispatch
+            stack -- the inner solvers stop branch enumeration as soon as
+            ``max_solutions`` deduplicated IKs are found.
+        :param q_seed: optional length-:attr:`dof` seed configuration. When
+            supported by the dispatched solver (currently
+            :mod:`ssik.solvers.jointlock.seven_r`), ``q_seed`` reorders the
+            internal lock-sample sweep so the closest-to-seed sample fires
+            first; combined with ``max_solutions=1`` this is the canonical
+            trajectory-tracking idiom. Solvers that don't accept ``q_seed``
+            silently ignore it.
+        :param policy: tolerance policy. Defaults to
+            :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+        :param allow_refinement: opt into Newton-on-spatial-Jacobian polish
+            for candidates that don't FK-close algebraically. Default off;
+            the analytical path is exact for well-conditioned poses.
+        :param refinement_max_iters: cap on Newton iterations per candidate
+            when ``allow_refinement=True``.
+        :param solver_kwargs: forwarded verbatim to the dispatched solver's
+            ``solve()`` for power users who need solver-specific knobs
+            (``swivel_samples`` for SRS-class, ``linearity_joint`` for RR,
+            etc.). Unknown kwargs raise :class:`TypeError` from the
+            underlying solver.
+
+        :returns: ``(solutions, is_ls)``. ``is_ls=True`` iff no candidate
+            FK-closed within ``policy.subproblem_numerical``; the returned
+            list is then either a single best-LS approximation or empty.
+
+        :raises ValueError: if ``T_target.shape != (4, 4)`` or
+            ``len(q_seed) != dof`` when ``q_seed`` is given.
+        """
+        T = np.asarray(T_target, dtype=np.float64)
+        if T.shape != (4, 4):
+            raise ValueError(f"ik expected T_target of shape (4, 4), got {T.shape}")
+        if q_seed is not None:
+            q_seed_arr: NDArray[np.float64] | None = np.asarray(q_seed, dtype=np.float64)
+            assert q_seed_arr is not None
+            if q_seed_arr.shape != (self.dof,):
+                raise ValueError(f"q_seed expected shape ({self.dof},), got {q_seed_arr.shape}")
+        else:
+            q_seed_arr = None
+
+        # Filter kwargs by the dispatched solver's signature so callers can
+        # pass q_seed (or any other not-universally-supported kwarg) without
+        # tripping TypeError on solvers that don't accept it. The dispatch
+        # is determined at __init__ time, so the signature lookup is per-IK
+        # but cheap (~5 us).
+        sig = inspect.signature(self._solver_module.solve)
+        params = sig.parameters
+        kwargs: dict[str, Any] = {"policy": policy}
+        if "allow_refinement" in params:
+            kwargs["allow_refinement"] = allow_refinement
+        if "refinement_max_iters" in params:
+            kwargs["refinement_max_iters"] = refinement_max_iters
+        if "max_solutions" in params:
+            kwargs["max_solutions"] = max_solutions
+        if q_seed_arr is not None and "q_seed" in params:
+            kwargs["q_seed"] = q_seed_arr
+        # Power-user kwargs override our defaults.
+        kwargs.update(solver_kwargs)
+
+        result: tuple[list[Solution], bool] = self._solver_module.solve(self._kb, T, **kwargs)
+        return result

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -1,0 +1,345 @@
+"""Bulletproof tests for the public :class:`ssik.Manipulator` API (#12, #227).
+
+Manipulator is the v1.0 entry point. These tests assert:
+
+- Factories work on every fixture (URDF + Python-spec).
+- ``fk`` and ``ik`` round-trip on hand-picked + random poses.
+- ``ik`` honors ``max_solutions``, ``q_seed``, ``allow_refinement``.
+- Error paths fire with clear messages.
+- The Manipulator's per-IK overhead is negligible (< 50 us vs the raw solver).
+- Repr/str are useful diagnostics.
+
+The tests cover the common path (``Manipulator.from_urdf`` then ``.fk`` / ``.ik``)
+on every fixture in ``tests/fixtures/``. Solver-specific bulletproof tests
+already exist (e.g. test_kinova_gen3.py); this file is the API contract.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import ssik
+from ssik._kinbody import build_kinbody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+FIXTURES = Path(__file__).parent / "fixtures"
+sys.path.insert(0, str(FIXTURES))
+
+# ---------------------------------------------------------------------------
+# URDF-based fixtures: full smoke matrix
+# ---------------------------------------------------------------------------
+
+
+_URDF_FIXTURES = [
+    # (filename, base_link, ee_link, expected_solver_name)
+    ("ur5.urdf", "base_link", "ee_link", "ikgeo.three_parallel"),
+    ("puma560.urdf", "base_link", "wrist_3_link", "ikgeo.spherical_two_parallel"),
+    ("gen3.urdf", "base_link", "end_effector_link", "seven_r.srs_polished"),
+    ("rizon4.urdf", "base_link", "flange", "jointlock.seven_r"),
+    ("kassow_kr810.urdf", "base", "end_effector", "jointlock.seven_r"),
+]
+
+
+@pytest.mark.parametrize(("urdf", "base", "ee", "expected_solver"), _URDF_FIXTURES)
+def test_from_urdf_dispatches_correctly(
+    urdf: str, base: str, ee: str, expected_solver: str
+) -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / urdf, base=base, ee=ee)
+    assert arm.solver_name == expected_solver
+    assert arm.dof in (6, 7)
+
+
+@pytest.mark.parametrize(("urdf", "base", "ee", "_solver"), _URDF_FIXTURES)
+def test_fk_then_ik_roundtrip(urdf: str, base: str, ee: str, _solver: str) -> None:
+    """Hand-picked q → fk → ik must return at least one IK that FK-closes."""
+    arm = ssik.Manipulator.from_urdf(FIXTURES / urdf, base=base, ee=ee)
+    rng = np.random.default_rng(0)
+    q_star = rng.uniform(-0.5, 0.5, size=arm.dof)
+    if arm.dof == 7:
+        # Avoid kinematic singularity for 7DOF arms (#225 follow-up; not the
+        # API contract under test).
+        q_star[3] = float(rng.uniform(0.3, 0.7))
+    T = arm.fk(q_star)
+    sols, is_ls = arm.ik(T)
+    assert not is_ls, f"{urdf}: ik returned is_ls=True on a reachable FK pose"
+    assert sols, f"{urdf}: ik returned no solutions"
+    # At least one solution FK-closes.
+    best = min(np.linalg.norm(arm.fk(s.q) - T) for s in sols)
+    assert best < 1e-6, f"{urdf}: best FK residual {best:.2e}"
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_dof_property() -> None:
+    arm6 = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    assert arm6.dof == 6
+    arm7 = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
+    assert arm7.dof == 7
+
+
+def test_joint_limits_shape() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    limits = arm.joint_limits
+    assert len(limits) == arm.dof
+    for lo, hi in limits:
+        assert lo < hi
+
+
+def test_dispatch_plan_has_useful_fields() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    plan = arm.dispatch_plan
+    assert plan.solver_name == "ikgeo.three_parallel"
+    assert plan.tier == 0
+    assert isinstance(plan.reason, str)
+    assert plan.reason
+    assert plan.expected_ms_median > 0
+
+
+def test_kinbody_property_exposes_internal() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    kb = arm.kinbody
+    assert isinstance(kb, ssik.KinBody)
+    assert len(kb.joints) == 6
+
+
+def test_repr_is_useful() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    r = repr(arm)
+    assert "Manipulator" in r
+    assert "6-DOF" in r
+    assert "ikgeo.three_parallel" in r
+
+
+# ---------------------------------------------------------------------------
+# fk
+# ---------------------------------------------------------------------------
+
+
+def test_fk_returns_4x4() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = arm.fk(np.zeros(6))
+    assert T.shape == (4, 4)
+    assert T.dtype == np.float64
+    # Bottom row is [0, 0, 0, 1].
+    assert np.allclose(T[3], [0, 0, 0, 1])
+
+
+def test_fk_matches_poe_forward_kinematics() -> None:
+    """``Manipulator.fk(q)`` must be bit-identical to the underlying primitive."""
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    rng = np.random.default_rng(42)
+    for _ in range(10):
+        q = rng.uniform(-1, 1, size=arm.dof)
+        T_manip = arm.fk(q)
+        T_raw = poe_forward_kinematics(arm.kinbody, q)
+        np.testing.assert_array_equal(T_manip, T_raw)
+
+
+def test_fk_accepts_list_and_tuple() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T_list = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    T_tuple = arm.fk((0.1, 0.2, 0.3, 0.4, 0.5, 0.6))
+    T_arr = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+    np.testing.assert_array_equal(T_list, T_arr)
+    np.testing.assert_array_equal(T_tuple, T_arr)
+
+
+def test_fk_rejects_wrong_shape() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    with pytest.raises(ValueError, match="fk expected q of shape"):
+        arm.fk(np.zeros(5))
+    with pytest.raises(ValueError, match="fk expected q of shape"):
+        arm.fk(np.zeros((6, 1)))
+
+
+# ---------------------------------------------------------------------------
+# ik
+# ---------------------------------------------------------------------------
+
+
+def test_ik_returns_solutions_and_is_ls() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+    sols, is_ls = arm.ik(T)
+    assert isinstance(sols, list)
+    assert isinstance(is_ls, bool)
+    assert all(isinstance(s, ssik.Solution) for s in sols)
+
+
+def test_ik_max_solutions_caps_returned() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+    sols_full, _ = arm.ik(T)
+    sols_capped, _ = arm.ik(T, max_solutions=2)
+    assert len(sols_full) > 2
+    assert len(sols_capped) <= 2
+    # FK closure preserved on the capped set.
+    for s in sols_capped:
+        assert s.fk_residual < 1e-6
+
+
+def test_ik_q_seed_passes_through_when_supported() -> None:
+    """``q_seed`` is accepted by jointlock.seven_r and used to reorder samples."""
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
+    rng = np.random.default_rng(0)
+    q = rng.uniform(-0.5, 0.5, size=7)
+    q[3] = 0.5
+    T = arm.fk(q)
+    # No q_seed: get solutions
+    sols_no_seed, _ = arm.ik(T, max_solutions=1)
+    # With q_seed: should also work, same solver path
+    sols_seeded, _ = arm.ik(T, max_solutions=1, q_seed=q)
+    assert len(sols_no_seed) == 1
+    assert len(sols_seeded) == 1
+
+
+def test_ik_q_seed_silently_ignored_when_unsupported() -> None:
+    """Solvers that don't accept ``q_seed`` (e.g. ikgeo.three_parallel) should
+    not raise -- the API filters kwargs by signature.
+    """
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+    # Should not raise even though ikgeo.three_parallel.solve has no q_seed param.
+    sols, _ = arm.ik(T, q_seed=np.zeros(6))
+    assert sols
+
+
+def test_ik_rejects_wrong_T_shape() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    with pytest.raises(ValueError, match="ik expected T_target"):
+        arm.ik(np.eye(3))
+    with pytest.raises(ValueError, match="ik expected T_target"):
+        arm.ik(np.zeros(16))
+
+
+def test_ik_rejects_wrong_q_seed_shape() -> None:
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
+    T = arm.fk(np.zeros(7))
+    with pytest.raises(ValueError, match="q_seed expected shape"):
+        arm.ik(T, q_seed=np.zeros(6))
+
+
+def test_ik_unreachable_target_returns_is_ls() -> None:
+    """A target way out of reach should set is_ls=True (no FK-closing IK)."""
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = np.eye(4)
+    T[:3, 3] = [100.0, 100.0, 100.0]  # 100 metres away
+    sols, is_ls = arm.ik(T)
+    assert is_ls
+    # Returned list may be empty or a single best-LS approx; both are valid.
+    assert len(sols) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Construction from a pre-built KinBody (escape hatch)
+# ---------------------------------------------------------------------------
+
+
+def test_construct_from_kinbody_directly() -> None:
+    """The public constructor accepts a KinBody for callers who already have one."""
+    from franka_panda import franka_panda_specs
+
+    kb = build_kinbody(franka_panda_specs())
+    arm = ssik.Manipulator(kb)
+    assert arm.dof == 7
+    assert arm.solver_name == "jointlock.seven_r"
+    # Same FK roundtrip contract.
+    rng = np.random.default_rng(0)
+    q = rng.uniform(-0.5, 0.5, size=7)
+    q[3] = 0.5
+    T = arm.fk(q)
+    sols, is_ls = arm.ik(T, max_solutions=1)
+    assert not is_ls
+    assert sols
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+def test_from_urdf_raises_on_missing_file(tmp_path: Path) -> None:
+    bad_path = tmp_path / "nonexistent.urdf"
+    with pytest.raises(FileNotFoundError):
+        ssik.Manipulator.from_urdf(bad_path, base="base", ee="ee")
+
+
+def test_from_urdf_raises_on_bad_link_name() -> None:
+    with pytest.raises(ValueError, match=r"this_link_does_not_exist|not found|no link"):
+        ssik.Manipulator.from_urdf(
+            FIXTURES / "ur5.urdf", base="this_link_does_not_exist", ee="ee_link"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public exports surface
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_exports_present() -> None:
+    """Every type a user needs is reachable from the top-level ``ssik`` namespace."""
+    expected = [
+        "Manipulator",
+        "Solution",
+        "KinBody",
+        "Joint",
+        "Link",
+        "JointSpec",
+        "build_kinbody",
+        "TolerancePolicy",
+        "DEFAULT_TOLERANCE_POLICY",
+        "DispatchPlan",
+        "TopologyReport",
+        "describe_topology",
+        "dispatch",
+        "__version__",
+    ]
+    for name in expected:
+        assert hasattr(ssik, name), f"ssik.{name} missing"
+    assert set(ssik.__all__) >= set(expected) - {"__version__"}
+
+
+# ---------------------------------------------------------------------------
+# Performance: Manipulator overhead must be small
+# ---------------------------------------------------------------------------
+
+
+def test_ik_overhead_under_100us() -> None:
+    """Manipulator.ik() should add < 100 us overhead vs the raw solver call.
+    The wrapper does signature inspection + kwarg filtering -- cheap, but
+    catch regressions where someone adds a per-call sympy import or similar.
+    """
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+
+    # Warm
+    for _ in range(20):
+        arm.ik(T)
+
+    # Manipulator path
+    t = time.perf_counter()
+    for _ in range(200):
+        arm.ik(T)
+    manip_per = (time.perf_counter() - t) / 200
+
+    # Raw solver path
+    from ssik.solvers.ikgeo import three_parallel
+
+    t = time.perf_counter()
+    for _ in range(200):
+        three_parallel.solve(arm.kinbody, T)
+    raw_per = (time.perf_counter() - t) / 200
+
+    overhead = (manip_per - raw_per) * 1e6
+    assert overhead < 100.0, (
+        f"Manipulator.ik overhead {overhead:.1f} us > 100 us regression gate "
+        f"(manip={manip_per * 1e6:.1f} us, raw={raw_per * 1e6:.1f} us)"
+    )


### PR DESCRIPTION
## Summary

The headline v1.0 API change (Phase 1 of #226). Users now do:

\`\`\`python
import ssik

arm = ssik.Manipulator.from_urdf(\"arm.urdf\", base=\"base_link\", ee=\"ee_link\")
T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
sols, is_ls = arm.ik(T)

# Trajectory tracking — typically 10-15× faster on 7R arms:
sols, is_ls = arm.ik(T, max_solutions=1, q_seed=q_prev)
\`\`\`

**Single import. One class.** The dispatched analytical solver auto-routes based on the arm's kinematic topology. Power users still have direct access to specific solvers (\`ssik.solvers.ikgeo.three_parallel\` etc.) but no longer need to navigate that graph for the common path.

## API surface

| Member | Purpose |
|---|---|
| \`Manipulator.from_urdf(path, *, base, ee, policy=...)\` | URDF factory (the headline) |
| \`Manipulator(kinbody)\` | escape hatch for callers with a pre-built KinBody |
| \`arm.fk(q) -> (4, 4) ndarray\` | forward kinematics |
| \`arm.ik(T, *, max_solutions, q_seed, policy, allow_refinement, refinement_max_iters, **solver_kwargs)\` | inverse kinematics |
| \`arm.dof\`, \`arm.joint_limits\`, \`arm.dispatch_plan\`, \`arm.kinbody\`, \`arm.solver_name\` | introspection |
| \`__repr__\` | \`<Manipulator: 6-DOF, dispatched to ikgeo.three_parallel (tier 0)>\` |

\`.ik()\` uses \`inspect.signature\` to filter kwargs by the dispatched solver's signature, so \`q_seed\` is silently ignored on solvers that don't accept it (only \`jointlock.seven_r\` currently). Power users pass solver-specific knobs via \`**solver_kwargs\`. Per-IK overhead measured at < 100 µs.

## Public exports

Added to \`ssik/__init__.py\`'s \`__all__\`: **\`Manipulator\`**, \`Solution\`, \`KinBody\`, \`Joint\`, \`Link\`, \`JointSpec\`, \`build_kinbody\`. Existing exports preserved (\`DispatchPlan\`, \`dispatch\`, \`TolerancePolicy\`, \`DEFAULT_TOLERANCE_POLICY\`, \`TopologyReport\`, \`describe_topology\`, \`__version__\`).

## Why no file renames

Internal modules (\`_kinbody\`, \`_urdf\`, \`_pencil\`) stay underscored at the file level. **Re-exporting from the top-level namespace** gives users a clean public API without forcing a file-rename ripple through the 250+ test imports of \`ssik._kinbody\` / \`ssik._urdf\`. Test migration to use \`ssik.*\` exports is a smaller follow-up cleanup if/when wanted.

This was a deliberate design call: the underscored modules are still where the implementation lives, but the user-facing namespace is now \`ssik.X\` for every public type. The leading underscore on the module path tells anyone tempted to import the internal module \"this is implementation detail; use \`ssik.X\` instead.\"

## Test plan

- [x] **31 new tests** in [test_manipulator.py](tests/test_manipulator.py) covering:
  - Factory works on every URDF fixture (UR5, Puma 560, Gen3, Rizon 4, Kassow KR810).
  - Dispatch picks the correct solver per fixture.
  - \`fk\` returns a 4×4 matrix; matches \`poe_forward_kinematics\` bit-for-bit.
  - \`ik\` honors \`max_solutions\`; \`q_seed\` passes through where supported, silently ignored where not.
  - Error paths: bad path, bad link names, wrong q/T shapes, wrong q_seed shape.
  - Out-of-reach target returns \`is_ls=True\`.
  - \`repr\` is informative.
  - Public top-level exports all present.
  - Per-IK overhead < 100 µs vs raw solver call.
- [x] **Full suite: 1284 passed** (+31 net), 1 skipped, 30 deselected (pre-existing flake), 7 xfailed, 4 xpassed.
- [x] Lint clean.

## README

New \`## Quickstart\` section showing the v1.0 API. Existing solver-matrix table and per-arm coverage tables preserved unchanged.

## What's next for v1.0

Per #226 umbrella:

- **Phase 2** (#14): docs + worked examples (UR5, JACO 2, Gen3) + mkdocs site.
- **Phase 3** (#228): BSD-3-Clause license switch.
- **Phase 3** (#132): TestPyPI v0.1.0a1 → PyPI v1.0.

Closes #12 and #227.