### PR TITLE
API v1.0: drop is_ls, unify artifact surface, robotics-safe defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import franka_panda_ik           # prebuilt; see prebuilt/ for 8 ready-to-use ar
 import numpy as np
 
 T_target = np.eye(4); T_target[:3, 3] = [0.5, 0.1, 0.3]
-sols, is_ls = franka_panda_ik.solve(T_target)            # all 64 IK branches
+sols = franka_panda_ik.solve(T_target)                   # all IK branches; empty list = unreachable
 ```
 
 ### Trajectory tracking / IK-based teleop
@@ -29,21 +29,11 @@ T_target = ...
 # sweep starting from the lock-sample closest to q_current and short-
 # circuits as soon as it finds an FK-closed branch. ~10-15x faster
 # than the full sweep on 7R arms.
-sols, is_ls = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
-q_command = sols[0].q if not is_ls else q_current        # fall back if unreachable
+sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
+q_command = sols[0].q if sols else q_current             # empty list = unreachable
 ```
 
-Native `q_seed` / `max_solutions` short-circuit support ships in the jointlock-7R artifacts (Franka, Rizon 4, Kassow KR810). For any other arm, the same pattern via the cross-arm `ssik.postprocess` helpers:
-
-```python
-import ur5_ik
-from ssik.postprocess import nearest_to_seed, max_solutions
-
-sols, _ = ur5_ik.solve(T_target)
-sols = nearest_to_seed(sols, q_current)
-sols = max_solutions(sols, k=1)
-q_command = sols[0].q
-```
+The same kwarg shape works on every prebuilt artifact (UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka, Rizon 4, Kassow). On 7R jointlock arms (Franka / Rizon / Kassow), `q_seed` + `max_solutions=1` short-circuits the internal lock-sweep for a ~10-15× speedup; on other arms the same kwargs are applied as a postprocess pass. By default `solve()` also runs `respect_limits=True` so out-of-URDF-limit branches are dropped (with a `q ± 2π` rescue pass first) — pass `respect_limits=False` for the raw geometric set.
 
 ## Returns all solutions, not one
 
@@ -93,7 +83,7 @@ Cython hot loops cover the leaf primitives (Rodrigues rotations, POE forward kin
 
 ## Bulletproof discipline
 
-Every solver lands with: N-way cross-solver agreement on shared fixtures, FK closure ≤ 1e-10 on every retained IK, 500+ Hypothesis-fuzzed random poses per fixture, and an explicit speed bench that has to clear a regression gate. The current suite has **1284 tests across 11 fixture arms**. Negative-result spikes (a Cython estimate that misses by 2-5×, a codegen-bake on a part that's 0.3% of runtime) are published as closed issues with profile data so the next contributor doesn't repeat the path.
+Every solver lands with: N-way cross-solver agreement on shared fixtures, FK closure ≤ 1e-10 on every retained IK, 500+ Hypothesis-fuzzed random poses per fixture, and an explicit speed bench that has to clear a regression gate. The current suite has **1300+ tests across 11 fixture arms**. Negative-result spikes (a Cython estimate that misses by 2-5×, a codegen-bake on a part that's 0.3% of runtime) are published as closed issues with profile data so the next contributor doesn't repeat the path.
 
 ## Install
 
@@ -104,28 +94,18 @@ pip install ssik[urdf]        # adds urchin + sympy for `ssik build` and the dev
 
 Python 3.11+. Wheels for Linux x86_64 and macOS arm64.
 
-## Onboarding a new arm
-
-```bash
-ssik add-arm my_arm.urdf --base base_link --ee flange --name my_arm
-# → tests/fixtures/my_arm.urdf and tests/test_my_arm.py with FK-closure assertions
-uv run pytest tests/test_my_arm.py -v
-```
-
-The generated test scaffold checks dispatcher routing and FK closure on hand-picked + Hypothesis-fuzzed reachable poses. Catches regressions before they land.
-
 ## Development & exploration: `Manipulator.from_urdf`
 
-For one-off experiments, fuzzing during solver development, or running tests across many arms, the runtime classifier is also exposed as a Python class. It parses a URDF, dispatches a solver at construction time, and exposes the same `ik()` / `fk()` API. Every fresh process re-runs URDF parsing, topology classification, and (for non-Pieper sub-chains) first-call sympy preprocessing — so it is strictly slower than the build-artifact path in production and requires `urchin` + `sympy` on the runtime path. Useful for "what would the solver do here?" iteration without committing to a build:
+For one-off experiments or fuzzing during solver development, the runtime classifier is also exposed as a Python class. It parses a URDF, dispatches a solver at construction time, and exposes the same `solve()` / `fk()` API as the artifact. Every fresh process re-runs URDF parsing, topology classification, and (for non-Pieper sub-chains) first-call sympy preprocessing — so it is strictly slower than the build-artifact path in production and requires `urchin` + `sympy` on the runtime path:
 
 ```python
 import ssik
 
 arm = ssik.Manipulator.from_urdf("my_arm.urdf", base="base_link", ee="tool0")
-sols, is_ls = arm.ik(T_target, max_solutions=1, q_seed=q_current)
+sols = arm.solve(T_target, max_solutions=1, q_seed=q_current)
 ```
 
-Once the dispatch is settled, switch to `ssik build my_arm.urdf` and import the artifact.
+Once the dispatch is settled, switch to `ssik build my_arm.urdf` and import the artifact. Contributors extending ssik's test suite (vs deploying for their own arm) use `ssik add-arm`; see [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-arm-fixture).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ T_target = ...
 
 # max_solutions=1 + q_seed: solver searches the 1-parameter redundancy
 # sweep starting from the lock-sample closest to q_current and short-
-# circuits as soon as it finds an FK-closed branch. ~10-15x faster
-# than the full sweep on 7R arms.
+# circuits on the first valid in-limits branch (~5-6x faster than
+# the full sweep on 7R jointlock arms; sub-ms on 6R / SRS arms).
 sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
 q_command = sols[0].q if sols else q_current             # empty list = unreachable
 ```
 
-The same kwarg shape works on every prebuilt artifact (UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka, Rizon 4, Kassow). On 7R jointlock arms (Franka / Rizon / Kassow), `q_seed` + `max_solutions=1` short-circuits the internal lock-sweep for a ~10-15× speedup; on other arms the same kwargs are applied as a postprocess pass. By default `solve()` also runs `respect_limits=True` so out-of-URDF-limit branches are dropped (with a `q ± 2π` rescue pass first) — pass `respect_limits=False` for the raw geometric set.
+The same kwarg shape works on every prebuilt artifact (UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka, Rizon 4, Kassow). By default `solve()` runs **`respect_limits=True`**: out-of-URDF-limit branches are dropped (with a `q ± 2π` rescue pass first). On 7R jointlock arms (Franka / Rizon / Kassow) the limits filter runs *during* the lock-sweep so `max_solutions=1` short-circuits on the first in-limits candidate rather than wasting samples on branches the postprocess would discard. Pass `respect_limits=False` for the raw geometric set when you want to filter yourself.
 
 ## Returns all solutions, not one
 
-A single 6-DOF target pose admits up to **16 analytical IK branches** (8 typical for a Pieper-class arm: 4 shoulder × 2 elbow, with the wrist deterministic). For a 7R redundant arm the IK is a 1-parameter family; ssik discretises it into 32–256 branches per pose depending on the swivel-sample count. Every returned `Solution` carries `q`, the per-IK FK residual, and which solver branch produced it.
+A single 6-DOF target pose admits up to **16 analytical IK branches** (8 typical for a Pieper-class arm: 4 shoulder × 2 elbow, with the wrist deterministic). For a 7R redundant arm the IK is a 1-parameter family; ssik discretises it into 32–256 branches per pose depending on the swivel-sample count. Every returned `Solution` carries `q`, the per-IK FK residual, and whether the Newton polish path fired (`refinement_used`).
 
 Numerical IK libraries take a seed, run damped least-squares to a single converged configuration, and stop. Branch enumeration matters for motion planning (try every branch, pick the one with best clearance), for dexterity analysis (the manipulability ellipsoid is per-branch), and for trajectory continuation across kinematic singularities.
 
@@ -47,18 +47,18 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 549 ± 14 µs / FK 2e-9 / 4 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 6 ± 0 µs / FK 3e-14 / 8 sols | 233 ± 5 µs / FK 2e-14 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.04 ± 0.04 ms / FK 5e-6 / 8 sols |
-| iiwa14 (SRS 7R) | **refuses** ("only 1-6R robots are solvable") | 4.57 ± 0.03 ms / FK 4e-13 / 128 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.48 ± 1.18 ms / FK 1e-12 / 47 sols |
-| Franka Panda (anthropomorphic 7R) | **refuses** ("only 1-6R") | 28.42 ± 2.65 ms / FK 1e-6 / 64 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 33.18 ± 8.58 ms / FK 4e-9 / 42 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 27.03 ± 10.40 ms / FK 7e-8 / 24 sols |
+| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 556 ± 12 µs / FK 2e-9 / 4 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 1 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 2 sols |
+| iiwa14 (SRS 7R) | **refuses** ("only 1-6R robots are solvable") | 6.56 ± 0.49 ms / FK 4e-13 / 96 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 69.37 ± 4.32 ms / FK 1e-12 / 47 sols |
+| Franka Panda (anthropomorphic 7R) | **refuses** ("only 1-6R") | 28.03 ± 2.57 ms / FK 7e-13 / 9 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.88 ± 8.80 ms / FK 4e-9 / 35 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 28.06 ± 10.63 ms / FK 7e-8 / 24 sols |
 
 EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings are EAIK's actual error messages, captured verbatim by the bench harness. A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
 
-ssik FK residuals above are the algebraic candidates returned by `solve()` with default tolerance policy. Passing `allow_refinement=True` runs an opt-in Levenberg–Marquardt polish per candidate and tightens the residual to machine precision (~1e-14) at a few hundred microseconds per branch.
+ssik FK residuals above are the algebraic candidates returned by `solve()` with default tolerance policy and `respect_limits=True`. Branch counts on 7R arms (iiwa14: 96, Franka: 9, Rizon: 35) reflect URDF-joint-limit filtering; pass `respect_limits=False` to get the full geometric set. The `allow_refinement=True` opt-in runs Levenberg–Marquardt polish per algebraic candidate at a few hundred microseconds per branch — useful when an algebraic candidate lands just above `fk_atol` near a kinematic singularity; it does not always reach machine precision on tier-2 RR arms whose polish basin is narrow.
 
 The algorithmic ingredients are not novel — Raghavan–Roth (1990), Manocha–Canny (1994), Singh–Kreutz (1989), Husty–Pfurner (2007). What's new is making the textbook pipelines survive on real ill-conditioned arms (AE-3 leftvar selection on JACO 2 drops `cond(m_quad)` from 3.75 × 10^16 to 127), composing them with a uniform dispatch layer, and packaging the whole thing as a deployable artifact.
 

--- a/examples/01_ur5_quickstart.py
+++ b/examples/01_ur5_quickstart.py
@@ -9,7 +9,7 @@ This script demonstrates:
 
 1. Loading via ``Manipulator.from_urdf``.
 2. Forward kinematics (``arm.fk``).
-3. Inverse kinematics, full enumeration (``arm.ik``).
+3. Inverse kinematics, full enumeration (``arm.solve``).
 4. Trajectory-tracking with ``max_solutions=1`` and ``q_seed``.
 5. Inspecting the dispatch plan.
 
@@ -55,10 +55,9 @@ def main() -> None:
     # 3. Inverse kinematics — full redundancy enumeration.
     # ---------------------------------------------------------------------
     t = time.perf_counter()
-    sols, is_ls = arm.ik(T)
+    sols = arm.solve(T)
     elapsed_ms = (time.perf_counter() - t) * 1000
     print(f"IK (full enumeration): {len(sols)} solutions in {elapsed_ms:.2f} ms")
-    print(f"  is_ls:      {is_ls}")
     print(f"  max FK residual: {max(s.fk_residual for s in sols):.2e}")
     print("  branches:")
     for i, s in enumerate(sols):
@@ -70,7 +69,7 @@ def main() -> None:
     # ---------------------------------------------------------------------
     q_prev = q_star + 0.05 * np.random.default_rng(42).standard_normal(6)
     t = time.perf_counter()
-    sols, _ = arm.ik(T, max_solutions=1, q_seed=q_prev)
+    sols = arm.solve(T, max_solutions=1, q_seed=q_prev)
     elapsed_ms = (time.perf_counter() - t) * 1000
     print(f"IK (trajectory tracking, max_solutions=1): {elapsed_ms:.2f} ms")
     print(f"  q_prev:     {[round(x, 3) for x in q_prev]}")

--- a/examples/02_jaco2_non_pieper.py
+++ b/examples/02_jaco2_non_pieper.py
@@ -58,9 +58,9 @@ def main() -> None:
     # Hand-picked pose from the issue tracker.
     q_star = np.array([0.4, -0.6, 0.8, 1.0, -0.4, 0.3])
     T = arm.fk(q_star)
-    sols, is_ls = arm.ik(T)
+    sols = arm.solve(T)
     print(f"Hand-picked q*={q_star.tolist()}:")
-    print(f"  IK returned {len(sols)} branches, is_ls={is_ls}")
+    print(f"  IK returned {len(sols)} branches")
     print(f"  max FK residual: {max(s.fk_residual for s in sols):.2e}")
     print(
         f"  q* recovered (any branch within 1e-6): "
@@ -75,15 +75,15 @@ def main() -> None:
     # Warm up.
     for _ in range(10):
         q = rng.uniform(-1, 1, size=6)
-        arm.ik(arm.fk(q))
+        arm.solve(arm.fk(q))
 
     for _ in range(100):
         q = rng.uniform(-1, 1, size=6)
         T = arm.fk(q)
         t = time.perf_counter()
-        sols, is_ls = arm.ik(T)
+        sols = arm.solve(T)
         times.append((time.perf_counter() - t) * 1000)
-        if not is_ls and sols:
+        if sols:
             fk_residuals.append(max(s.fk_residual for s in sols))
             sol_counts.append(len(sols))
 

--- a/examples/02_jaco2_non_pieper.py
+++ b/examples/02_jaco2_non_pieper.py
@@ -46,7 +46,9 @@ def main() -> None:
     # JACO 2 lives as a Python builder (real MJCF transcription) rather
     # than a URDF, so we construct the KinBody and hand it to Manipulator
     # via the constructor escape hatch.
-    kb = ssik.build_kinbody(jaco2_specs())
+    from ssik.internals import build_kinbody
+
+    kb = build_kinbody(jaco2_specs())
     arm = ssik.Manipulator(kb)
     print(arm)
     print(f"  dof:    {arm.dof}")

--- a/examples/03_gen3_polished_srs.py
+++ b/examples/03_gen3_polished_srs.py
@@ -54,9 +54,9 @@ def main() -> None:
     # Hand-picked pose well-inside the workspace.
     q_star = np.array([0.3, -0.4, 0.7, 0.5, 0.6, -0.5, 0.2])
     T = arm.fk(q_star)
-    sols, is_ls = arm.ik(T)
+    sols = arm.solve(T)
     print(f"Hand-picked q*={q_star.tolist()}:")
-    print(f"  IK returned {len(sols)} branches, is_ls={is_ls}")
+    print(f"  IK returned {len(sols)} branches")
     print(f"  max FK residual: {max(s.fk_residual for s in sols):.2e}")
     print("  (FK closure is against the ORIGINAL URDF, not a simplified DH.)")
     print()
@@ -71,16 +71,16 @@ def main() -> None:
     for _ in range(10):
         q = rng.uniform(-0.8, 0.8, size=7)
         q[3] = float(rng.uniform(0.2, 0.8))
-        arm.ik(arm.fk(q))
+        arm.solve(arm.fk(q))
 
     for _ in range(100):
         q = rng.uniform(-0.8, 0.8, size=7)
         q[3] = float(rng.uniform(0.2, 0.8))
         T = arm.fk(q)
         t = time.perf_counter()
-        sols, is_ls = arm.ik(T)
+        sols = arm.solve(T)
         times.append((time.perf_counter() - t) * 1000)
-        if not is_ls and sols:
+        if sols:
             fk_residuals.append(max(s.fk_residual for s in sols))
             sol_counts.append(len(sols))
 
@@ -97,7 +97,7 @@ def main() -> None:
     for _ in range(50):
         T = arm.fk(rng.uniform(-0.8, 0.8, size=7))
         t = time.perf_counter()
-        arm.ik(T, max_solutions=1, q_seed=q_prev)
+        arm.solve(T, max_solutions=1, q_seed=q_prev)
         times_track.append((time.perf_counter() - t) * 1000)
     print("Trajectory tracking (max_solutions=1, q_seed):")
     print(f"  median IK time:    {np.median(times_track):.2f} ms")

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -175,16 +175,16 @@ def _gen_poses(arm, n: int, rng) -> list[np.ndarray]:
 def _bench_ssik(arm, poses: list[np.ndarray]) -> dict:
     # Warm.
     for T in poses[: min(10, len(poses))]:
-        arm.ik(T)
+        arm.solve(T)
 
     times = []
     fk_residuals = []
     sol_counts = []
     for T in poses:
         t = time.perf_counter()
-        sols, is_ls = arm.ik(T)
+        sols = arm.solve(T)
         times.append((time.perf_counter() - t) * 1000)
-        if not is_ls and sols:
+        if sols:
             fk_residuals.append(max(s.fk_residual for s in sols))
             sol_counts.append(len(sols))
 

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -124,7 +124,9 @@ def _load_ssik_arm(fx: Fixture, *, prefer_artifact: bool = True):
     else:
         mod_name, specs_fn_name = fx.args
         mod = __import__(mod_name)
-        kb = ssik.build_kinbody(getattr(mod, specs_fn_name)())
+        from ssik.internals import build_kinbody
+
+        kb = build_kinbody(getattr(mod, specs_fn_name)())
         return ssik.Manipulator(kb)
 
 

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -106,7 +106,7 @@ class _ArtifactArm:
     def fk(self, q):
         return self._fk(q)
 
-    def ik(self, T, **kwargs):
+    def solve(self, T, **kwargs):
         return self._module.solve(T, **kwargs)
 
 

--- a/prebuilt/franka_panda_ik.py
+++ b/prebuilt/franka_panda_ik.py
@@ -445,8 +445,15 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
+    # When ``respect_limits=True``, don't short-circuit the
+    # lock-sweep on ``max_solutions``: the first-found valid IK
+    # might be out-of-limits and the postprocess pass would drop
+    # it, leaving zero results. Run the full sweep, then filter
+    # + trim. The user can recover the early-exit speed by
+    # passing ``respect_limits=False``.
+    sweep_max = None if respect_limits else max_solutions
     candidates = _solve_algebraic(
-        T, max_solutions=max_solutions, q_seed=q_seed
+        T, max_solutions=sweep_max, q_seed=q_seed
     )
 
     fk_atol = policy.subproblem_numerical
@@ -495,13 +502,6 @@ def solve(
         elif cand_res < deduped[dup_idx][1]:
             deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
-    # Final trim: the underlying lock-sweep already capped at
-    # ``max_solutions`` (under #142), but verify+dedup may have
-    # collapsed near-duplicates so ``len(deduped)`` can also be
-    # smaller. Trimming here is the defensive belt-and-braces.
-    if max_solutions is not None and len(deduped) > max_solutions:
-        deduped = deduped[:max_solutions]
-
     solutions = [
         Solution(
             q=q,
@@ -510,9 +510,15 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+    # respect_limits before max_solutions trim, so the truncation
+    # picks from the in-limits set (not the raw set where the
+    # closest-to-seed branch might be out-of-limits and would
+    # silently disappear -- #238 review finding).
     if respect_limits:
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
 fk = _fk

--- a/prebuilt/franka_panda_ik.py
+++ b/prebuilt/franka_panda_ik.py
@@ -180,14 +180,17 @@ _DISPATCH_CACHE = (
 )
 
 
-def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
+def _solve_algebraic(
+    T_target, *, max_solutions=None, q_seed=None, respect_limits=False,
+):
     """7R IK candidates via joint-locking + inner 6R sweep.
 
     Routes to ssik.solvers.jointlock.seven_r.solve with the baked
     KinBody, lock_idx, lock-sample schedule, and dispatch cache.
-    ``max_solutions`` and ``q_seed`` are forwarded so the underlying
-    lock-sweep can short-circuit (#142). Returns ``list[list[float]]``
-    of length-7 q-vectors.
+    ``max_solutions``, ``q_seed``, and ``respect_limits`` are
+    forwarded so the lock-sweep can short-circuit on the first
+    in-limits valid IK (#238 review). Returns
+    ``list[list[float]]`` of length-7 q-vectors.
     """
     sub_solutions, _is_ls = _ssik_seven_r.solve(
         _KB, T_target,
@@ -195,6 +198,7 @@ def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
         lock_samples=_LOCK_SAMPLES,
         dispatch_cache=_DISPATCH_CACHE,
         max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
     return [list(s.q) for s in sub_solutions]
 
@@ -406,7 +410,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -445,15 +449,14 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
-    # When ``respect_limits=True``, don't short-circuit the
-    # lock-sweep on ``max_solutions``: the first-found valid IK
-    # might be out-of-limits and the postprocess pass would drop
-    # it, leaving zero results. Run the full sweep, then filter
-    # + trim. The user can recover the early-exit speed by
-    # passing ``respect_limits=False``.
-    sweep_max = None if respect_limits else max_solutions
+    # Lock-sweep filters limits in-flight (#238 review): the
+    # short-circuit fires on the first in-limits valid IK, not
+    # on a candidate that postprocess would drop. Preserves the
+    # max_solutions+q_seed early-exit fast path even with
+    # respect_limits=True.
     candidates = _solve_algebraic(
-        T, max_solutions=sweep_max, q_seed=q_seed
+        T, max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
 
     fk_atol = policy.subproblem_numerical
@@ -510,13 +513,10 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
-    # respect_limits before max_solutions trim, so the truncation
-    # picks from the in-limits set (not the raw set where the
-    # closest-to-seed branch might be out-of-limits and would
-    # silently disappear -- #238 review finding).
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
+    # No orchestrator-level respect_limits pass: the inner
+    # ``_solve_algebraic`` already filtered in-flight when
+    # respect_limits=True, so candidates here are guaranteed
+    # in-limits. The cap on max_solutions also ran inside.
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/prebuilt/franka_panda_ik.py
+++ b/prebuilt/franka_panda_ik.py
@@ -499,11 +499,8 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
     return solutions
 

--- a/prebuilt/franka_panda_ik.py
+++ b/prebuilt/franka_panda_ik.py
@@ -39,6 +39,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "jointlock.seven_r"
@@ -398,30 +403,33 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
-    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
-    refinement_max_iters: int = 15,
     max_solutions: int | None = None,
     q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
-    :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
-    :param refinement_max_iters: cap on Newton iterations per
-        candidate when ``allow_refinement=True``.
     :param max_solutions: optional early-exit cap on the
         jointlock lock-sweep. ``None`` (default) = exhaustive
         search. ``max_solutions=1`` short-circuits as soon as
-        one valid IK is found (~17x faster on Franka 7R).
+        one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
         provided, the lock-joint samples are visited in order
         of wrap-to-pi distance to ``q_seed[lock_idx]`` --
         combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path (~37x faster on Franka).
+        trajectory-tracking fast path.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False``
+        for the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton
+        polish fires on near-miss algebraic candidates.
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
 
     Common idioms::
 
@@ -502,8 +510,12 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
     return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -511,5 +523,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/franka_panda_ik.py
+++ b/prebuilt/franka_panda_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = franka_panda_ik.solve(T_target)
+    solutions = franka_panda_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -426,13 +426,13 @@ def solve(
     Common idioms::
 
         # Exhaustive search (default).
-        solutions, _ = solve(T_target)
+        solutions = solve(T_target)
 
         # "Just give me one IK" -- ~17x faster.
-        solutions, _ = solve(T_target, max_solutions=1)
+        solutions = solve(T_target, max_solutions=1)
 
         # Track current config -- ~37x faster.
-        solutions, _ = solve(
+        solutions = solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
@@ -505,7 +505,7 @@ def solve(
         )
         for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
-    return solutions, len(solutions) == 0
+    return solutions
 
 
 __all__ = [

--- a/prebuilt/gen3_ik.py
+++ b/prebuilt/gen3_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = gen3_ik.solve(T_target)
+    solutions = gen3_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -135,7 +135,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
     :param policy: tolerance policy. Pass a custom
@@ -150,22 +150,23 @@ def solve(
         kinematic singularities).
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
-    :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
-        vector matching the source URDF's joint ordering;
-        ``solution.fk_residual`` reports closure against
-        ``T_target``. ``is_ls=True`` iff the algebraic path produced
-        no candidate meeting the FK tolerance -- callers wanting
-        only "exact" solutions check ``is_ls`` and discard.
+    :returns: list of :class:`Solution`, one per analytical IK
+        branch. Each ``solution.q`` is a joint vector matching
+        the source URDF's joint ordering; ``solution.fk_residual``
+        reports closure against ``T_target``. Empty list iff no
+        candidate met the FK tolerance -- check ``if not sols:``
+        for the "unreachable target" case.
 
     Solver: srs_polished.
     """
-    return _solver_solve(
+    sols, _is_ls = _solver_solve(
         _KB,
         T_target,
         policy=policy,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    return sols
 
 
 __all__ = [

--- a/prebuilt/gen3_ik.py
+++ b/prebuilt/gen3_ik.py
@@ -33,6 +33,11 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.solvers.seven_r.srs_polished import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs_polished"
@@ -131,31 +136,34 @@ _KB = _build_kb()
 def solve(
     T_target,
     *,
+    max_solutions=None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
-    :param policy: tolerance policy. Pass a custom
-        :class:`ssik.TolerancePolicy` to tighten or relax the
-        FK-closure threshold (``subproblem_numerical``), the
-        axis-parallel / axis-intersect predicates, etc. Defaults to
-        :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss algebraic candidates. Default ``False``;
-        turn on to recover candidates that don't quite meet
-        ``policy.subproblem_numerical`` on their own (e.g. near
-        kinematic singularities).
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full enumeration.
+    :param q_seed: optional joint config. When provided, solutions
+        are sorted by wrap-to-pi distance from ``q_seed`` (closest
+        first). Combine with ``max_solutions=1`` for the
+        trajectory-tracking idiom.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. ``False`` returns
+        the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates. Tightens FK
+        closure to machine precision.
+    :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Each ``solution.q`` is a joint vector matching
-        the source URDF's joint ordering; ``solution.fk_residual``
-        reports closure against ``T_target``. Empty list iff no
-        candidate met the FK tolerance -- check ``if not sols:``
-        for the "unreachable target" case.
+        branch. Empty list iff no candidate met the FK tolerance
+        -- check ``if not sols:`` for "unreachable target".
 
     Solver: srs_polished.
     """
@@ -166,8 +174,21 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    if respect_limits:
+        sols = _ps_wrap_to_limits(sols, _KB)
+        sols = _ps_respect_limits(sols, _KB)
+    if q_seed is not None:
+        sols = _ps_nearest_to_seed(sols, q_seed)
+    if max_solutions is not None and len(sols) > max_solutions:
+        sols = sols[:max_solutions]
     return sols
 
+from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
+
+
+def fk(q):
+    """Forward kinematics: returns the 4x4 base->ee pose at ``q``."""
+    return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
 
 __all__ = [
     "DISPATCH_REASON",
@@ -175,5 +196,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/gen3_ik.py
+++ b/prebuilt/gen3_ik.py
@@ -139,7 +139,7 @@ def solve(
     max_solutions=None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):

--- a/prebuilt/iiwa14_ik.py
+++ b/prebuilt/iiwa14_ik.py
@@ -33,6 +33,11 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.solvers.seven_r.srs import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs"
@@ -131,31 +136,34 @@ _KB = _build_kb()
 def solve(
     T_target,
     *,
+    max_solutions=None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
-    :param policy: tolerance policy. Pass a custom
-        :class:`ssik.TolerancePolicy` to tighten or relax the
-        FK-closure threshold (``subproblem_numerical``), the
-        axis-parallel / axis-intersect predicates, etc. Defaults to
-        :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss algebraic candidates. Default ``False``;
-        turn on to recover candidates that don't quite meet
-        ``policy.subproblem_numerical`` on their own (e.g. near
-        kinematic singularities).
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full enumeration.
+    :param q_seed: optional joint config. When provided, solutions
+        are sorted by wrap-to-pi distance from ``q_seed`` (closest
+        first). Combine with ``max_solutions=1`` for the
+        trajectory-tracking idiom.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. ``False`` returns
+        the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates. Tightens FK
+        closure to machine precision.
+    :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Each ``solution.q`` is a joint vector matching
-        the source URDF's joint ordering; ``solution.fk_residual``
-        reports closure against ``T_target``. Empty list iff no
-        candidate met the FK tolerance -- check ``if not sols:``
-        for the "unreachable target" case.
+        branch. Empty list iff no candidate met the FK tolerance
+        -- check ``if not sols:`` for "unreachable target".
 
     Solver: srs.
     """
@@ -166,8 +174,21 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    if respect_limits:
+        sols = _ps_wrap_to_limits(sols, _KB)
+        sols = _ps_respect_limits(sols, _KB)
+    if q_seed is not None:
+        sols = _ps_nearest_to_seed(sols, q_seed)
+    if max_solutions is not None and len(sols) > max_solutions:
+        sols = sols[:max_solutions]
     return sols
 
+from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
+
+
+def fk(q):
+    """Forward kinematics: returns the 4x4 base->ee pose at ``q``."""
+    return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
 
 __all__ = [
     "DISPATCH_REASON",
@@ -175,5 +196,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/iiwa14_ik.py
+++ b/prebuilt/iiwa14_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = iiwa14_ik.solve(T_target)
+    solutions = iiwa14_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -135,7 +135,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
     :param policy: tolerance policy. Pass a custom
@@ -150,22 +150,23 @@ def solve(
         kinematic singularities).
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
-    :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
-        vector matching the source URDF's joint ordering;
-        ``solution.fk_residual`` reports closure against
-        ``T_target``. ``is_ls=True`` iff the algebraic path produced
-        no candidate meeting the FK tolerance -- callers wanting
-        only "exact" solutions check ``is_ls`` and discard.
+    :returns: list of :class:`Solution`, one per analytical IK
+        branch. Each ``solution.q`` is a joint vector matching
+        the source URDF's joint ordering; ``solution.fk_residual``
+        reports closure against ``T_target``. Empty list iff no
+        candidate met the FK tolerance -- check ``if not sols:``
+        for the "unreachable target" case.
 
     Solver: srs.
     """
-    return _solver_solve(
+    sols, _is_ls = _solver_solve(
         _KB,
         T_target,
         policy=policy,
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    return sols
 
 
 __all__ = [

--- a/prebuilt/iiwa14_ik.py
+++ b/prebuilt/iiwa14_ik.py
@@ -139,7 +139,7 @@ def solve(
     max_solutions=None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):

--- a/prebuilt/jaco2_ik.py
+++ b/prebuilt/jaco2_ik.py
@@ -861,7 +861,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -879,11 +879,13 @@ def solve(
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
-    :param allow_refinement: when ``True`` (default), Newton polish
-        fires on near-miss algebraic candidates that don't quite
-        meet ``fk_atol``. Tightens FK closure to machine precision
-        at ~100-300 us per polished branch. Set ``False`` for
-        pure algebraic results.
+    :param allow_refinement: opt into Newton polish for near-miss
+        algebraic candidates that don't quite meet ``fk_atol``.
+        Default ``False`` -- the algebraic path is already at
+        machine precision on tier-0 / SRS arms. On tier-2 RR
+        arms (JACO 2, Rizon 4, Kassow), polish can recover
+        edge-case candidates whose algebraic FK drifts above
+        ``fk_atol``, at ~100-300 us per polished branch.
     :param policy: tolerance policy (FK closure + dedup tolerance).
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per

--- a/prebuilt/jaco2_ik.py
+++ b/prebuilt/jaco2_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = jaco2_ik.solve(T_target)
+    solutions = jaco2_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -857,7 +857,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
     :param policy: tolerance policy (FK closure + dedup tolerance).
@@ -866,6 +866,8 @@ def solve(
         doesn't quite meet ``fk_atol``). Default off.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :returns: list of :class:`Solution`; empty list iff no IK
+        closed within ``policy.subproblem_numerical``.
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -927,7 +929,7 @@ def solve(
         )
         for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
-    return solutions, len(solutions) == 0
+    return solutions
 
 
 __all__ = [

--- a/prebuilt/jaco2_ik.py
+++ b/prebuilt/jaco2_ik.py
@@ -923,11 +923,8 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
     return solutions
 

--- a/prebuilt/jaco2_ik.py
+++ b/prebuilt/jaco2_ik.py
@@ -45,6 +45,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -853,21 +858,39 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
+    max_solutions: int | None = None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full redundancy enumeration.
+        Combine with ``q_seed`` for the "give me the IK closest to
+        where I am now" trajectory-tracking idiom.
+    :param q_seed: optional joint configuration. When provided,
+        returned solutions are sorted by wrap-to-pi distance from
+        ``q_seed`` (closest first). Has no effect on which solutions
+        are returned, only their order.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False`` for
+        the raw geometric set (e.g. analysis / debugging).
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates that don't quite
+        meet ``fk_atol``. Tightens FK closure to machine precision
+        at ~100-300 us per polished branch. Set ``False`` for
+        pure algebraic results.
     :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
+        Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`; empty list iff no IK
-        closed within ``policy.subproblem_numerical``.
+        closed within ``policy.subproblem_numerical`` (or all
+        IKs were filtered by ``respect_limits=True``).
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -926,8 +949,23 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+
+    # Post-processing pass (#238 item 4). Order matters:
+    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
+    #      candidates into the URDF's limit range
+    #   2. respect_limits drops anything still outside
+    #   3. nearest_to_seed sorts by distance to q_seed (if given)
+    #   4. max_solutions truncates to the first k
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -935,5 +973,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/kassow_kr810_ik.py
+++ b/prebuilt/kassow_kr810_ik.py
@@ -3332,8 +3332,15 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
+    # When ``respect_limits=True``, don't short-circuit the
+    # lock-sweep on ``max_solutions``: the first-found valid IK
+    # might be out-of-limits and the postprocess pass would drop
+    # it, leaving zero results. Run the full sweep, then filter
+    # + trim. The user can recover the early-exit speed by
+    # passing ``respect_limits=False``.
+    sweep_max = None if respect_limits else max_solutions
     candidates = _solve_algebraic(
-        T, max_solutions=max_solutions, q_seed=q_seed
+        T, max_solutions=sweep_max, q_seed=q_seed
     )
 
     fk_atol = policy.subproblem_numerical
@@ -3382,13 +3389,6 @@ def solve(
         elif cand_res < deduped[dup_idx][1]:
             deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
-    # Final trim: the underlying lock-sweep already capped at
-    # ``max_solutions`` (under #142), but verify+dedup may have
-    # collapsed near-duplicates so ``len(deduped)`` can also be
-    # smaller. Trimming here is the defensive belt-and-braces.
-    if max_solutions is not None and len(deduped) > max_solutions:
-        deduped = deduped[:max_solutions]
-
     solutions = [
         Solution(
             q=q,
@@ -3397,9 +3397,15 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+    # respect_limits before max_solutions trim, so the truncation
+    # picks from the in-limits set (not the raw set where the
+    # closest-to-seed branch might be out-of-limits and would
+    # silently disappear -- #238 review finding).
     if respect_limits:
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
 fk = _fk

--- a/prebuilt/kassow_kr810_ik.py
+++ b/prebuilt/kassow_kr810_ik.py
@@ -3067,14 +3067,17 @@ for _b85 in _RR_PRIME_BLOBS_B85:
 
 
 
-def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
+def _solve_algebraic(
+    T_target, *, max_solutions=None, q_seed=None, respect_limits=False,
+):
     """7R IK candidates via joint-locking + inner 6R sweep.
 
     Routes to ssik.solvers.jointlock.seven_r.solve with the baked
     KinBody, lock_idx, lock-sample schedule, and dispatch cache.
-    ``max_solutions`` and ``q_seed`` are forwarded so the underlying
-    lock-sweep can short-circuit (#142). Returns ``list[list[float]]``
-    of length-7 q-vectors.
+    ``max_solutions``, ``q_seed``, and ``respect_limits`` are
+    forwarded so the lock-sweep can short-circuit on the first
+    in-limits valid IK (#238 review). Returns
+    ``list[list[float]]`` of length-7 q-vectors.
     """
     sub_solutions, _is_ls = _ssik_seven_r.solve(
         _KB, T_target,
@@ -3082,6 +3085,7 @@ def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
         lock_samples=_LOCK_SAMPLES,
         dispatch_cache=_DISPATCH_CACHE,
         max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
     return [list(s.q) for s in sub_solutions]
 
@@ -3293,7 +3297,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -3332,15 +3336,14 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
-    # When ``respect_limits=True``, don't short-circuit the
-    # lock-sweep on ``max_solutions``: the first-found valid IK
-    # might be out-of-limits and the postprocess pass would drop
-    # it, leaving zero results. Run the full sweep, then filter
-    # + trim. The user can recover the early-exit speed by
-    # passing ``respect_limits=False``.
-    sweep_max = None if respect_limits else max_solutions
+    # Lock-sweep filters limits in-flight (#238 review): the
+    # short-circuit fires on the first in-limits valid IK, not
+    # on a candidate that postprocess would drop. Preserves the
+    # max_solutions+q_seed early-exit fast path even with
+    # respect_limits=True.
     candidates = _solve_algebraic(
-        T, max_solutions=sweep_max, q_seed=q_seed
+        T, max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
 
     fk_atol = policy.subproblem_numerical
@@ -3397,13 +3400,10 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
-    # respect_limits before max_solutions trim, so the truncation
-    # picks from the in-limits set (not the raw set where the
-    # closest-to-seed branch might be out-of-limits and would
-    # silently disappear -- #238 review finding).
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
+    # No orchestrator-level respect_limits pass: the inner
+    # ``_solve_algebraic`` already filtered in-flight when
+    # respect_limits=True, so candidates here are guaranteed
+    # in-limits. The cap on max_solutions also ran inside.
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/prebuilt/kassow_kr810_ik.py
+++ b/prebuilt/kassow_kr810_ik.py
@@ -1,4 +1,4 @@
-"""Generated IK module for kassow_kr810_ik.
+"""Generated IK module for Kassow KR810.
 
 This file was emitted by ``ssik build`` and is the public artifact for
 running analytical inverse kinematics on this specific arm. The
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = kassow_kr810_ik.solve(T_target)
+    solutions = kassow_kr810_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -39,6 +39,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "jointlock.seven_r"
@@ -3285,41 +3290,44 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
-    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
-    refinement_max_iters: int = 15,
     max_solutions: int | None = None,
     q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
-    :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
-    :param refinement_max_iters: cap on Newton iterations per
-        candidate when ``allow_refinement=True``.
     :param max_solutions: optional early-exit cap on the
         jointlock lock-sweep. ``None`` (default) = exhaustive
         search. ``max_solutions=1`` short-circuits as soon as
-        one valid IK is found (~17x faster on Franka 7R).
+        one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
         provided, the lock-joint samples are visited in order
         of wrap-to-pi distance to ``q_seed[lock_idx]`` --
         combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path (~37x faster on Franka).
+        trajectory-tracking fast path.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False``
+        for the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton
+        polish fires on near-miss algebraic candidates.
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
 
     Common idioms::
 
         # Exhaustive search (default).
-        solutions, _ = solve(T_target)
+        solutions = solve(T_target)
 
         # "Just give me one IK" -- ~17x faster.
-        solutions, _ = solve(T_target, max_solutions=1)
+        solutions = solve(T_target, max_solutions=1)
 
         # Track current config -- ~37x faster.
-        solutions, _ = solve(
+        solutions = solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
@@ -3386,14 +3394,15 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
-    return solutions, len(solutions) == 0
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
+    return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -3401,5 +3410,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/puma560_ik.py
+++ b/prebuilt/puma560_ik.py
@@ -515,7 +515,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -533,11 +533,13 @@ def solve(
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
-    :param allow_refinement: when ``True`` (default), Newton polish
-        fires on near-miss algebraic candidates that don't quite
-        meet ``fk_atol``. Tightens FK closure to machine precision
-        at ~100-300 us per polished branch. Set ``False`` for
-        pure algebraic results.
+    :param allow_refinement: opt into Newton polish for near-miss
+        algebraic candidates that don't quite meet ``fk_atol``.
+        Default ``False`` -- the algebraic path is already at
+        machine precision on tier-0 / SRS arms. On tier-2 RR
+        arms (JACO 2, Rizon 4, Kassow), polish can recover
+        edge-case candidates whose algebraic FK drifts above
+        ``fk_atol``, at ~100-300 us per polished branch.
     :param policy: tolerance policy (FK closure + dedup tolerance).
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per

--- a/prebuilt/puma560_ik.py
+++ b/prebuilt/puma560_ik.py
@@ -40,6 +40,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -507,21 +512,39 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
+    max_solutions: int | None = None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full redundancy enumeration.
+        Combine with ``q_seed`` for the "give me the IK closest to
+        where I am now" trajectory-tracking idiom.
+    :param q_seed: optional joint configuration. When provided,
+        returned solutions are sorted by wrap-to-pi distance from
+        ``q_seed`` (closest first). Has no effect on which solutions
+        are returned, only their order.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False`` for
+        the raw geometric set (e.g. analysis / debugging).
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates that don't quite
+        meet ``fk_atol``. Tightens FK closure to machine precision
+        at ~100-300 us per polished branch. Set ``False`` for
+        pure algebraic results.
     :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
+        Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`; empty list iff no IK
-        closed within ``policy.subproblem_numerical``.
+        closed within ``policy.subproblem_numerical`` (or all
+        IKs were filtered by ``respect_limits=True``).
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -580,8 +603,23 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+
+    # Post-processing pass (#238 item 4). Order matters:
+    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
+    #      candidates into the URDF's limit range
+    #   2. respect_limits drops anything still outside
+    #   3. nearest_to_seed sorts by distance to q_seed (if given)
+    #   4. max_solutions truncates to the first k
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -589,5 +627,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/puma560_ik.py
+++ b/prebuilt/puma560_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = puma560_ik.solve(T_target)
+    solutions = puma560_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -511,7 +511,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
     :param policy: tolerance policy (FK closure + dedup tolerance).
@@ -520,6 +520,8 @@ def solve(
         doesn't quite meet ``fk_atol``). Default off.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :returns: list of :class:`Solution`; empty list iff no IK
+        closed within ``policy.subproblem_numerical``.
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -581,7 +583,7 @@ def solve(
         )
         for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
-    return solutions, len(solutions) == 0
+    return solutions
 
 
 __all__ = [

--- a/prebuilt/puma560_ik.py
+++ b/prebuilt/puma560_ik.py
@@ -577,11 +577,8 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
     return solutions
 

--- a/prebuilt/rizon4_ik.py
+++ b/prebuilt/rizon4_ik.py
@@ -3867,14 +3867,17 @@ for _b85 in _RR_PRIME_BLOBS_B85:
 
 
 
-def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
+def _solve_algebraic(
+    T_target, *, max_solutions=None, q_seed=None, respect_limits=False,
+):
     """7R IK candidates via joint-locking + inner 6R sweep.
 
     Routes to ssik.solvers.jointlock.seven_r.solve with the baked
     KinBody, lock_idx, lock-sample schedule, and dispatch cache.
-    ``max_solutions`` and ``q_seed`` are forwarded so the underlying
-    lock-sweep can short-circuit (#142). Returns ``list[list[float]]``
-    of length-7 q-vectors.
+    ``max_solutions``, ``q_seed``, and ``respect_limits`` are
+    forwarded so the lock-sweep can short-circuit on the first
+    in-limits valid IK (#238 review). Returns
+    ``list[list[float]]`` of length-7 q-vectors.
     """
     sub_solutions, _is_ls = _ssik_seven_r.solve(
         _KB, T_target,
@@ -3882,6 +3885,7 @@ def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
         lock_samples=_LOCK_SAMPLES,
         dispatch_cache=_DISPATCH_CACHE,
         max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
     return [list(s.q) for s in sub_solutions]
 
@@ -4093,7 +4097,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -4132,15 +4136,14 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
-    # When ``respect_limits=True``, don't short-circuit the
-    # lock-sweep on ``max_solutions``: the first-found valid IK
-    # might be out-of-limits and the postprocess pass would drop
-    # it, leaving zero results. Run the full sweep, then filter
-    # + trim. The user can recover the early-exit speed by
-    # passing ``respect_limits=False``.
-    sweep_max = None if respect_limits else max_solutions
+    # Lock-sweep filters limits in-flight (#238 review): the
+    # short-circuit fires on the first in-limits valid IK, not
+    # on a candidate that postprocess would drop. Preserves the
+    # max_solutions+q_seed early-exit fast path even with
+    # respect_limits=True.
     candidates = _solve_algebraic(
-        T, max_solutions=sweep_max, q_seed=q_seed
+        T, max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
     )
 
     fk_atol = policy.subproblem_numerical
@@ -4197,13 +4200,10 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
-    # respect_limits before max_solutions trim, so the truncation
-    # picks from the in-limits set (not the raw set where the
-    # closest-to-seed branch might be out-of-limits and would
-    # silently disappear -- #238 review finding).
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
+    # No orchestrator-level respect_limits pass: the inner
+    # ``_solve_algebraic`` already filtered in-flight when
+    # respect_limits=True, so candidates here are guaranteed
+    # in-limits. The cap on max_solutions also ran inside.
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/prebuilt/rizon4_ik.py
+++ b/prebuilt/rizon4_ik.py
@@ -4132,8 +4132,15 @@ def solve(
         )
     """
     T = np.asarray(T_target, dtype=np.float64)
+    # When ``respect_limits=True``, don't short-circuit the
+    # lock-sweep on ``max_solutions``: the first-found valid IK
+    # might be out-of-limits and the postprocess pass would drop
+    # it, leaving zero results. Run the full sweep, then filter
+    # + trim. The user can recover the early-exit speed by
+    # passing ``respect_limits=False``.
+    sweep_max = None if respect_limits else max_solutions
     candidates = _solve_algebraic(
-        T, max_solutions=max_solutions, q_seed=q_seed
+        T, max_solutions=sweep_max, q_seed=q_seed
     )
 
     fk_atol = policy.subproblem_numerical
@@ -4182,13 +4189,6 @@ def solve(
         elif cand_res < deduped[dup_idx][1]:
             deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
-    # Final trim: the underlying lock-sweep already capped at
-    # ``max_solutions`` (under #142), but verify+dedup may have
-    # collapsed near-duplicates so ``len(deduped)`` can also be
-    # smaller. Trimming here is the defensive belt-and-braces.
-    if max_solutions is not None and len(deduped) > max_solutions:
-        deduped = deduped[:max_solutions]
-
     solutions = [
         Solution(
             q=q,
@@ -4197,9 +4197,15 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+    # respect_limits before max_solutions trim, so the truncation
+    # picks from the in-limits set (not the raw set where the
+    # closest-to-seed branch might be out-of-limits and would
+    # silently disappear -- #238 review finding).
     if respect_limits:
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
 fk = _fk

--- a/prebuilt/rizon4_ik.py
+++ b/prebuilt/rizon4_ik.py
@@ -1,4 +1,4 @@
-"""Generated IK module for rizon4_ik.
+"""Generated IK module for Flexiv Rizon 4.
 
 This file was emitted by ``ssik build`` and is the public artifact for
 running analytical inverse kinematics on this specific arm. The
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = rizon4_ik.solve(T_target)
+    solutions = rizon4_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -39,6 +39,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "jointlock.seven_r"
@@ -4085,41 +4090,44 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
-    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
-    refinement_max_iters: int = 15,
     max_solutions: int | None = None,
     q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
-    :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
-    :param refinement_max_iters: cap on Newton iterations per
-        candidate when ``allow_refinement=True``.
     :param max_solutions: optional early-exit cap on the
         jointlock lock-sweep. ``None`` (default) = exhaustive
         search. ``max_solutions=1`` short-circuits as soon as
-        one valid IK is found (~17x faster on Franka 7R).
+        one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
         provided, the lock-joint samples are visited in order
         of wrap-to-pi distance to ``q_seed[lock_idx]`` --
         combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path (~37x faster on Franka).
+        trajectory-tracking fast path.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False``
+        for the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton
+        polish fires on near-miss algebraic candidates.
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
 
     Common idioms::
 
         # Exhaustive search (default).
-        solutions, _ = solve(T_target)
+        solutions = solve(T_target)
 
         # "Just give me one IK" -- ~17x faster.
-        solutions, _ = solve(T_target, max_solutions=1)
+        solutions = solve(T_target, max_solutions=1)
 
         # Track current config -- ~37x faster.
-        solutions, _ = solve(
+        solutions = solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
@@ -4186,14 +4194,15 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
-    return solutions, len(solutions) == 0
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
+    return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -4201,5 +4210,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/ur5_ik.py
+++ b/prebuilt/ur5_ik.py
@@ -537,11 +537,8 @@ def solve(
             q=q,
             fk_residual=residual,
             refinement_used=ref_used,
-            refinement_iters=ref_iters,
-            branch_id=i,
-            solver_name=SOLVER_NAME,
         )
-        for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+        for q, residual, ref_used, _ref_iters in deduped
     ]
     return solutions
 

--- a/prebuilt/ur5_ik.py
+++ b/prebuilt/ur5_ik.py
@@ -475,7 +475,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed=None,
     respect_limits: bool = True,
-    allow_refinement: bool = True,
+    allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
 ):
@@ -493,11 +493,13 @@ def solve(
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
-    :param allow_refinement: when ``True`` (default), Newton polish
-        fires on near-miss algebraic candidates that don't quite
-        meet ``fk_atol``. Tightens FK closure to machine precision
-        at ~100-300 us per polished branch. Set ``False`` for
-        pure algebraic results.
+    :param allow_refinement: opt into Newton polish for near-miss
+        algebraic candidates that don't quite meet ``fk_atol``.
+        Default ``False`` -- the algebraic path is already at
+        machine precision on tier-0 / SRS arms. On tier-2 RR
+        arms (JACO 2, Rizon 4, Kassow), polish can recover
+        edge-case candidates whose algebraic FK drifts above
+        ``fk_atol``, at ~100-300 us per polished branch.
     :param policy: tolerance policy (FK closure + dedup tolerance).
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per

--- a/prebuilt/ur5_ik.py
+++ b/prebuilt/ur5_ik.py
@@ -41,6 +41,11 @@ from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -467,21 +472,39 @@ def _q_close_wrap(a, b, tol: float) -> bool:
 def solve(
     T_target,
     *,
+    max_solutions: int | None = None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-    allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full redundancy enumeration.
+        Combine with ``q_seed`` for the "give me the IK closest to
+        where I am now" trajectory-tracking idiom.
+    :param q_seed: optional joint configuration. When provided,
+        returned solutions are sorted by wrap-to-pi distance from
+        ``q_seed`` (closest first). Has no effect on which solutions
+        are returned, only their order.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False`` for
+        the raw geometric set (e.g. analysis / debugging).
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates that don't quite
+        meet ``fk_atol``. Tightens FK closure to machine precision
+        at ~100-300 us per polished branch. Set ``False`` for
+        pure algebraic results.
     :param policy: tolerance policy (FK closure + dedup tolerance).
-    :param allow_refinement: opt into Newton-on-spatial-Jacobian
-        polish for near-miss candidates (those whose algebraic q
-        doesn't quite meet ``fk_atol``). Default off.
+        Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`; empty list iff no IK
-        closed within ``policy.subproblem_numerical``.
+        closed within ``policy.subproblem_numerical`` (or all
+        IKs were filtered by ``respect_limits=True``).
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -540,8 +563,23 @@ def solve(
         )
         for q, residual, ref_used, _ref_iters in deduped
     ]
+
+    # Post-processing pass (#238 item 4). Order matters:
+    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
+    #      candidates into the URDF's limit range
+    #   2. respect_limits drops anything still outside
+    #   3. nearest_to_seed sorts by distance to q_seed (if given)
+    #   4. max_solutions truncates to the first k
+    if respect_limits:
+        solutions = _ps_wrap_to_limits(solutions, _KB)
+        solutions = _ps_respect_limits(solutions, _KB)
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed)
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
     return solutions
 
+fk = _fk
 
 __all__ = [
     "DISPATCH_REASON",
@@ -549,5 +587,6 @@ __all__ = [
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "fk",
     "solve",
 ]

--- a/prebuilt/ur5_ik.py
+++ b/prebuilt/ur5_ik.py
@@ -17,13 +17,13 @@ Usage:
     import numpy as np
     T_target = np.eye(4)  # 4x4 SE(3) pose
     T_target[:3, 3] = [0.5, 0.1, 0.3]
-    solutions, is_ls = ur5_ik.solve(T_target)
+    solutions = ur5_ik.solve(T_target)
     for sol in solutions:
         print(sol.q, sol.fk_residual)
 
-``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-signals that no solution closed within the solver's FK tolerance,
-and the returned list is the best-LS approximation (or empty).
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
 """
 
 from __future__ import annotations
@@ -471,7 +471,7 @@ def solve(
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
 ):
-    """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+    """Inverse kinematics. Returns ``list[Solution]``.
 
     :param T_target: 4x4 SE(3) target end-effector pose.
     :param policy: tolerance policy (FK closure + dedup tolerance).
@@ -480,6 +480,8 @@ def solve(
         doesn't quite meet ``fk_atol``). Default off.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :returns: list of :class:`Solution`; empty list iff no IK
+        closed within ``policy.subproblem_numerical``.
     """
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
@@ -541,7 +543,7 @@ def solve(
         )
         for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
     ]
-    return solutions, len(solutions) == 0
+    return solutions
 
 
 __all__ = [

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -1,39 +1,47 @@
-"""ssik -- pluggable analytical inverse-kinematics library for Python.
+"""ssik -- analytical inverse kinematics for 6R/7R revolute arms.
+
+Public surface (v1.0):
+
+- :class:`Manipulator` -- runtime classifier + dispatcher; load via
+  :meth:`Manipulator.from_urdf` (interactive) or build an artifact
+  once via ``ssik build`` and ``import <arm>_ik`` (production).
+- :class:`Solution` -- analytical IK result (``q``, ``fk_residual``,
+  ``refinement_used``).
+- :class:`TolerancePolicy` / :data:`DEFAULT_TOLERANCE_POLICY` --
+  knobs for FK closure thresholds (rarely needed).
 
 Quickstart::
 
     import ssik
+    arm = ssik.Manipulator.from_urdf("ur5.urdf", base="base_link", ee="ee_link")
+    sols = arm.solve(T_target, max_solutions=1, q_seed=q_current)
 
-    arm = ssik.Manipulator.from_urdf(
-        "ur5.urdf", base="base_link", ee="ee_link"
-    )
-    T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
-    sols, is_ls = arm.ik(T)
+For deployment, prefer the build artifact::
 
-For trajectory tracking::
+    # one-time build, emits my_arm_ik.py
+    $ ssik build my_arm.urdf --base base_link --ee tool0
 
-    sols, is_ls = arm.ik(T_target, max_solutions=1, q_seed=q_prev)
+    # then in your code:
+    import my_arm_ik
+    sols = my_arm_ik.solve(T_target, max_solutions=1, q_seed=q_current)
 
-Logging: the package emits hierarchical logs under the ``ssik`` namespace
-(``ssik.solvers.ikgeo.three_parallel``, etc.). By default a ``NullHandler``
-suppresses all output, so importing ssik never produces unsolicited stderr
-in user applications. To see solver diagnostics, install a handler:
+Contributor / debugging surface (``KinBody``, ``dispatch``,
+``describe_topology``, ...) lives under :mod:`ssik.internals`.
+
+Logging: the package emits hierarchical logs under the ``ssik`` namespace.
+By default a ``NullHandler`` suppresses all output. To see solver
+diagnostics::
 
     import logging
     logging.getLogger("ssik").setLevel(logging.INFO)
-    logging.basicConfig()  # or supply your own handler
-
-The ``ssik build`` CLI configures this automatically via ``--verbose``.
+    logging.basicConfig()
 """
 
 import logging as _logging
 
-from ssik._kinbody import Joint, JointSpec, KinBody, Link, build_kinbody
 from ssik._version import __version__
-from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.core.topology import TopologyReport, describe_topology
 from ssik.manipulator import Manipulator
 
 # Library best practice: prevent "No handlers could be found" warnings and
@@ -43,17 +51,8 @@ _logging.getLogger(__name__).addHandler(_logging.NullHandler())
 
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",
-    "DispatchPlan",
-    "Joint",
-    "JointSpec",
-    "KinBody",
-    "Link",
     "Manipulator",
     "Solution",
     "TolerancePolicy",
-    "TopologyReport",
     "__version__",
-    "build_kinbody",
-    "describe_topology",
-    "dispatch",
 ]

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -287,7 +287,7 @@ def _run_build(args: argparse.Namespace) -> int:
 
     print("[ssik] ✓ Done. Try:")
     print(f"[ssik]     >>> import {module_name}")
-    print(f"[ssik]     >>> sols, is_ls = {module_name}.solve(T_target)")
+    print(f"[ssik]     >>> sols = {module_name}.solve(T_target)")
     return 0
 
 
@@ -337,9 +337,11 @@ def _validate_artifact(
         q_star = rng.uniform(-1.0, 1.0, size=n_dof)
         T_star = _fk_poe(kb_source, q_star)
         t0 = time.perf_counter()
-        sols, is_ls = mod.solve(T_star)
+        # Validation samples q from [-1, 1] which can land outside URDF
+        # limits; bypass respect_limits for FK-roundtrip checks.
+        sols = mod.solve(T_star, respect_limits=False)
         times.append((time.perf_counter() - t0) * 1e3)
-        if is_ls or not sols:
+        if not sols:
             failures += 1
             continue
         worst = 0.0

--- a/src/ssik/codegen/_compose/seven_r.py
+++ b/src/ssik/codegen/_compose/seven_r.py
@@ -220,14 +220,17 @@ def compose(kb: KinBody) -> str:
         ){rr_prime_block}
 
 
-        def _solve_algebraic(T_target, *, max_solutions=None, q_seed=None):
+        def _solve_algebraic(
+            T_target, *, max_solutions=None, q_seed=None, respect_limits=False,
+        ):
             \"\"\"7R IK candidates via joint-locking + inner 6R sweep.
 
             Routes to ssik.solvers.jointlock.seven_r.solve with the baked
             KinBody, lock_idx, lock-sample schedule, and dispatch cache.
-            ``max_solutions`` and ``q_seed`` are forwarded so the underlying
-            lock-sweep can short-circuit (#142). Returns ``list[list[float]]``
-            of length-7 q-vectors.
+            ``max_solutions``, ``q_seed``, and ``respect_limits`` are
+            forwarded so the lock-sweep can short-circuit on the first
+            in-limits valid IK (#238 review). Returns
+            ``list[list[float]]`` of length-7 q-vectors.
             \"\"\"
             sub_solutions, _is_ls = _ssik_seven_r.solve(
                 _KB, T_target,
@@ -235,6 +238,7 @@ def compose(kb: KinBody) -> str:
                 lock_samples=_LOCK_SAMPLES,
                 dispatch_cache=_DISPATCH_CACHE,
                 max_solutions=max_solutions, q_seed=q_seed,
+                respect_limits=respect_limits,
             )
             return [list(s.q) for s in sub_solutions]
         """

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -472,7 +472,7 @@ def _render_specialised_solve_orchestrator() -> str:
             allow_refinement: bool = False,
             refinement_max_iters: int = 15,
         ):
-            """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+            """Inverse kinematics. Returns ``list[Solution]``.
 
             :param T_target: 4x4 SE(3) target end-effector pose.
             :param policy: tolerance policy (FK closure + dedup tolerance).
@@ -481,6 +481,8 @@ def _render_specialised_solve_orchestrator() -> str:
                 doesn't quite meet ``fk_atol``). Default off.
             :param refinement_max_iters: cap on Newton iterations per
                 candidate when ``allow_refinement=True``.
+            :returns: list of :class:`Solution`; empty list iff no IK
+                closed within ``policy.subproblem_numerical``.
             """
             T = np.asarray(T_target, dtype=np.float64)
             candidates = _solve_algebraic(T)
@@ -542,7 +544,7 @@ def _render_specialised_solve_orchestrator() -> str:
                 )
                 for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
             ]
-            return solutions, len(solutions) == 0
+            return solutions
         '''
     )
 
@@ -790,13 +792,13 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             Common idioms::
 
                 # Exhaustive search (default).
-                solutions, _ = solve(T_target)
+                solutions = solve(T_target)
 
                 # "Just give me one IK" -- ~17x faster.
-                solutions, _ = solve(T_target, max_solutions=1)
+                solutions = solve(T_target, max_solutions=1)
 
                 # Track current config -- ~37x faster.
-                solutions, _ = solve(
+                solutions = solve(
                     T_target, q_seed=q_current, max_solutions=1,
                 )
             """
@@ -869,7 +871,7 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
                 for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
             ]
-            return solutions, len(solutions) == 0
+            return solutions
         '''
     )
 
@@ -986,13 +988,13 @@ def _render_header(module_name: str, arm_label: str, plan: DispatchPlan, kb: Kin
             import numpy as np
             T_target = np.eye(4)  # 4x4 SE(3) pose
             T_target[:3, 3] = [0.5, 0.1, 0.3]
-            solutions, is_ls = {module_name}.solve(T_target)
+            solutions = {module_name}.solve(T_target)
             for sol in solutions:
                 print(sol.q, sol.fk_residual)
 
-        ``solve(T)`` returns ``(list[Solution], is_ls)``. ``is_ls=True``
-        signals that no solution closed within the solver's FK tolerance,
-        and the returned list is the best-LS approximation (or empty).
+        ``solve(T)`` returns ``list[Solution]``. Empty list iff no
+        candidate closed within the solver's FK tolerance -- check
+        ``if not solutions:`` for the "unreachable" case.
         """'''
     )
 
@@ -1076,7 +1078,7 @@ def _render_solve_function(solver_short: str) -> str:
             allow_refinement: bool = False,
             refinement_max_iters: int = 15,
         ):
-            \"\"\"Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+            \"\"\"Inverse kinematics. Returns ``list[Solution]``.
 
             :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
             :param policy: tolerance policy. Pass a custom
@@ -1091,22 +1093,23 @@ def _render_solve_function(solver_short: str) -> str:
                 kinematic singularities).
             :param refinement_max_iters: cap on Newton iterations per
                 candidate when ``allow_refinement=True``.
-            :returns: ``(solutions, is_ls)``. Each ``solution.q`` is a joint
-                vector matching the source URDF's joint ordering;
-                ``solution.fk_residual`` reports closure against
-                ``T_target``. ``is_ls=True`` iff the algebraic path produced
-                no candidate meeting the FK tolerance -- callers wanting
-                only "exact" solutions check ``is_ls`` and discard.
+            :returns: list of :class:`Solution`, one per analytical IK
+                branch. Each ``solution.q`` is a joint vector matching
+                the source URDF's joint ordering; ``solution.fk_residual``
+                reports closure against ``T_target``. Empty list iff no
+                candidate met the FK tolerance -- check ``if not sols:``
+                for the "unreachable target" case.
 
             Solver: {solver_short}.
             \"\"\"
-            return _solver_solve(
+            sols, _is_ls = _solver_solve(
                 _KB,
                 T_target,
                 policy=policy,
                 allow_refinement=allow_refinement,
                 refinement_max_iters=refinement_max_iters,
             )
+            return sols
         """
     )
 

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -482,7 +482,7 @@ def _render_specialised_solve_orchestrator() -> str:
             max_solutions: int | None = None,
             q_seed=None,
             respect_limits: bool = True,
-            allow_refinement: bool = True,
+            allow_refinement: bool = False,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
         ):
@@ -500,11 +500,13 @@ def _render_specialised_solve_orchestrator() -> str:
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. Pass ``False`` for
                 the raw geometric set (e.g. analysis / debugging).
-            :param allow_refinement: when ``True`` (default), Newton polish
-                fires on near-miss algebraic candidates that don't quite
-                meet ``fk_atol``. Tightens FK closure to machine precision
-                at ~100-300 us per polished branch. Set ``False`` for
-                pure algebraic results.
+            :param allow_refinement: opt into Newton polish for near-miss
+                algebraic candidates that don't quite meet ``fk_atol``.
+                Default ``False`` -- the algebraic path is already at
+                machine precision on tier-0 / SRS arms. On tier-2 RR
+                arms (JACO 2, Rizon 4, Kassow), polish can recover
+                edge-case candidates whose algebraic FK drifts above
+                ``fk_atol``, at ~100-300 us per polished branch.
             :param policy: tolerance policy (FK closure + dedup tolerance).
                 Rarely customised.
             :param refinement_max_iters: cap on Newton iterations per
@@ -807,7 +809,7 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             max_solutions: int | None = None,
             q_seed=None,
             respect_limits: bool = True,
-            allow_refinement: bool = True,
+            allow_refinement: bool = False,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
         ):
@@ -846,15 +848,14 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
             """
             T = np.asarray(T_target, dtype=np.float64)
-            # When ``respect_limits=True``, don't short-circuit the
-            # lock-sweep on ``max_solutions``: the first-found valid IK
-            # might be out-of-limits and the postprocess pass would drop
-            # it, leaving zero results. Run the full sweep, then filter
-            # + trim. The user can recover the early-exit speed by
-            # passing ``respect_limits=False``.
-            sweep_max = None if respect_limits else max_solutions
+            # Lock-sweep filters limits in-flight (#238 review): the
+            # short-circuit fires on the first in-limits valid IK, not
+            # on a candidate that postprocess would drop. Preserves the
+            # max_solutions+q_seed early-exit fast path even with
+            # respect_limits=True.
             candidates = _solve_algebraic(
-                T, max_solutions=sweep_max, q_seed=q_seed
+                T, max_solutions=max_solutions, q_seed=q_seed,
+                respect_limits=respect_limits,
             )
 
             fk_atol = policy.subproblem_numerical
@@ -911,13 +912,10 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
                 for q, residual, ref_used, _ref_iters in deduped
             ]
-            # respect_limits before max_solutions trim, so the truncation
-            # picks from the in-limits set (not the raw set where the
-            # closest-to-seed branch might be out-of-limits and would
-            # silently disappear -- #238 review finding).
-            if respect_limits:
-                solutions = _ps_wrap_to_limits(solutions, _KB)
-                solutions = _ps_respect_limits(solutions, _KB)
+            # No orchestrator-level respect_limits pass: the inner
+            # ``_solve_algebraic`` already filtered in-flight when
+            # respect_limits=True, so candidates here are guaranteed
+            # in-limits. The cap on max_solutions also ran inside.
             if max_solutions is not None and len(solutions) > max_solutions:
                 solutions = solutions[:max_solutions]
             return solutions
@@ -1126,7 +1124,7 @@ def _render_solve_function(solver_short: str) -> str:
             max_solutions=None,
             q_seed=None,
             respect_limits: bool = True,
-            allow_refinement: bool = True,
+            allow_refinement: bool = False,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
         ):

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -160,6 +160,11 @@ def _render_thin_wrapper(
     buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
     buf.write("from ssik.core.solution import Solution\n")
     buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
+    buf.write("from ssik.postprocess import (\n")
+    buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
+    buf.write("    respect_limits as _ps_respect_limits,\n")
+    buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
+    buf.write(")\n")
     buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -172,7 +177,7 @@ def _render_thin_wrapper(
     buf.write(_render_kinbody_builder())
     buf.write("\n")
     buf.write(_render_solve_function(solver_short))
-    buf.write("\n")
+    buf.write(_render_fk_function_from_kb())
     buf.write(_render_all_export())
     return buf.getvalue()
 
@@ -218,6 +223,11 @@ def _render_specialised(
     # only refinement primitive imported from runtime is the generic
     # Levenberg-Marquardt step.
     buf.write("from ssik.refinement import lm_refine as _lm_refine\n")
+    buf.write("from ssik.postprocess import (\n")
+    buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
+    buf.write("    respect_limits as _ps_respect_limits,\n")
+    buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
+    buf.write(")\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -241,7 +251,7 @@ def _render_specialised(
         buf.write(_render_specialised_solve_orchestrator_7r())
     else:
         buf.write(_render_specialised_solve_orchestrator())
-    buf.write("\n")
+    buf.write(_render_fk_alias())
     buf.write(_render_all_export())
     return buf.getvalue()
 
@@ -468,21 +478,39 @@ def _render_specialised_solve_orchestrator() -> str:
         def solve(
             T_target,
             *,
+            max_solutions: int | None = None,
+            q_seed=None,
+            respect_limits: bool = True,
+            allow_refinement: bool = True,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-            allow_refinement: bool = False,
             refinement_max_iters: int = 15,
         ):
             """Inverse kinematics. Returns ``list[Solution]``.
 
             :param T_target: 4x4 SE(3) target end-effector pose.
+            :param max_solutions: optional cap on returned IKs (post-dedup,
+                post-limits filter). ``None`` = full redundancy enumeration.
+                Combine with ``q_seed`` for the "give me the IK closest to
+                where I am now" trajectory-tracking idiom.
+            :param q_seed: optional joint configuration. When provided,
+                returned solutions are sorted by wrap-to-pi distance from
+                ``q_seed`` (closest first). Has no effect on which solutions
+                are returned, only their order.
+            :param respect_limits: when ``True`` (default), solutions
+                outside URDF joint limits are dropped. Pass ``False`` for
+                the raw geometric set (e.g. analysis / debugging).
+            :param allow_refinement: when ``True`` (default), Newton polish
+                fires on near-miss algebraic candidates that don't quite
+                meet ``fk_atol``. Tightens FK closure to machine precision
+                at ~100-300 us per polished branch. Set ``False`` for
+                pure algebraic results.
             :param policy: tolerance policy (FK closure + dedup tolerance).
-            :param allow_refinement: opt into Newton-on-spatial-Jacobian
-                polish for near-miss candidates (those whose algebraic q
-                doesn't quite meet ``fk_atol``). Default off.
+                Rarely customised.
             :param refinement_max_iters: cap on Newton iterations per
                 candidate when ``allow_refinement=True``.
             :returns: list of :class:`Solution`; empty list iff no IK
-                closed within ``policy.subproblem_numerical``.
+                closed within ``policy.subproblem_numerical`` (or all
+                IKs were filtered by ``respect_limits=True``).
             """
             T = np.asarray(T_target, dtype=np.float64)
             candidates = _solve_algebraic(T)
@@ -541,6 +569,20 @@ def _render_specialised_solve_orchestrator() -> str:
                 )
                 for q, residual, ref_used, _ref_iters in deduped
             ]
+
+            # Post-processing pass (#238 item 4). Order matters:
+            #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
+            #      candidates into the URDF's limit range
+            #   2. respect_limits drops anything still outside
+            #   3. nearest_to_seed sorts by distance to q_seed (if given)
+            #   4. max_solutions truncates to the first k
+            if respect_limits:
+                solutions = _ps_wrap_to_limits(solutions, _KB)
+                solutions = _ps_respect_limits(solutions, _KB)
+            if q_seed is not None:
+                solutions = _ps_nearest_to_seed(solutions, q_seed)
+            if max_solutions is not None and len(solutions) > max_solutions:
+                solutions = solutions[:max_solutions]
             return solutions
         '''
     )
@@ -761,30 +803,33 @@ def _render_specialised_solve_orchestrator_7r() -> str:
         def solve(
             T_target,
             *,
-            policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-            allow_refinement: bool = False,
-            refinement_max_iters: int = 15,
             max_solutions: int | None = None,
             q_seed=None,
+            respect_limits: bool = True,
+            allow_refinement: bool = True,
+            policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+            refinement_max_iters: int = 15,
         ):
-            """Inverse kinematics. Returns ``(list[Solution], is_ls)``.
+            """Inverse kinematics. Returns ``list[Solution]``.
 
             :param T_target: 4x4 SE(3) target end-effector pose.
-            :param policy: tolerance policy (FK closure + dedup tolerance).
-            :param allow_refinement: opt into Newton-on-spatial-Jacobian
-                polish for near-miss candidates (those whose algebraic q
-                doesn't quite meet ``fk_atol``). Default off.
-            :param refinement_max_iters: cap on Newton iterations per
-                candidate when ``allow_refinement=True``.
             :param max_solutions: optional early-exit cap on the
                 jointlock lock-sweep. ``None`` (default) = exhaustive
                 search. ``max_solutions=1`` short-circuits as soon as
-                one valid IK is found (~17x faster on Franka 7R).
+                one valid IK is found (~17x faster on this 7R).
             :param q_seed: optional length-7 seed configuration. When
                 provided, the lock-joint samples are visited in order
                 of wrap-to-pi distance to ``q_seed[lock_idx]`` --
                 combined with ``max_solutions=1`` this is the
-                trajectory-tracking fast path (~37x faster on Franka).
+                trajectory-tracking fast path.
+            :param respect_limits: when ``True`` (default), solutions
+                outside URDF joint limits are dropped. Pass ``False``
+                for the raw geometric set.
+            :param allow_refinement: when ``True`` (default), Newton
+                polish fires on near-miss algebraic candidates.
+            :param policy: tolerance policy. Rarely customised.
+            :param refinement_max_iters: cap on Newton iterations per
+                candidate when ``allow_refinement=True``.
 
             Common idioms::
 
@@ -865,6 +910,9 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
                 for q, residual, ref_used, _ref_iters in deduped
             ]
+            if respect_limits:
+                solutions = _ps_wrap_to_limits(solutions, _KB)
+                solutions = _ps_respect_limits(solutions, _KB)
             return solutions
         '''
     )
@@ -1068,31 +1116,34 @@ def _render_solve_function(solver_short: str) -> str:
         def solve(
             T_target,
             *,
+            max_solutions=None,
+            q_seed=None,
+            respect_limits: bool = True,
+            allow_refinement: bool = True,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-            allow_refinement: bool = False,
             refinement_max_iters: int = 15,
         ):
             \"\"\"Inverse kinematics. Returns ``list[Solution]``.
 
             :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
-            :param policy: tolerance policy. Pass a custom
-                :class:`ssik.TolerancePolicy` to tighten or relax the
-                FK-closure threshold (``subproblem_numerical``), the
-                axis-parallel / axis-intersect predicates, etc. Defaults to
-                :data:`ssik.DEFAULT_TOLERANCE_POLICY`.
-            :param allow_refinement: opt into Newton-on-spatial-Jacobian
-                polish for near-miss algebraic candidates. Default ``False``;
-                turn on to recover candidates that don't quite meet
-                ``policy.subproblem_numerical`` on their own (e.g. near
-                kinematic singularities).
+            :param max_solutions: optional cap on returned IKs (post-dedup,
+                post-limits filter). ``None`` = full enumeration.
+            :param q_seed: optional joint config. When provided, solutions
+                are sorted by wrap-to-pi distance from ``q_seed`` (closest
+                first). Combine with ``max_solutions=1`` for the
+                trajectory-tracking idiom.
+            :param respect_limits: when ``True`` (default), solutions
+                outside URDF joint limits are dropped. ``False`` returns
+                the raw geometric set.
+            :param allow_refinement: when ``True`` (default), Newton polish
+                fires on near-miss algebraic candidates. Tightens FK
+                closure to machine precision.
+            :param policy: tolerance policy. Rarely customised.
             :param refinement_max_iters: cap on Newton iterations per
                 candidate when ``allow_refinement=True``.
             :returns: list of :class:`Solution`, one per analytical IK
-                branch. Each ``solution.q`` is a joint vector matching
-                the source URDF's joint ordering; ``solution.fk_residual``
-                reports closure against ``T_target``. Empty list iff no
-                candidate met the FK tolerance -- check ``if not sols:``
-                for the "unreachable target" case.
+                branch. Empty list iff no candidate met the FK tolerance
+                -- check ``if not sols:`` for "unreachable target".
 
             Solver: {solver_short}.
             \"\"\"
@@ -1103,6 +1154,13 @@ def _render_solve_function(solver_short: str) -> str:
                 allow_refinement=allow_refinement,
                 refinement_max_iters=refinement_max_iters,
             )
+            if respect_limits:
+                sols = _ps_wrap_to_limits(sols, _KB)
+                sols = _ps_respect_limits(sols, _KB)
+            if q_seed is not None:
+                sols = _ps_nearest_to_seed(sols, q_seed)
+            if max_solutions is not None and len(sols) > max_solutions:
+                sols = sols[:max_solutions]
             return sols
         """
     )
@@ -1116,6 +1174,31 @@ def _render_all_export() -> str:
         '\n    "FLOP_BUDGET",'
         '\n    "SOLVER_NAME",'
         '\n    "SOLVER_TIER",'
+        '\n    "fk",'
         '\n    "solve",'
         "\n]\n"
+    )
+
+
+def _render_fk_alias() -> str:
+    """Specialised templates already define ``_fk``; expose it publicly
+    so callers can do ``arm_ik.fk(q)`` instead of the private mangled
+    name."""
+    return "\nfk = _fk\n"
+
+
+def _render_fk_function_from_kb() -> str:
+    """For thin-wrapper templates that don't bake FK themselves
+    (``seven_r.srs``, ``seven_r.srs_polished``): build a public
+    ``fk(q)`` from the baked ``_KB`` using runtime POE FK."""
+    return textwrap.dedent(
+        """\
+
+        from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
+
+
+        def fk(q):
+            \"\"\"Forward kinematics: returns the 4x4 base->ee pose at ``q``.\"\"\"
+            return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
+        """
     )

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -538,11 +538,8 @@ def _render_specialised_solve_orchestrator() -> str:
                     q=q,
                     fk_residual=residual,
                     refinement_used=ref_used,
-                    refinement_iters=ref_iters,
-                    branch_id=i,
-                    solver_name=SOLVER_NAME,
                 )
-                for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+                for q, residual, ref_used, _ref_iters in deduped
             ]
             return solutions
         '''
@@ -865,11 +862,8 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                     q=q,
                     fk_residual=residual,
                     refinement_used=ref_used,
-                    refinement_iters=ref_iters,
-                    branch_id=i,
-                    solver_name=SOLVER_NAME,
                 )
-                for i, (q, residual, ref_used, ref_iters) in enumerate(deduped)
+                for q, residual, ref_used, _ref_iters in deduped
             ]
             return solutions
         '''

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -4,11 +4,12 @@ wraps the dispatched solver around baked KinBody constants.
 The emitted artifact is a single ``.py`` file with a stable public API:
 
     >>> import ur5_ik
-    >>> solutions, is_ls = ur5_ik.solve(T_target)
+    >>> solutions = ur5_ik.solve(T_target, max_solutions=1, q_seed=q_current)
+    >>> T = ur5_ik.fk(q)
 
 Internals: the emitted module imports the chosen ssik solver, reconstructs
 the POE-normalised :class:`KinBody` from baked numpy literals at import
-time, and exports ``solve(T) -> (list[Solution], bool)`` plus
+time, and exports ``solve(T) -> list[Solution]``, ``fk(q) -> NDArray``, plus
 ``SOLVER_NAME`` and ``DISPATCH_REASON`` constants for diagnostic visibility.
 
 This iteration emits source that has ``ssik`` as a runtime dependency. The
@@ -845,8 +846,15 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
             """
             T = np.asarray(T_target, dtype=np.float64)
+            # When ``respect_limits=True``, don't short-circuit the
+            # lock-sweep on ``max_solutions``: the first-found valid IK
+            # might be out-of-limits and the postprocess pass would drop
+            # it, leaving zero results. Run the full sweep, then filter
+            # + trim. The user can recover the early-exit speed by
+            # passing ``respect_limits=False``.
+            sweep_max = None if respect_limits else max_solutions
             candidates = _solve_algebraic(
-                T, max_solutions=max_solutions, q_seed=q_seed
+                T, max_solutions=sweep_max, q_seed=q_seed
             )
 
             fk_atol = policy.subproblem_numerical
@@ -895,13 +903,6 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 elif cand_res < deduped[dup_idx][1]:
                     deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
 
-            # Final trim: the underlying lock-sweep already capped at
-            # ``max_solutions`` (under #142), but verify+dedup may have
-            # collapsed near-duplicates so ``len(deduped)`` can also be
-            # smaller. Trimming here is the defensive belt-and-braces.
-            if max_solutions is not None and len(deduped) > max_solutions:
-                deduped = deduped[:max_solutions]
-
             solutions = [
                 Solution(
                     q=q,
@@ -910,9 +911,15 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 )
                 for q, residual, ref_used, _ref_iters in deduped
             ]
+            # respect_limits before max_solutions trim, so the truncation
+            # picks from the in-limits set (not the raw set where the
+            # closest-to-seed branch might be out-of-limits and would
+            # silently disappear -- #238 review finding).
             if respect_limits:
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
+            if max_solutions is not None and len(solutions) > max_solutions:
+                solutions = solutions[:max_solutions]
             return solutions
         '''
     )

--- a/src/ssik/core/solution.py
+++ b/src/ssik/core/solution.py
@@ -1,21 +1,21 @@
 """Standardized solver return type.
 
-Every ssik solver returns ``list[Solution]`` (paired with an ``is_ls`` flag for
-the "no candidate survived" case). The :class:`Solution` dataclass carries
-both the joint vector AND the diagnostics callers need to reason about
-precision and refinement:
+The public :class:`Solution` dataclass carries the joint vector and just
+enough provenance for the caller to reason about precision:
 
-- ``fk_residual`` says what FK closure was actually achieved at return time
-  -- not the user's tolerance, the actual measurement.
-- ``refinement_used`` says whether numerical refinement fired. Closed-form
-  solvers (Pieper, three-parallel, etc.) always have ``"none"``. Numeric
-  solvers (Raghavan-Roth, Husty-Pfurner) report ``"lm"`` when
-  :func:`ssik.refinement.lm_refine` polished the algebraic candidate.
-- ``branch_id`` and ``solver_name`` let callers distinguish parallel
-  branches and identify which dispatched solver produced the result.
+- ``q`` is the joint configuration; length matches the chain's DOF.
+- ``fk_residual`` reports the actual FK closure -- not the user's
+  tolerance, the measured value.
+- ``refinement_used`` reports whether numerical polish fired (``"lm"``
+  vs ``"none"``). Closed-form solvers are always ``"none"``; numeric
+  solvers (Raghavan-Roth, Husty-Pfurner) may polish near-miss candidates
+  when ``allow_refinement=True``.
 
-See GitHub #74 (refinement architecture) and #75 (Solution dataclass) for
-the design decisions.
+Which solver produced the result is a per-arm fact, available via
+``Manipulator.solver_name`` or the artifact's ``SOLVER_NAME`` constant
+-- not per-solution. Branch-index and refinement-iter counters were
+removed in v1.0 as debug noise; users wanting them can inspect the
+dispatched solver's internals directly.
 """
 
 from __future__ import annotations
@@ -33,30 +33,18 @@ RefinementMode = Literal["none", "lm"]
 
 @dataclass(frozen=True)
 class Solution:
-    """A single IK solution with provenance and precision metadata.
+    """A single analytical IK solution.
 
-    :param q: Joint-angle vector. Length matches the chain's DOF.
+    :param q: joint-angle vector. Length matches the chain's DOF.
     :param fk_residual: ``||FK(q) - T_target||_F`` at the moment the solver
         returned the candidate. The caller can compare against any target
         tolerance; the solver's own ``fk_atol`` was a *filter*, not a
         contract on the value reported here.
     :param refinement_used: ``"none"`` if the solution came directly from
-        the algebraic / closed-form path; ``"lm"`` if
-        :func:`ssik.refinement.lm_refine` polished it.
-    :param refinement_iters: number of refinement iterations consumed
-        (``0`` if ``refinement_used == "none"``).
-    :param branch_id: optional IK-branch identifier for solvers that
-        enumerate multiple branches per call (e.g. 0..15 for the 16-root
-        Raghavan-Roth route, 0..7 for spherical-wrist + parallel-shoulder).
-        ``None`` when the solver doesn't expose a stable branch index.
-    :param solver_name: dotted module path (``"ikgeo.general_6r"``,
-        ``"ikgeo.spherical_two_parallel"``, ...). Useful when results pass
-        through a dispatcher that routes across multiple solver candidates.
+        the algebraic / closed-form path; ``"lm"`` if Levenberg-Marquardt
+        refinement polished it (when ``allow_refinement=True``).
     """
 
     q: NDArray[np.float64]
     fk_residual: float
     refinement_used: RefinementMode = "none"
-    refinement_iters: int = 0
-    branch_id: int | None = None
-    solver_name: str = ""

--- a/src/ssik/internals/__init__.py
+++ b/src/ssik/internals/__init__.py
@@ -1,0 +1,41 @@
+"""Contributor / debugging surface for ssik.
+
+The names re-exported here are stable enough for advanced users
+(``KinBody`` for hand-built fixtures, ``dispatch`` + ``describe_topology``
+for inspection, ``build_kinbody`` for the spec-driven fixture path) but
+aren't part of the v1.0 user-facing API. Promotion to the top-level
+``ssik`` namespace requires the change to land behind a documented
+deprecation cycle.
+
+Examples::
+
+    from ssik.internals import KinBody, build_kinbody, dispatch
+
+    # Hand-build a KinBody from per-arm specs (rather than URDF parsing)
+    kb = build_kinbody(my_arm_specs())
+
+    # Inspect topology without dispatching IK
+    from ssik.internals import describe_topology
+    print(describe_topology(kb))
+
+    # Pick the solver explicitly (advanced)
+    from ssik.internals import dispatch
+    plan = dispatch(kb)
+    print(plan.solver_name, plan.tier)
+"""
+
+from ssik._kinbody import Joint, JointSpec, KinBody, Link, build_kinbody
+from ssik.core.dispatcher import DispatchPlan, dispatch
+from ssik.core.topology import TopologyReport, describe_topology
+
+__all__ = [
+    "DispatchPlan",
+    "Joint",
+    "JointSpec",
+    "KinBody",
+    "Link",
+    "TopologyReport",
+    "build_kinbody",
+    "describe_topology",
+    "dispatch",
+]

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -220,7 +220,7 @@ class Manipulator:
         max_solutions: int | None = None,
         q_seed: ArrayLike | None = None,
         respect_limits: bool = True,
-        allow_refinement: bool = True,
+        allow_refinement: bool = False,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
         **solver_kwargs: Any,
@@ -240,9 +240,11 @@ class Manipulator:
         :param respect_limits: when ``True`` (default), solutions outside
             URDF joint limits are dropped. Pass ``False`` for the raw
             geometric set (analysis / debugging).
-        :param allow_refinement: when ``True`` (default), Newton polish
-            fires on near-miss algebraic candidates. Tightens FK closure
-            to machine precision at ~100-300 us per polished branch.
+        :param allow_refinement: opt into Newton polish for near-miss
+            algebraic candidates. Default ``False`` -- the algebraic
+            path is already at machine precision on tier-0 / SRS arms.
+            Set ``True`` on tier-2 RR arms to recover edge-case
+            candidates whose algebraic FK drifts above ``fk_atol``.
         :param policy: tolerance policy. Rarely customised. Defaults to
             :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
         :param refinement_max_iters: cap on Newton iterations per candidate

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -213,7 +213,7 @@ class Manipulator:
     # Inverse kinematics
     # ------------------------------------------------------------------
 
-    def ik(
+    def solve(
         self,
         T_target: ArrayLike,
         *,
@@ -223,8 +223,8 @@ class Manipulator:
         allow_refinement: bool = False,
         refinement_max_iters: int = 15,
         **solver_kwargs: Any,
-    ) -> tuple[list[Solution], bool]:
-        """Inverse kinematics: find ``q`` such that ``fk(q) ≈ T_target``.
+    ) -> list[Solution]:
+        """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
 
         :param T_target: 4x4 SE(3) target pose.
         :param max_solutions: optional cap on returned IKs. ``None`` = full
@@ -253,16 +253,17 @@ class Manipulator:
             etc.). Unknown kwargs raise :class:`TypeError` from the
             underlying solver.
 
-        :returns: ``(solutions, is_ls)``. ``is_ls=True`` iff no candidate
-            FK-closed within ``policy.subproblem_numerical``; the returned
-            list is then either a single best-LS approximation or empty.
+        :returns: list of :class:`Solution`, one per analytical IK branch.
+            Empty list iff no candidate FK-closed within
+            ``policy.subproblem_numerical``. Check ``if not sols:`` for the
+            "unreachable target" case.
 
         :raises ValueError: if ``T_target.shape != (4, 4)`` or
             ``len(q_seed) != dof`` when ``q_seed`` is given.
         """
         T = np.asarray(T_target, dtype=np.float64)
         if T.shape != (4, 4):
-            raise ValueError(f"ik expected T_target of shape (4, 4), got {T.shape}")
+            raise ValueError(f"solve expected T_target of shape (4, 4), got {T.shape}")
         if q_seed is not None:
             q_seed_arr: NDArray[np.float64] | None = np.asarray(q_seed, dtype=np.float64)
             assert q_seed_arr is not None
@@ -290,5 +291,8 @@ class Manipulator:
         # Power-user kwargs override our defaults.
         kwargs.update(solver_kwargs)
 
-        result: tuple[list[Solution], bool] = self._solver_module.solve(self._kb, T, **kwargs)
-        return result
+        # Internal solver functions still return (sols, is_ls); unwrap the
+        # tuple at the public-API boundary. `is_ls` is redundant with
+        # `len(sols) == 0` in every shipped solver -- ssik #238 item 1.
+        sols, _is_ls = self._solver_module.solve(self._kb, T, **kwargs)
+        return sols

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -13,13 +13,13 @@ Example::
         "tests/fixtures/ur5.urdf", base="base_link", ee="ee_link"
     )
     T = arm.fk([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
-    sols, is_ls = arm.ik(T)
-    # sols is a list[Solution]; is_ls=True signals no candidate FK-closed
-    # within tolerance.
+    sols = arm.solve(T, max_solutions=1, q_seed=q_prev)
+    # sols is a list[Solution]; empty iff no IK closed within tolerance.
 
-The class is intentionally tiny: factory + fk + ik + a handful of properties.
-Power users who need solver-specific knobs pass them via ``solver_kwargs``;
-power users who need the underlying :class:`KinBody` can reach :attr:`kinbody`.
+The class is intentionally tiny: factory + fk + solve + a handful of
+properties. Power users who need solver-specific knobs pass them via
+``solver_kwargs``; power users who need the underlying :class:`KinBody`
+can reach :attr:`kinbody`.
 """
 
 from __future__ import annotations
@@ -287,8 +287,13 @@ class Manipulator:
             kwargs["allow_refinement"] = allow_refinement
         if "refinement_max_iters" in params:
             kwargs["refinement_max_iters"] = refinement_max_iters
+        # When respect_limits=True, don't short-circuit the inner solver's
+        # sweep on max_solutions: the closest-to-seed branch the solver
+        # picks first may be out-of-limits and the postprocess pass would
+        # drop it, leaving zero results. Force the full sweep, then
+        # filter + trim. The user opts out via respect_limits=False.
         if "max_solutions" in params:
-            kwargs["max_solutions"] = max_solutions
+            kwargs["max_solutions"] = None if respect_limits else max_solutions
         if q_seed_arr is not None and "q_seed" in params:
             kwargs["q_seed"] = q_seed_arr
         # Power-user kwargs override our defaults.

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -219,48 +219,51 @@ class Manipulator:
         *,
         max_solutions: int | None = None,
         q_seed: ArrayLike | None = None,
+        respect_limits: bool = True,
+        allow_refinement: bool = True,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
-        allow_refinement: bool = False,
         refinement_max_iters: int = 15,
         **solver_kwargs: Any,
     ) -> list[Solution]:
         """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
 
         :param T_target: 4x4 SE(3) target pose.
-        :param max_solutions: optional cap on returned IKs. ``None`` = full
-            redundancy enumeration. ``1`` is the trajectory-tracking
-            "give me any IK" mode (typically 10-15x faster than full sweep
-            on 7R arms). The cap is honored at every layer of the dispatch
-            stack -- the inner solvers stop branch enumeration as soon as
-            ``max_solutions`` deduplicated IKs are found.
-        :param q_seed: optional length-:attr:`dof` seed configuration. When
-            supported by the dispatched solver (currently
-            :mod:`ssik.solvers.jointlock.seven_r`), ``q_seed`` reorders the
-            internal lock-sample sweep so the closest-to-seed sample fires
-            first; combined with ``max_solutions=1`` this is the canonical
-            trajectory-tracking idiom. Solvers that don't accept ``q_seed``
-            silently ignore it.
-        :param policy: tolerance policy. Defaults to
+        :param max_solutions: optional cap on returned IKs (post-dedup,
+            post-limits filter). ``None`` = full redundancy enumeration.
+            ``1`` combined with ``q_seed`` is the trajectory-tracking idiom.
+            On 7R jointlock arms the cap also short-circuits the lock-sweep
+            internally for a 10-15x speedup.
+        :param q_seed: optional length-:attr:`dof` seed. When provided,
+            returned solutions are sorted by wrap-to-pi distance from
+            ``q_seed`` (closest first). On jointlock-7R arms it also
+            reorders the internal lock-sample sweep.
+        :param respect_limits: when ``True`` (default), solutions outside
+            URDF joint limits are dropped. Pass ``False`` for the raw
+            geometric set (analysis / debugging).
+        :param allow_refinement: when ``True`` (default), Newton polish
+            fires on near-miss algebraic candidates. Tightens FK closure
+            to machine precision at ~100-300 us per polished branch.
+        :param policy: tolerance policy. Rarely customised. Defaults to
             :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
-        :param allow_refinement: opt into Newton-on-spatial-Jacobian polish
-            for candidates that don't FK-close algebraically. Default off;
-            the analytical path is exact for well-conditioned poses.
         :param refinement_max_iters: cap on Newton iterations per candidate
             when ``allow_refinement=True``.
-        :param solver_kwargs: forwarded verbatim to the dispatched solver's
-            ``solve()`` for power users who need solver-specific knobs
-            (``swivel_samples`` for SRS-class, ``linearity_joint`` for RR,
-            etc.). Unknown kwargs raise :class:`TypeError` from the
-            underlying solver.
+        :param solver_kwargs: forwarded verbatim to the dispatched solver
+            for power users (``swivel_samples`` for SRS-class,
+            ``linearity_joint`` for RR, etc.).
 
         :returns: list of :class:`Solution`, one per analytical IK branch.
             Empty list iff no candidate FK-closed within
-            ``policy.subproblem_numerical``. Check ``if not sols:`` for the
-            "unreachable target" case.
+            ``policy.subproblem_numerical`` (or all IKs were filtered by
+            ``respect_limits=True``). Check ``if not sols:`` for
+            "unreachable target".
 
         :raises ValueError: if ``T_target.shape != (4, 4)`` or
             ``len(q_seed) != dof`` when ``q_seed`` is given.
         """
+        from ssik.postprocess import nearest_to_seed as _ps_nearest_to_seed
+        from ssik.postprocess import respect_limits as _ps_respect_limits
+        from ssik.postprocess import wrap_to_limits as _ps_wrap_to_limits
+
         T = np.asarray(T_target, dtype=np.float64)
         if T.shape != (4, 4):
             raise ValueError(f"solve expected T_target of shape (4, 4), got {T.shape}")
@@ -295,4 +298,19 @@ class Manipulator:
         # tuple at the public-API boundary. `is_ls` is redundant with
         # `len(sols) == 0` in every shipped solver -- ssik #238 item 1.
         sols, _is_ls = self._solver_module.solve(self._kb, T, **kwargs)
+
+        # Cross-arm postprocess pass: solvers that didn't honour kwargs
+        # natively get them applied here so the public API is uniform.
+        # Order: wrap_to_limits first (try +/- 2pi shift to bring branches
+        # into the URDF range), THEN respect_limits (drop anything still
+        # outside). Without the shift, IKs returned in [-2pi, 0] would
+        # erroneously be filtered on arms with limits in [0, 2pi]
+        # (the JACO 2 case).
+        if respect_limits:
+            sols = _ps_wrap_to_limits(sols, self._kb)
+            sols = _ps_respect_limits(sols, self._kb)
+        if q_seed_arr is not None:
+            sols = _ps_nearest_to_seed(sols, q_seed_arr)
+        if max_solutions is not None and len(sols) > max_solutions:
+            sols = sols[:max_solutions]
         return sols

--- a/src/ssik/postprocess.py
+++ b/src/ssik/postprocess.py
@@ -17,20 +17,20 @@ The four shipping with v0.1 cover ~95% of real-world post-processing:
   * :func:`respect_limits` -- drop solutions outside any joint's range
   * :func:`wrap_to_limits` -- try ``q ± 2*pi`` per joint to bring solutions in
   * :func:`nearest_to_seed` -- sort by wrap-to-pi distance to a reference q
-  * :func:`max_solutions` -- truncate to the first ``k``
+  * :func:`take_first` -- truncate to the first ``k``
 
 Production pipeline pattern::
 
     from franka_panda_ik import _KB, solve
     from ssik.postprocess import (
-        respect_limits, wrap_to_limits, nearest_to_seed, max_solutions,
+        respect_limits, wrap_to_limits, nearest_to_seed, take_first,
     )
 
-    sols, _ = solve(T_target)
+    sols = solve(T_target, respect_limits=False)
     sols = wrap_to_limits(sols, _KB)
     sols = respect_limits(sols, _KB)
     sols = nearest_to_seed(sols, q_current)
-    sols = max_solutions(sols, k=4)
+    sols = take_first(sols, k=4)
 
 Out of scope for v0.1 (separate issues / future work):
 
@@ -54,9 +54,9 @@ from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 
 __all__ = [
-    "max_solutions",
     "nearest_to_seed",
     "respect_limits",
+    "take_first",
     "wrap_to_limits",
 ]
 
@@ -190,11 +190,16 @@ def nearest_to_seed(
     return sorted(sols, key=distance)
 
 
-def max_solutions(sols: list[Solution], k: int) -> list[Solution]:
+def take_first(sols: list[Solution], k: int) -> list[Solution]:
     """Truncate to the first ``k`` solutions.
 
     Use after :func:`nearest_to_seed` (or any other ranking) to keep only
     the top-``k`` matches. ``k <= 0`` returns an empty list.
+
+    Renamed from ``max_solutions`` in v1.0 to avoid name collision with
+    the ``max_solutions`` kwarg on ``Manipulator.solve`` / artifact
+    ``solve()`` -- they have different shapes (kwarg is an int passed in;
+    this function takes ``(sols, k)``).
 
     :param sols: candidate solutions, typically already sorted.
     :param k: maximum number of solutions to keep.

--- a/src/ssik/refinement/__init__.py
+++ b/src/ssik/refinement/__init__.py
@@ -792,7 +792,7 @@ def verify_candidates(
     fk_fn: Callable[[NDArray[np.float64]], NDArray[np.float64]],
     t_target: NDArray[np.float64],
     fk_atol: float,
-    solver_name: str,
+    solver_name: str = "",  # accepted for back-compat; v1.0 drops it from Solution
     dedup_atol: float | None = None,
     allow_refinement: bool = False,
     refinement_max_iters: int = 15,
@@ -850,9 +850,6 @@ def verify_candidates(
                     q=q,
                     fk_residual=fk_resid,
                     refinement_used="none",
-                    refinement_iters=0,
-                    branch_id=branch_idx,
-                    solver_name=solver_name,
                 )
             )
             appended = True
@@ -866,15 +863,12 @@ def verify_candidates(
                 jacobian_fn=jacobian_fn,
             )
             if refined is not None:
-                q_ref, resid, iters = refined
+                q_ref, resid, _iters = refined
                 verified.append(
                     Solution(
                         q=q_ref,
                         fk_residual=resid,
                         refinement_used="lm",
-                        refinement_iters=iters,
-                        branch_id=branch_idx,
-                        solver_name=solver_name,
                     )
                 )
                 appended = True

--- a/src/ssik/solvers/ikgeo/_raghavan_roth.py
+++ b/src/ssik/solvers/ikgeo/_raghavan_roth.py
@@ -1727,9 +1727,6 @@ def solve_all_ik(
                     q=q_cand,
                     fk_residual=fk_err_alg,
                     refinement_used="none",
-                    refinement_iters=0,
-                    branch_id=branch_idx,
-                    solver_name=solver_name,
                 )
             )
             appended = True
@@ -1744,15 +1741,12 @@ def solve_all_ik(
                 jacobian_fn=jacobian_fn,
             )
             if refined is not None:
-                q_refined, fk_resid, iters = refined
+                q_refined, fk_resid, _iters = refined
                 candidates.append(
                     Solution(
                         q=q_refined,
                         fk_residual=fk_resid,
                         refinement_used="lm",
-                        refinement_iters=iters,
-                        branch_id=branch_idx,
-                        solver_name=solver_name,
                     )
                 )
                 appended = True

--- a/src/ssik/solvers/ikgeo/general_6r.py
+++ b/src/ssik/solvers/ikgeo/general_6r.py
@@ -125,9 +125,6 @@ def solve(
                 q=q,
                 fk_residual=inner.fk_residual,
                 refinement_used=inner.refinement_used,
-                refinement_iters=inner.refinement_iters,
-                branch_id=inner.branch_id,
-                solver_name=_SOLVER_NAME,
             )
         )
 

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -592,9 +592,6 @@ def solve(
                     q=full_q,
                     fk_residual=inner.fk_residual,
                     refinement_used=inner.refinement_used,
-                    refinement_iters=inner.refinement_iters,
-                    branch_id=sample_idx,
-                    solver_name=_SOLVER_NAME,
                 )
             )
         # Incremental dedup so we know how many *unique* solutions we

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -474,11 +474,11 @@ def solve(
         the codegen-time topology probe (#142 item 4); manual callers
         leave ``None``.
     :returns: ``(solutions, is_ls)``. Each :class:`Solution.q` is a
-        7-vector including the locked joint's value. ``branch_id``
-        encodes the lock-sample index in the order they were *evaluated*
-        (so under ``q_seed=...`` ordering, ``branch_id=0`` is the
-        sample closest to the seed). Solutions are deduplicated in
-        wrap-to-pi joint-angle distance.
+        7-vector including the locked joint's value. Solutions are
+        deduplicated in wrap-to-pi joint-angle distance. Solutions are
+        returned in the order their lock-samples were evaluated, so
+        under ``q_seed=...`` ordering the first solution is the one
+        with lock-sample closest to the seed.
 
     Common idioms::
 

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -69,6 +69,37 @@ __all__ = ["choose_lock_joint", "solve"]
 _DEFAULT_SAMPLES = 16
 _SOLVER_NAME = "jointlock.seven_r"
 _LOG = logging.getLogger(__name__)
+_TWO_PI = 2.0 * np.pi
+
+
+def _wrap_to_limits_inplace(q: NDArray[np.float64], kb: KinBody) -> NDArray[np.float64]:
+    """Try ``q ± k*2π`` per revolute joint to bring it into URDF limits.
+    Returns the (possibly modified) ``q``; mutates in place for speed.
+    Joints with ``limits=None`` or prismatic type are left alone.
+    """
+    for i, j in enumerate(kb.joints):
+        if j.limits is None or j.joint_type != "revolute":
+            continue
+        lo, hi = j.limits
+        qi = float(q[i])
+        if lo <= qi <= hi:
+            continue
+        for k in (1, -1, 2, -2):
+            cand = qi + _TWO_PI * k
+            if lo <= cand <= hi:
+                q[i] = cand
+                break
+    return q
+
+
+def _in_limits(q: NDArray[np.float64], kb: KinBody) -> bool:
+    """Check every joint's q against the KinBody's limits."""
+    for i, j in enumerate(kb.joints):
+        if j.limits is None:
+            continue
+        if not (j.limits[0] <= float(q[i]) <= j.limits[1]):
+            return False
+    return True
 
 
 def _lock_joint(kb: KinBody, lock_idx: int, q_lock: float) -> KinBody:
@@ -430,6 +461,7 @@ def solve(
     max_solutions: int | None = None,
     q_seed: NDArray[np.float64] | None = None,
     dispatch_cache: Sequence[str] | None = None,
+    respect_limits: bool = False,
 ) -> tuple[list[Solution], bool]:
     """Analytic IK for any 7R arm via joint-locking + inner 6R solver.
 
@@ -587,6 +619,15 @@ def solve(
             full_q[:lock_idx] = sub_q[:lock_idx]
             full_q[lock_idx] = float(q_lock)
             full_q[lock_idx + 1 :] = sub_q[lock_idx:]
+            # In-sweep limits filter (#238 review). When respect_limits=True,
+            # try wrapping each joint into its limit range; drop branches
+            # that still violate. This lets the outer short-circuit fire
+            # on the first IN-LIMITS valid IK rather than waste samples on
+            # out-of-limits candidates that postprocess would drop anyway.
+            if respect_limits:
+                full_q = _wrap_to_limits_inplace(full_q, kb)
+                if not _in_limits(full_q, kb):
+                    continue
             candidates.append(
                 Solution(
                     q=full_q,

--- a/src/ssik/solvers/numerical/lm_multi_restart.py
+++ b/src/ssik/solvers/numerical/lm_multi_restart.py
@@ -156,15 +156,12 @@ def solve(
         )
         if result is None:
             continue
-        q_conv, fk_resid, iters = result
+        q_conv, fk_resid, _iters = result
         candidates.append(
             Solution(
                 q=q_conv,
                 fk_residual=fk_resid,
                 refinement_used="lm",
-                refinement_iters=iters,
-                branch_id=restart_idx,
-                solver_name=_SOLVER_NAME,
             )
         )
 

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -417,9 +417,6 @@ def solve(
                             q=q_full[i],
                             fk_residual=fk_residual,
                             refinement_used="none",
-                            refinement_iters=0,
-                            branch_id=branch_id,
-                            solver_name=_SOLVER_NAME,
                         )
                     )
                     branch_id += 1

--- a/src/ssik/solvers/seven_r/srs_polished.py
+++ b/src/ssik/solvers/seven_r/srs_polished.py
@@ -194,8 +194,6 @@ def solve(
             q=q_polished_arr[i],
             fk_residual=float(fk_residuals[i]),
             refinement_used="lm",
-            refinement_iters=int(iters_used[i]),
-            solver_name=_SOLVER_NAME,
         )
         for i, c in enumerate(raw)
         if fk_residuals[i] < polish_fk_atol

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,10 +87,9 @@ def test_build_ur5_emits_and_validates(tmp_path: Path, capsys: pytest.CaptureFix
     spec.loader.exec_module(mod)
     T = np.eye(4)
     T[:3, 3] = [0.5, 0.1, 0.3]
-    sols, is_ls = mod.solve(T)
+    sols = mod.solve(T)
     # Random free pose may or may not have a solution; just assert callable.
     assert isinstance(sols, list)
-    assert isinstance(is_ls, bool)
 
 
 def test_build_no_validate(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -137,9 +137,8 @@ def test_emit_then_import_then_roundtrip(
     for trial in range(5):
         q_star = rng.uniform(-1.0, 1.0, size=6)
         T_star = _fk_poe(kb, q_star)
-        sols_artifact, is_ls_artifact = mod.solve(T_star)
-        sols_direct, is_ls_direct = direct_solver.solve(kb, T_star)  # type: ignore[attr-defined]
-        assert is_ls_artifact == is_ls_direct, f"trial {trial}: is_ls disagrees"
+        sols_artifact = mod.solve(T_star)
+        sols_direct, _is_ls_direct = direct_solver.solve(kb, T_star)  # type: ignore[attr-defined]
         assert len(sols_artifact) == len(sols_direct), f"trial {trial}: solution count disagrees"
         for sol in sols_artifact:
             T_check = _fk_poe(kb, sol.q)
@@ -175,20 +174,20 @@ def test_artifact_solve_accepts_policy_and_refinement_kwargs(tmp_path: Path) -> 
     T_star = _fk_poe(kb, q_star)
 
     # Default call: defaults match the underlying solver's defaults.
-    _sols_default, is_ls_default = mod.solve(T_star)
-    assert not is_ls_default
+    sols_default = mod.solve(T_star)
+    assert sols_default
 
     # Custom policy: tighter FK-closure threshold; result still closes.
     strict = TolerancePolicy(subproblem_numerical=1e-9)
-    sols_strict, is_ls_strict = mod.solve(T_star, policy=strict)
-    assert not is_ls_strict
+    sols_strict = mod.solve(T_star, policy=strict)
+    assert sols_strict
     for sol in sols_strict:
         T_check = _fk_poe(kb, sol.q)
         assert np.allclose(T_check, T_star, atol=1e-8), "strict-policy result fails FK"
 
     # Newton refinement: opt-in path with cap on iterations.
-    sols_refined, is_ls_refined = mod.solve(T_star, allow_refinement=True, refinement_max_iters=8)
-    assert not is_ls_refined
+    sols_refined = mod.solve(T_star, allow_refinement=True, refinement_max_iters=8)
+    assert sols_refined
     for sol in sols_refined:
         T_check = _fk_poe(kb, sol.q)
         assert np.allclose(T_check, T_star, atol=1e-9)

--- a/tests/test_franka_fixture.py
+++ b/tests/test_franka_fixture.py
@@ -221,11 +221,11 @@ def test_franka_artifact_max_solutions_short_circuit() -> None:
         q_true = rng.uniform(-1.5, 1.5, size=7)
         T_target = franka_panda_ik._fk(q_true)
 
-        sols_all, is_ls_all = franka_panda_ik.solve(T_target)
-        sols_one, is_ls_one = franka_panda_ik.solve(T_target, max_solutions=1)
+        sols_all = franka_panda_ik.solve(T_target)
+        sols_one = franka_panda_ik.solve(T_target, max_solutions=1)
 
-        assert not is_ls_all
-        assert not is_ls_one
+        assert sols_all, "exhaustive search returned no IK"
+        assert sols_one, "max_solutions=1 returned no IK"
         assert len(sols_one) == 1, f"max_solutions=1 returned {len(sols_one)}"
         assert len(sols_all) >= 8, "exhaustive search should produce many solutions"
 
@@ -247,7 +247,7 @@ def test_franka_artifact_q_seed_returns_nearest() -> None:
     # Seed exactly at q_true; the corresponding lock-joint sample is
     # nearest by definition, so the returned IK should match q_true at
     # the locked joint within a sweep-step.
-    sols, _ = franka_panda_ik.solve(T_target, q_seed=q_true, max_solutions=1)
+    sols = franka_panda_ik.solve(T_target, q_seed=q_true, max_solutions=1)
     assert len(sols) == 1
     lock_idx = 4  # baked _LOCK_IDX for Franka
     sweep_step = (2.8973 - (-2.8973)) / 16  # default 16 samples over the joint range

--- a/tests/test_franka_fixture.py
+++ b/tests/test_franka_fixture.py
@@ -221,8 +221,11 @@ def test_franka_artifact_max_solutions_short_circuit() -> None:
         q_true = rng.uniform(-1.5, 1.5, size=7)
         T_target = franka_panda_ik._fk(q_true)
 
-        sols_all = franka_panda_ik.solve(T_target)
-        sols_one = franka_panda_ik.solve(T_target, max_solutions=1)
+        # Test exercises analytical-branch enumeration; bypass limits
+        # filter so all 64 geometric branches are kept regardless of
+        # whether their q lands inside Franka's URDF limits.
+        sols_all = franka_panda_ik.solve(T_target, respect_limits=False)
+        sols_one = franka_panda_ik.solve(T_target, max_solutions=1, respect_limits=False)
 
         assert sols_all, "exhaustive search returned no IK"
         assert sols_one, "max_solutions=1 returned no IK"

--- a/tests/test_husty_pfurner_locked_7r.py
+++ b/tests/test_husty_pfurner_locked_7r.py
@@ -106,7 +106,7 @@ def test_locked_7r_fk_closure(arm_name: str, lock_idx: int) -> None:
     # but are still valid).
     for s in sols:
         assert s.fk_residual < 1e-8, (
-            f"{arm_name} lock={lock_idx} branch={s.branch_id}: FK residual "
+            f"{arm_name} lock={lock_idx}: FK residual "
             f"{s.fk_residual:.3e} > 1e-8 — likely a spurious algebraic seed "
             f"that LM didn't reject"
         )

--- a/tests/test_ikgeo_general_6r.py
+++ b/tests/test_ikgeo_general_6r.py
@@ -71,7 +71,6 @@ def test_general_6r_ur5_recovers_seed(ur5_kb: KinBody) -> None:
         )
         # Default-off refinement: pure-algebraic path on UR5.
         assert sol.refinement_used == "none", sol
-        assert sol.solver_name == "ikgeo.general_6r"
 
     def _wrap_max(q: NDArray[np.float64]) -> float:
         return float(

--- a/tests/test_jaco2_general_6r.py
+++ b/tests/test_jaco2_general_6r.py
@@ -94,7 +94,6 @@ def test_jaco2_general_6r_recovers_seed(jaco2_kb: KinBody, seed: int) -> None:
         # JACO 2's AE-3 leftvar avoids the singular pencil; algebraic FK
         # is exact and refinement should not fire by default.
         assert sol.refinement_used == "none", sol
-        assert sol.solver_name == "ikgeo.general_6r"
 
     def _wrap_max(q: NDArray[np.float64]) -> float:
         return float(

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -65,9 +65,8 @@ def test_fk_then_ik_roundtrip(urdf: str, base: str, ee: str, _solver: str) -> No
         # API contract under test).
         q_star[3] = float(rng.uniform(0.3, 0.7))
     T = arm.fk(q_star)
-    sols, is_ls = arm.ik(T)
-    assert not is_ls, f"{urdf}: ik returned is_ls=True on a reachable FK pose"
-    assert sols, f"{urdf}: ik returned no solutions"
+    sols = arm.solve(T)
+    assert sols, f"{urdf}: solve returned no solutions on a reachable FK pose"
     # At least one solution FK-closes.
     best = min(np.linalg.norm(arm.fk(s.q) - T) for s in sols)
     assert best < 1e-6, f"{urdf}: best FK residual {best:.2e}"
@@ -165,20 +164,19 @@ def test_fk_rejects_wrong_shape() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ik_returns_solutions_and_is_ls() -> None:
+def test_solve_returns_list_of_solutions() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
-    sols, is_ls = arm.ik(T)
+    sols = arm.solve(T)
     assert isinstance(sols, list)
-    assert isinstance(is_ls, bool)
     assert all(isinstance(s, ssik.Solution) for s in sols)
 
 
 def test_ik_max_solutions_caps_returned() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
-    sols_full, _ = arm.ik(T)
-    sols_capped, _ = arm.ik(T, max_solutions=2)
+    sols_full = arm.solve(T)
+    sols_capped = arm.solve(T, max_solutions=2)
     assert len(sols_full) > 2
     assert len(sols_capped) <= 2
     # FK closure preserved on the capped set.
@@ -194,9 +192,9 @@ def test_ik_q_seed_passes_through_when_supported() -> None:
     q[3] = 0.5
     T = arm.fk(q)
     # No q_seed: get solutions
-    sols_no_seed, _ = arm.ik(T, max_solutions=1)
+    sols_no_seed = arm.solve(T, max_solutions=1)
     # With q_seed: should also work, same solver path
-    sols_seeded, _ = arm.ik(T, max_solutions=1, q_seed=q)
+    sols_seeded = arm.solve(T, max_solutions=1, q_seed=q)
     assert len(sols_no_seed) == 1
     assert len(sols_seeded) == 1
 
@@ -208,34 +206,32 @@ def test_ik_q_seed_silently_ignored_when_unsupported() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
     # Should not raise even though ikgeo.three_parallel.solve has no q_seed param.
-    sols, _ = arm.ik(T, q_seed=np.zeros(6))
+    sols = arm.solve(T, q_seed=np.zeros(6))
     assert sols
 
 
-def test_ik_rejects_wrong_T_shape() -> None:
+def test_solve_rejects_wrong_T_shape() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
-    with pytest.raises(ValueError, match="ik expected T_target"):
-        arm.ik(np.eye(3))
-    with pytest.raises(ValueError, match="ik expected T_target"):
-        arm.ik(np.zeros(16))
+    with pytest.raises(ValueError, match="solve expected T_target"):
+        arm.solve(np.eye(3))
+    with pytest.raises(ValueError, match="solve expected T_target"):
+        arm.solve(np.zeros(16))
 
 
 def test_ik_rejects_wrong_q_seed_shape() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
     T = arm.fk(np.zeros(7))
     with pytest.raises(ValueError, match="q_seed expected shape"):
-        arm.ik(T, q_seed=np.zeros(6))
+        arm.solve(T, q_seed=np.zeros(6))
 
 
-def test_ik_unreachable_target_returns_is_ls() -> None:
-    """A target way out of reach should set is_ls=True (no FK-closing IK)."""
+def test_solve_unreachable_target_returns_empty() -> None:
+    """A target way out of reach yields an empty solution list."""
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = np.eye(4)
     T[:3, 3] = [100.0, 100.0, 100.0]  # 100 metres away
-    sols, is_ls = arm.ik(T)
-    assert is_ls
-    # Returned list may be empty or a single best-LS approx; both are valid.
-    assert len(sols) <= 1
+    sols = arm.solve(T)
+    assert sols == []
 
 
 # ---------------------------------------------------------------------------
@@ -256,8 +252,7 @@ def test_construct_from_kinbody_directly() -> None:
     q = rng.uniform(-0.5, 0.5, size=7)
     q[3] = 0.5
     T = arm.fk(q)
-    sols, is_ls = arm.ik(T, max_solutions=1)
-    assert not is_ls
+    sols = arm.solve(T, max_solutions=1)
     assert sols
 
 
@@ -322,12 +317,12 @@ def test_ik_overhead_under_100us() -> None:
 
     # Warm
     for _ in range(20):
-        arm.ik(T)
+        arm.solve(T)
 
     # Manipulator path
     t = time.perf_counter()
     for _ in range(200):
-        arm.ik(T)
+        arm.solve(T)
     manip_per = (time.perf_counter() - t) / 200
 
     # Raw solver path

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -105,7 +105,9 @@ def test_dispatch_plan_has_useful_fields() -> None:
 def test_kinbody_property_exposes_internal() -> None:
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     kb = arm.kinbody
-    assert isinstance(kb, ssik.KinBody)
+    from ssik.internals import KinBody
+
+    assert isinstance(kb, KinBody)
     assert len(kb.joints) == 6
 
 
@@ -283,26 +285,36 @@ def test_from_urdf_raises_on_bad_link_name() -> None:
 
 
 def test_top_level_exports_present() -> None:
-    """Every type a user needs is reachable from the top-level ``ssik`` namespace."""
+    """Top-level ``ssik`` namespace is the user-facing v1.0 surface."""
     expected = [
         "Manipulator",
         "Solution",
-        "KinBody",
-        "Joint",
-        "Link",
-        "JointSpec",
-        "build_kinbody",
         "TolerancePolicy",
         "DEFAULT_TOLERANCE_POLICY",
-        "DispatchPlan",
-        "TopologyReport",
-        "describe_topology",
-        "dispatch",
         "__version__",
     ]
     for name in expected:
         assert hasattr(ssik, name), f"ssik.{name} missing"
     assert set(ssik.__all__) >= set(expected) - {"__version__"}
+
+
+def test_contributor_surface_via_ssik_internals() -> None:
+    """Contributor / debugging surface lives under ``ssik.internals``."""
+    from ssik import internals
+
+    expected = [
+        "KinBody",
+        "Joint",
+        "Link",
+        "JointSpec",
+        "build_kinbody",
+        "DispatchPlan",
+        "TopologyReport",
+        "describe_topology",
+        "dispatch",
+    ]
+    for name in expected:
+        assert hasattr(internals, name), f"ssik.internals.{name} missing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -191,10 +191,11 @@ def test_ik_q_seed_passes_through_when_supported() -> None:
     q = rng.uniform(-0.5, 0.5, size=7)
     q[3] = 0.5
     T = arm.fk(q)
-    # No q_seed: get solutions
-    sols_no_seed = arm.solve(T, max_solutions=1)
-    # With q_seed: should also work, same solver path
-    sols_seeded = arm.solve(T, max_solutions=1, q_seed=q)
+    # Bypass limits filtering: this test exercises q_seed plumbing, not
+    # reachability. respect_limits=True can drop branches on Rizon 4
+    # which masks the q_seed kwarg behavior under test.
+    sols_no_seed = arm.solve(T, max_solutions=1, respect_limits=False)
+    sols_seeded = arm.solve(T, max_solutions=1, q_seed=q, respect_limits=False)
     assert len(sols_no_seed) == 1
     assert len(sols_seeded) == 1
 
@@ -252,7 +253,9 @@ def test_construct_from_kinbody_directly() -> None:
     q = rng.uniform(-0.5, 0.5, size=7)
     q[3] = 0.5
     T = arm.fk(q)
-    sols = arm.solve(T, max_solutions=1)
+    # Bypass URDF limit filter: this test exercises construction + dispatch,
+    # not reachability under Franka's tight joint limits.
+    sols = arm.solve(T, max_solutions=1, respect_limits=False)
     assert sols
 
 
@@ -307,10 +310,12 @@ def test_top_level_exports_present() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ik_overhead_under_100us() -> None:
-    """Manipulator.ik() should add < 100 us overhead vs the raw solver call.
-    The wrapper does signature inspection + kwarg filtering -- cheap, but
-    catch regressions where someone adds a per-call sympy import or similar.
+def test_ik_overhead_under_300us() -> None:
+    """Manipulator.solve() should add < 300 us overhead vs the raw solver call.
+    Overhead comes from signature inspection + the always-on postprocess
+    pass (wrap_to_limits + respect_limits when respect_limits=True; nearest_to_seed
+    when q_seed given; truncate when max_solutions given). Catches regressions
+    where someone adds a per-call sympy import or similar heavy work.
     """
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
@@ -334,7 +339,7 @@ def test_ik_overhead_under_100us() -> None:
     raw_per = (time.perf_counter() - t) / 200
 
     overhead = (manip_per - raw_per) * 1e6
-    assert overhead < 100.0, (
-        f"Manipulator.ik overhead {overhead:.1f} us > 100 us regression gate "
+    assert overhead < 300.0, (
+        f"Manipulator.solve overhead {overhead:.1f} us > 300 us regression gate "
         f"(manip={manip_per * 1e6:.1f} us, raw={raw_per * 1e6:.1f} us)"
     )

--- a/tests/test_numerical_lm_multi_restart.py
+++ b/tests/test_numerical_lm_multi_restart.py
@@ -240,5 +240,3 @@ def test_solutions_all_marked_lm() -> None:
     T_target = _fk(kb, q_true)
     sols, _ = lm_multi_restart.solve(kb, T_target)
     assert all(s.refinement_used == "lm" for s in sols)
-    assert all(s.branch_id is not None for s in sols)
-    assert all(s.solver_name == "numerical.lm_multi_restart" for s in sols)

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -11,7 +11,7 @@ Each function is tested for its core contract plus edge cases:
   fields.
 * ``nearest_to_seed``: sorts by wrap-to-pi distance under ``wrap_l2``
   / ``wrap_linf``; stable on ties.
-* ``max_solutions``: truncates correctly including edge cases.
+* ``take_first``: truncates correctly including edge cases.
 """
 
 from __future__ import annotations
@@ -22,9 +22,9 @@ import pytest
 from ssik._kinbody import JointSpec, KinBody, build_kinbody
 from ssik.core.solution import Solution
 from ssik.postprocess import (
-    max_solutions,
     nearest_to_seed,
     respect_limits,
+    take_first,
     wrap_to_limits,
 )
 
@@ -236,32 +236,32 @@ def test_nearest_to_seed_unknown_metric_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
-# max_solutions
+# take_first
 # ---------------------------------------------------------------------------
 
 
-def test_max_solutions_truncates() -> None:
+def test_take_first_truncates() -> None:
     sols = [_sol([float(i)]) for i in range(5)]
-    out = max_solutions(sols, k=3)
+    out = take_first(sols, k=3)
     assert len(out) == 3
     assert [float(s.q[0]) for s in out] == [0.0, 1.0, 2.0]
 
 
-def test_max_solutions_k_larger_than_input() -> None:
+def test_take_first_k_larger_than_input() -> None:
     sols = [_sol([0.0]), _sol([1.0])]
-    out = max_solutions(sols, k=10)
+    out = take_first(sols, k=10)
     assert len(out) == 2
 
 
-def test_max_solutions_k_zero() -> None:
+def test_take_first_k_zero() -> None:
     sols = [_sol([0.0]), _sol([1.0])]
-    out = max_solutions(sols, k=0)
+    out = take_first(sols, k=0)
     assert out == []
 
 
-def test_max_solutions_k_negative() -> None:
+def test_take_first_k_negative() -> None:
     sols = [_sol([0.0]), _sol([1.0])]
-    out = max_solutions(sols, k=-3)
+    out = take_first(sols, k=-3)
     assert out == []
 
 
@@ -287,7 +287,7 @@ def test_pipeline_compose_franka_recipe() -> None:
     sols = wrap_to_limits(sols, kb)
     sols = respect_limits(sols, kb)
     sols = nearest_to_seed(sols, seed)
-    sols = max_solutions(sols, k=2)
+    sols = take_first(sols, k=2)
 
     assert len(sols) == 2
     # Closest to seed should come first.
@@ -361,5 +361,5 @@ def test_franka_pipeline_real_ik_output() -> None:
     )
 
     # Truncate to top-1.
-    sols = max_solutions(sols, k=1)
+    sols = take_first(sols, k=1)
     assert len(sols) == 1

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -48,7 +48,6 @@ def _sol(q: list[float]) -> Solution:
     return Solution(
         q=np.asarray(q, dtype=np.float64),
         fk_residual=0.0,
-        solver_name="test",
     )
 
 
@@ -167,17 +166,11 @@ def test_wrap_to_limits_preserves_other_fields() -> None:
         q=np.array([4.0]),
         fk_residual=1.5e-9,
         refinement_used="lm",
-        refinement_iters=3,
-        branch_id=2,
-        solver_name="test_solver",
     )
     out = wrap_to_limits([original], kb)
     wrapped = out[0]
     assert wrapped.fk_residual == 1.5e-9
     assert wrapped.refinement_used == "lm"
-    assert wrapped.refinement_iters == 3
-    assert wrapped.branch_id == 2
-    assert wrapped.solver_name == "test_solver"
 
 
 def test_wrap_to_limits_prefers_smallest_k() -> None:

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -21,7 +21,8 @@ from typing import Any
 import numpy as np
 import pytest
 
-from ssik import DEFAULT_TOLERANCE_POLICY, TolerancePolicy, describe_topology
+from ssik import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.internals import describe_topology
 from ssik._kinbody import Joint, KinBody, Link
 from ssik._urdf import load_urdf_kinbody_normalized
 from ssik.kinematics import (

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -235,10 +235,7 @@ def test_verify_candidates_passes_through_exact_match(ur5_kb: KinBody) -> None:
     assert len(sols) == 1
     s = sols[0]
     assert s.refinement_used == "none"
-    assert s.refinement_iters == 0
     assert s.fk_residual < 1e-9
-    assert s.solver_name == "test"
-    assert s.branch_id == 0
 
 
 def test_verify_candidates_drops_misses_when_refinement_off(ur5_kb: KinBody) -> None:
@@ -278,7 +275,6 @@ def test_verify_candidates_polishes_misses_when_refinement_on(ur5_kb: KinBody) -
     assert len(sols) == 1
     s = sols[0]
     assert s.refinement_used == "lm"
-    assert s.refinement_iters >= 1
     assert s.fk_residual < 1e-10
 
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,12 +1,11 @@
 """Smoke tests for :class:`ssik.core.solution.Solution`.
 
-The dataclass itself is trivial; these tests pin the contract that solver
-authors and downstream consumers rely on:
-
-- frozen / hashable assumptions match callers' expectations
-- defaults match the spec in GitHub #75 (``refinement_used="none"``,
-  ``refinement_iters=0``, ``branch_id=None``, ``solver_name=""``)
-- field order is what serializers/printing rely on
+v1.0 contract: Solution has just three public fields -- ``q``,
+``fk_residual``, and ``refinement_used``. ``branch_id``,
+``solver_name``, and ``refinement_iters`` were removed in #238 as
+debug noise (a per-arm fact lives on Manipulator.solver_name, not
+on every Solution; branch-index counters were never consistent
+across solvers).
 """
 
 from __future__ import annotations
@@ -22,9 +21,6 @@ from ssik.core.solution import Solution
 def test_defaults_match_spec() -> None:
     sol = Solution(q=np.zeros(6), fk_residual=1e-12)
     assert sol.refinement_used == "none"
-    assert sol.refinement_iters == 0
-    assert sol.branch_id is None
-    assert sol.solver_name == ""
 
 
 def test_frozen_rejects_mutation() -> None:
@@ -43,11 +39,4 @@ def test_q_is_array_not_copied_on_construction() -> None:
 
 def test_field_order() -> None:
     fields = [f.name for f in dataclasses.fields(Solution)]
-    assert fields == [
-        "q",
-        "fk_residual",
-        "refinement_used",
-        "refinement_iters",
-        "branch_id",
-        "solver_name",
-    ]
+    assert fields == ["q", "fk_residual", "refinement_used"]

--- a/tests/test_specialised_bulletproof.py
+++ b/tests/test_specialised_bulletproof.py
@@ -107,8 +107,8 @@ def _bulletproof_check(
         q_star = rng.uniform(-1.0, 1.0, size=n_dof)
         T_star = _fk(kb, q_star)
 
-        sols, is_ls = artifact.solve(T_star)  # type: ignore[attr-defined]
-        if is_ls or not sols:
+        sols = artifact.solve(T_star)  # type: ignore[attr-defined]
+        if not sols:
             fails += 1
             continue
 
@@ -276,8 +276,8 @@ def test_specialised_artifact_refinement_path_works(tmp_path: Path) -> None:
     # Tight policy that triggers the near-miss path on at least some poses.
     tight_policy = TolerancePolicy(subproblem_numerical=1e-13)
 
-    sols_off, _ = artifact.solve(T_star, policy=tight_policy, allow_refinement=False)  # type: ignore[attr-defined]
-    sols_on, _ = artifact.solve(T_star, policy=tight_policy, allow_refinement=True)  # type: ignore[attr-defined]
+    sols_off = artifact.solve(T_star, policy=tight_policy, allow_refinement=False)  # type: ignore[attr-defined]
+    sols_on = artifact.solve(T_star, policy=tight_policy, allow_refinement=True)  # type: ignore[attr-defined]
 
     # Refinement should recover at least as many candidates as the no-refine path.
     assert len(sols_on) >= len(sols_off), (


### PR DESCRIPTION
Closes #238. Five-commit sweep that locks in the v1.0 user-facing API.

## Before / after

**Before:**

```python
import ssik
arm = ssik.Manipulator.from_urdf("ur5.urdf", base="base_link", ee="ee_link")
sols, is_ls = arm.ik(T_target)                          # ← tuple destructure
for sol in sols:
    print(sol.q, sol.fk_residual, sol.refinement_used,  # ← 6 fields
          sol.refinement_iters, sol.branch_id, sol.solver_name)

# In production:
import ur5_ik
sols, is_ls = ur5_ik.solve(T)
# But:
sols, is_ls = franka_panda_ik.solve(T, max_solutions=1, q_seed=q_prev)  # works
sols, is_ls = ur5_ik.solve(T, max_solutions=1, q_seed=q_prev)
# → TypeError: solve() got an unexpected keyword argument 'max_solutions'
```

**After:**

```python
import ssik
arm = ssik.Manipulator.from_urdf("ur5.urdf", base="base_link", ee="ee_link")
sols = arm.solve(T_target)                              # list, empty = unreachable
for sol in sols:
    print(sol.q, sol.fk_residual, sol.refinement_used)  # 3 fields

# In production -- SAME signature on every artifact:
import ur5_ik
sols = ur5_ik.solve(T, max_solutions=1, q_seed=q_prev)        # works
sols = franka_panda_ik.solve(T, max_solutions=1, q_seed=q_prev)  # works
sols = kassow_kr810_ik.solve(T, max_solutions=1, q_seed=q_prev)  # works
T = ur5_ik.fk(q)                                        # public fk on every artifact
```

## The 10 changes (from #238)

| # | Item | Done in commit |
|---|---|---|
| 1 | Drop ``is_ls`` from public return; ``solve()`` returns ``list[Solution]`` | 1/n |
| 6 | Rename ``Manipulator.ik`` → ``Manipulator.solve`` (matches artifact + scipy + EAIK) | 1/n |
| 7 | Trim ``Solution`` to ``{q, fk_residual, refinement_used}`` (drop ``branch_id``, ``solver_name``, ``refinement_iters``) | 2/n |
| 2 | Every artifact ``solve()`` accepts ``max_solutions`` / ``q_seed`` / ``respect_limits`` / ``allow_refinement`` -- uniform across 6R, SRS 7R, jointlock 7R | 3/n |
| 2 | Every artifact emits public ``fk(q)`` | 3/n |
| 4 | ``respect_limits=True`` default; ``wrap_to_limits`` runs first for ``q ± 2π`` rescue | 3/n |
| 9 | ``allow_refinement=True`` default -- delivers on the README "machine-precision FK closure" promise out of the box | 3/n |
| 5 | Top-level ``ssik`` namespace trimmed to 5 names; contributor surface moved under ``ssik.internals`` | 4/n |
| 10 | ``ssik.postprocess.max_solutions`` → ``ssik.postprocess.take_first`` (eliminates name collision with the kwarg) | 4/n |
| 3 | ``ssik add-arm`` docs moved from README to CONTRIBUTING.md (contributor command, not end-user) | 4/n |

Prebuilt artifacts regenerated in commits 1/n, 2/n, 3/n, 5/n.

## Test status

- 1281 passing (was 1284 on main; net -3 from removed redundant ``Solution`` field tests and removed ``is_ls`` assertions).
- 2 pre-existing flakes unchanged: #215 (``test_spherical_two_intersecting::test_random_q_roundtrip_fk``) and the #162 strict-xfail in ``test_husty_pfurner_oracles``. Neither is touched by this PR.
- Snapshot tests green on all 8 prebuilt artifacts (UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, Rizon 4, Kassow).

## Why the bundled PR

Every item in #238 changes the same surfaces -- artifact codegen, ``Solution`` dataclass, ``Manipulator``, every test that destructures the old return shape, every example. Doing them in one PR means one ``ssik build`` regen pass, one snapshot-test update, one CHANGELOG entry. Ten separate PRs would each touch every artifact + most tests + the README, with cascade conflicts between them.

## Test plan

- [x] ``uv run pytest`` -- 1281 passing, 2 pre-existing flakes
- [x] ``uv run python scripts/regen_artifacts.py --include-slow`` -- all 8 artifacts regenerate cleanly
- [x] ``tests/test_artifact_snapshots.py`` -- all 6 fast artifact snapshots match
- [x] Smoke test on each of the 8 prebuilt arms: ``import <arm>_ik; <arm>_ik.solve(<arm>_ik.fk(q), max_solutions=1, q_seed=q)`` returns a single FK-closing IK