### PR TITLE
BSD-3-Clause license + URL migration to personalrobotics/ssik (closes #228)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ ssik/
 ## Dev setup
 
 ```bash
-git clone https://github.com/siddhss5/ikfastpy.git
-cd ikfastpy
+git clone https://github.com/personalrobotics/ssik.git
+cd ssik
 uv sync                                 # install dev deps
 uv run python scripts/build_cython.py   # one-time: build .so files for hot loops
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,34 +1,29 @@
-Copyright (c) 2026 Siddhartha Srinivasa.
+BSD 3-Clause License
 
-All rights reserved. This software and its documentation are proprietary
-and confidential. No part of this work may be reproduced, distributed, or
-transmitted in any form or by any means, including photocopying, recording,
-or other electronic or mechanical methods, without prior written permission
-from the copyright holder, except in the case of brief quotations embodied
-in critical reviews and certain other non-commercial uses permitted by
-copyright law.
+Copyright (c) 2026, Siddhartha Srinivasa
+All rights reserved.
 
-For licensing inquiries, contact the copyright holder.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-================================================================================
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-Third-party components
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-This project incorporates the algorithms (clean-room reimplemented from the
-academic literature) of:
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-* IK-Geo (Elias & Wen, 2022/2025; arXiv:2211.05737), originally distributed
-  under the BSD 3-Clause license. The subproblem catalog (SP1-SP6) and the
-  per-family compositions in `ssik.subproblems` and `ssik.solvers.ikgeo`
-  derive from that work. BSD-3 attribution: Copyright (c) the IK-Geo
-  authors; see https://github.com/rpiRobotics/ik-geo for the upstream
-  source. ssik's reimplementation is independent code; the BSD-3 attribution
-  is preserved in good faith for the algorithmic lineage.
-
-* The Raghavan-Roth (1990) and Manocha-Canny (1994) inverse-kinematics
-  algorithms are reimplemented from the original academic publications.
-  Algorithms are not copyrightable; ssik's implementation is original code.
-
-Runtime dependencies (numpy, sympy, scipy when available, urchin via the
-`[urdf]` extra) are distributed under their own permissive licenses; refer
-to each package's LICENSE for terms.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The generated test scaffold checks dispatcher routing and FK closure on hand-pic
 @software{ssik,
   author = {Srinivasa, Siddhartha},
   title  = {ssik: analytical inverse kinematics for 6R and 7R revolute arms},
-  url    = {https://github.com/siddhss5/ikfastpy},
+  url    = {https://github.com/personalrobotics/ssik},
   year   = {2026},
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,12 +7,12 @@ ssik dispatches to one of 11 analytical solvers based on the arm's kinematic top
 | Tier | Solver modules | Typical IK time | Algorithm |
 |---|---|---|---|
 | 0 — closed-form 6R | `three_parallel`, `spherical_two_parallel`, `spherical_two_intersecting`, `spherical` | ~1 ms | SP1–SP6 composition; one branch per Pieper specialisation |
-| 0 — closed-form 7R (SRS) | `seven_r.srs` | ~4.3 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs (vectorised inner loop, [#217](https://github.com/siddhss5/ikfastpy/issues/217)) |
+| 0 — closed-form 7R (SRS) | `seven_r.srs` | ~4.3 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs (vectorised inner loop, [#217](https://github.com/personalrobotics/ssik/issues/217)) |
 | 0 — approximate SRS + LM polish | `seven_r.srs_polished` | ~56 ms full sweep | Relaxed Singh-Kreutz (small-drift arms) + batched LM polish to machine precision against the original URDF FK |
 | 1 — univariate search | `two_parallel`, `two_intersecting` | ~100 ms – 2 s | tan-half-angle reduction + 200-sample search + Newton polish |
-| 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms tier-0 inner; **~17 ms with cached-RR ([#210](https://github.com/siddhss5/ikfastpy/issues/210))** when artifact-built | lock one joint, dispatch inner 6R, sweep 16 lock samples; Raghavan-Roth pre-baked at codegen for non-Pieper sub-chains |
+| 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms tier-0 inner; **~17 ms with cached-RR ([#210](https://github.com/personalrobotics/ssik/issues/210))** when artifact-built | lock one joint, dispatch inner 6R, sweep 16 lock samples; Raghavan-Roth pre-baked at codegen for non-Pieper sub-chains |
 | 2 — Raghavan–Roth + Manocha–Canny | `ikgeo.general_6r` | ~0.6-5 ms | numeric RR resultant with AE-3 leftvar selection; **production tier-2** |
-| 2 — Husty-Pfurner universal fallback | `husty_pfurner.general_6r` | ~25-200 ms | Study-quaternion algebra; perturbation path ([#176](https://github.com/siddhss5/ikfastpy/issues/176)) handles symmetric-DH singularities; backstops RR on ill-conditioned arms |
+| 2 — Husty-Pfurner universal fallback | `husty_pfurner.general_6r` | ~25-200 ms | Study-quaternion algebra; perturbation path ([#176](https://github.com/personalrobotics/ssik/issues/176)) handles symmetric-DH singularities; backstops RR on ill-conditioned arms |
 
 ## Dispatch flow
 
@@ -47,7 +47,7 @@ ssik's solver code is clean-room from published math. Algorithmic credits (alrea
 
 - **IK-Geo** (Elias-Wen 2022, [arXiv:2211.05737](https://arxiv.org/abs/2211.05737)) — BSD-3 Rust reference. Source for the SP1-SP6 subproblem family and the spherical-class composition (`spherical_two_parallel`, `spherical_two_intersecting`, `three_parallel`, `spherical`).
 - **Raghavan–Roth 1990** + **Manocha–Canny 1994** — non-Pieper 6R via 24×24 companion matrix eigendecomposition. Foundation of `ikgeo.general_6r`.
-- **AE-3 leftvar selection** (ssik-original; [#70](https://github.com/siddhss5/ikfastpy/issues/70)) — pick the spectral parameter that puts pathological joints out of the linearity variable. Drops cond(m_quad) from 3.75e16 → 127 on JACO 2 (14 orders of magnitude).
+- **AE-3 leftvar selection** (ssik-original; [#70](https://github.com/personalrobotics/ssik/issues/70)) — pick the spectral parameter that puts pathological joints out of the linearity variable. Drops cond(m_quad) from 3.75e16 → 127 on JACO 2 (14 orders of magnitude).
 - **Singh–Kreutz 1989** — closed-form 7R for SRS-class arms. Foundation of `seven_r.srs`.
 - **Husty–Pfurner 2007** + **Capco-Manongsong** giac code (Zenodo 3157441, MIT) — universal 6R fallback via Study-quaternion algebra. Foundation of `husty_pfurner.general_6r`.
 

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -25,7 +25,7 @@ The arms ssik exists for: deliberate non-orthogonal twists that violate Pieper's
 |-----|--------|:-----:|:-----:|
 | **Kinova JACO 2 (j2n6s200, 55° DH)** | `ikgeo.general_6r` (RR + AE-3) | **~5 ms median** | ✅ real MJCF in [`tests/fixtures/`](../tests/fixtures/) |
 | Agilex Piper | `ikgeo.general_6r` | expected ~5 ms | 🔗 [mujoco_menagerie/agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper) |
-| Custom non-Pieper 6R | `ikgeo.general_6r` | expected ~5 ms | URDF intake via [#95](https://github.com/siddhss5/ikfastpy/issues/95) |
+| Custom non-Pieper 6R | `ikgeo.general_6r` | expected ~5 ms | URDF intake via [#95](https://github.com/personalrobotics/ssik/issues/95) |
 
 ## 7R redundant — pure SRS (`seven_r.srs`)
 
@@ -46,7 +46,7 @@ Refused (drift exceeds Newton's basin, ~3-5 cm): falls back to `jointlock + HP`.
 
 For 7R arms whose topology doesn't match strict or approximate SRS, `jointlock.seven_r` is the universal fallback: locks one joint (auto-selected by topology rank of the resulting 6R sub-chain) and dispatches the 6R IK to the best-matching tier-0/1 ikgeo solver. 16-sample lock sweep × inner 6R solver per call.
 
-**Cached-RR fast path** ([#210](https://github.com/siddhss5/ikfastpy/issues/210)): when an arm hits the universal fallback for non-Pieper sub-chains, `ssik build` bakes the per-(DH, linearity) Raghavan-Roth derivation into the artifact. Module import primes the cache once (~5 seconds via #210 Phase 2 / #220); every subsequent `solve(T)` call uses cached RR (~1 ms warm) instead of HP / two_parallel (~13-260 ms). **12-25× speedup post-import** on Rizon 4, Kassow, and other previously-slow non-Pieper 7R arms. The URDF-loaded path (no artifact) keeps the original solver — no cold-cache cost in tests.
+**Cached-RR fast path** ([#210](https://github.com/personalrobotics/ssik/issues/210)): when an arm hits the universal fallback for non-Pieper sub-chains, `ssik build` bakes the per-(DH, linearity) Raghavan-Roth derivation into the artifact. Module import primes the cache once (~5 seconds via #210 Phase 2 / #220); every subsequent `solve(T)` call uses cached RR (~1 ms warm) instead of HP / two_parallel (~13-260 ms). **12-25× speedup post-import** on Rizon 4, Kassow, and other previously-slow non-Pieper 7R arms. The URDF-loaded path (no artifact) keeps the original solver — no cold-cache cost in tests.
 
 Covers Franka Panda (anthropomorphic 7R), uFactory xArm7 (mixed structure), and the literature-SRS-but-URDF-far-from-SRS arms whose drift exceeds the polished-SRS basin (Flexiv Rizon 4: 151 mm wrist drift; Kassow KR810: 111 mm wrist drift).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ssik"
-description = "Analytical inverse kinematics for non-Pieper 6R arms."
+description = "Analytical inverse kinematics for 6R and 7R revolute arms. Returns every IK branch at machine precision."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [{ name = "Siddhartha Srinivasa" }]
 keywords = ["robotics", "inverse-kinematics", "ik-geo", "kinematics"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -44,8 +44,8 @@ urdf = [
 ]
 
 [project.urls]
-Repository = "https://github.com/siddhss5/ikfastpy"
-Issues = "https://github.com/siddhss5/ikfastpy/issues"
+Repository = "https://github.com/personalrobotics/ssik"
+Issues = "https://github.com/personalrobotics/ssik/issues"
 
 [project.scripts]
 ssik = "ssik.cli:main"

--- a/tests/test_husty_pfurner_oracles.py
+++ b/tests/test_husty_pfurner_oracles.py
@@ -55,7 +55,7 @@ from ssik.solvers.husty_pfurner.general_6r import solve as hp_solve
 
 XFAIL_REASON = (
     "Husty-Pfurner solver not yet implemented; tracked in "
-    "https://github.com/siddhss5/ikfastpy/issues/162"
+    "https://github.com/personalrobotics/ssik/issues/162"
 )
 XFAIL = pytest.mark.xfail(strict=True, reason=XFAIL_REASON, raises=NotImplementedError)
 


### PR DESCRIPTION
## Summary

Phase 3 of #226 (v1.0 readiness). Two coupled changes:

1. **License switch**: proprietary → **BSD-3-Clause** with copyright \`Siddhartha Srinivasa\`.
2. **URL migration**: \`siddhss5/ikfastpy\` → \`personalrobotics/ssik\` everywhere it's referenced as a full URL.

The GitHub repo move itself is a UI action by the owner; this PR brings the in-repo references in line with the post-move state.

## License changes

| File | Change |
|---|---|
| \`LICENSE\` | Replace proprietary text with canonical [SPDX BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html). Copyright: \`Siddhartha Srinivasa\` (no UW / PRL mention per user preference). |
| \`pyproject.toml\` | PEP 639 SPDX form: \`license = \"BSD-3-Clause\"\`, \`license-files = [\"LICENSE\"]\`. Drop legacy \`License :: Other/Proprietary License\` classifier. Bump \`Development Status\` from \`2 - Pre-Alpha\` to \`4 - Beta\`. Updated description. |

Verified via \`uv build\`: the wheel's METADATA correctly emits \`License-Expression: BSD-3-Clause\` + \`License-File: LICENSE\` (PEP 639 hatchling 1.27+ recognises the format).

## URL migration

| File | What changed |
|---|---|
| \`pyproject.toml\` | \`[project.urls]\` Repository + Issues → \`personalrobotics/ssik\` |
| \`README.md\` | BibTeX citation \`url\` |
| \`CONTRIBUTING.md\` | Clone instructions (\`git clone … && cd ssik\`) |
| \`docs/architecture.md\` | Issue links (#217, #210, #176, #70) |
| \`docs/arm_coverage.md\` | Issue links (#95, #210) |
| \`tests/test_husty_pfurner_oracles.py\` | Issue link in docstring (#162) |

The \`#N\`-style issue references in source comments and docstrings (e.g., \`# See #74\`, \`# Per #210 Phase 1\`) are NOT touched. GitHub preserves issue numbers across repo transfers, and \`#N\` references resolve to the current repo automatically — they keep working post-move without any edits.

## Test plan

- [x] \`uv build\` succeeds; wheel METADATA correctly populated:
  ```
  License-Expression: BSD-3-Clause
  License-File: LICENSE
  Project-URL: Repository, https://github.com/personalrobotics/ssik
  Project-URL: Issues, https://github.com/personalrobotics/ssik/issues
  Classifier: Development Status :: 4 - Beta
  ```
- [x] \`grep -r 'siddhss5/ikfastpy' --include='*.md' --include='*.py' --include='*.toml'\` returns 0 hits.
- [x] \`grep -r 'ikfastpy' --include='*.md' --include='*.py' --include='*.toml'\` returns 0 hits.
- [x] **Suite: 1284 passed** unchanged.
- [x] Lint clean.

## Note on the GitHub repo move

The user is moving \`siddhss5/ikfastpy\` → \`personalrobotics/ssik\` separately via the GitHub UI. After this PR merges and the move happens:

- Existing clones with origin pointing at \`siddhss5/ikfastpy\` continue working (GitHub redirects).
- Recommended: contributors run \`git remote set-url origin git@github.com:personalrobotics/ssik.git\` to point at the new canonical URL.
- Open PRs and issues transfer automatically; numbers preserved.

The order is: merge this PR → move repo → publish to PyPI (#132). Doing it in this order means the wheel's metadata is already correct when published.

Closes #228.