### PR TITLE
release.yml: bump cibuildwheel v2.21 → v3.4.1 (#132 rc1 fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,12 @@ jobs:
           fetch-depth: 0  # hatch-vcs derives version from git tags
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        # v2.21 pinned ``packaging==24.1`` in its build-isolation constraints,
+        # which conflicts with ``hatchling>=1.27`` requiring ``packaging>=24.2``
+        # (broke macOS arm64 + Windows on v1.0.0rc1; Linux happened to resolve
+        # because the manylinux constraints file is slightly different).
+        # v3.x has updated pins.
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What broke

v1.0.0rc1 release ([run #25778498207](https://github.com/personalrobotics/ssik/actions/runs/25778498207)) failed on macOS arm64 + Windows:

```
ERROR: Cannot install hatchling==1.27.0, hatchling==1.28.0 and hatchling==1.29.0
       because these package versions have conflicting dependencies.
The conflict is caused by:
    hatchling 1.29.0 depends on packaging>=24.2
    The user requested (constraint) packaging==24.1
```

cibuildwheel v2.21 pinned `packaging==24.1` in its build-isolation constraints file. Hatchling 1.27+ requires `packaging>=24.2`. Linux happened to resolve because the manylinux constraints file pins differently.

## Fix

Bump `pypa/cibuildwheel@v2.21` → `v3.4.1`. v3.x has updated pins.

Config in `pyproject.toml` ([tool.cibuildwheel]) is API-stable across the v2→v3 boundary (build patterns, skip patterns, test-command, manylinux_2_28 image all unchanged in v3).

## Next

Once merged: `git tag v1.0.0rc2 && git push origin v1.0.0rc2`. The previous (failed) rc1 tag never reached TestPyPI — publish jobs depend on all wheel jobs + sdist succeeding, so the failures gated TestPyPI as designed.