### PR TITLE
Declare scipy as runtime dep + harden cibuildwheel smoke (#252, blocks rc3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.0",
+    # scipy.linalg / scipy.signal are imported at module top in
+    # ``ssik._pencil`` and ``ssik.solvers.husty_pfurner._eliminate``; HP backs
+    # every non-SRS 7R prebuilt (Franka, Rizon, Kassow). Without scipy a
+    # fresh ``pip install ssik`` followed by ``ssik --help`` (or importing
+    # any HP-backed prebuilt) crashes with ModuleNotFoundError. See #252.
+    "scipy>=1.13",
     "sympy>=1.10",
     # Required for ``import cython`` at module top in compiled-source modules
     # (``ssik.kinematics._scalar3``, ``ssik.subproblems._rotation``,
@@ -100,13 +106,25 @@ build = "cp311-* cp312-* cp313-*"
 # 32-bit Linux, 32-bit Windows, PyPy. Linux aarch64 is also deferred.
 skip = ["*-musllinux_*", "*-manylinux_i686", "*-win32", "pp*", "*linux_aarch64"]
 build-verbosity = 1
-test-requires = ["numpy>=2.0", "pytest>=8"]
-# Wheel smoke gate: import the namespaced prebuilt, FK-roundtrip, FK closure
-# within 1e-9. If the wheel is missing the prebuilt subpackage, or a
-# compiled extension is malformed, or a transitive import chokes, this
-# fires before the wheel ever reaches PyPI. Single quotes inside double
-# quotes to keep the whole command on one TOML line.
-test-command = 'python -c "from ssik.prebuilt import iiwa14_ik; import numpy as np; q = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]); T = iiwa14_ik.fk(q); sols = iiwa14_ik.solve(T); assert sols and max(s.fk_residual for s in sols) < 1e-9, \"wheel smoke test failed\""'
+test-requires = ["numpy>=2.0"]
+# Wheel smoke gate. Runs in the cibuildwheel test venv against the BUILT
+# wheel (not the dev checkout) so any missing runtime dep, malformed .so,
+# or broken import chain fires before publish. Three checks:
+#
+#  1. iiwa14_ik (strict SRS, no HP/scipy in the chain) -- baseline import
+#     + FK roundtrip + FK closure < 1e-9.
+#  2. franka_panda_ik (HP-backed via jointlock) -- catches transitive
+#     scipy / HP-stack import issues that the strict-SRS path skips. This
+#     check would have caught #252 had it existed earlier.
+#  3. ``ssik --help`` -- exercises the CLI's full import chain (codegen,
+#     dispatcher, every solver composer). The CLI uses the broadest
+#     import surface in the package; if anything is import-broken, this
+#     fires.
+test-command = [
+    'python -c "from ssik.prebuilt import iiwa14_ik; import numpy as np; q = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]); T = iiwa14_ik.fk(q); sols = iiwa14_ik.solve(T); assert sols and max(s.fk_residual for s in sols) < 1e-9, \"iiwa14_ik smoke failed\""',
+    'python -c "from ssik.prebuilt import franka_panda_ik; import numpy as np; T = franka_panda_ik.fk(np.array([0.2, 0.3, -0.4, -1.2, 0.3, 1.4, 0.5])); sols = franka_panda_ik.solve(T); assert sols, \"franka_panda_ik returned no IK\""',
+    "ssik --help",
+]
 
 [tool.cibuildwheel.linux]
 # manylinux_2_28 ships GCC 14; sufficient for Cython 3.x.

--- a/uv.lock
+++ b/uv.lock
@@ -1255,6 +1255,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cython" },
     { name = "numpy" },
+    { name = "scipy" },
     { name = "sympy" },
 ]
 
@@ -1282,6 +1283,7 @@ docs = [
 requires-dist = [
     { name = "cython", specifier = ">=3.1" },
     { name = "numpy", specifier = ">=2.0" },
+    { name = "scipy", specifier = ">=1.13" },
     { name = "sympy", specifier = ">=1.10" },
     { name = "urchin", marker = "extra == 'urdf'", specifier = ">=0.0.27" },
 ]


### PR DESCRIPTION
## Bug

`pip install ssik` followed by `ssik --help` or `from ssik.prebuilt import franka_panda_ik` crashes with:

```
ModuleNotFoundError: No module named 'scipy'
```

Three modules import scipy at module top: `ssik._pencil` (scipy.linalg), `ssik.solvers.ikgeo._raghavan_roth` (scipy.linalg, conditional), `ssik.solvers.husty_pfurner._eliminate` (scipy.signal.convolve2d). Every non-SRS 7R prebuilt (`franka_panda_ik`, `rizon4_ik`, `kassow_kr810_ik`) routes through HP via jointlock, so they all break. The CLI's codegen import chain also touches HP, so `ssik --help` crashes.

**v1.0.0rc1 and v1.0.0rc2 both ship this bug.** rc3 needs it.

## Why our cibuildwheel smoke gate missed it

The previous `test-command` only imported `ssik.prebuilt.iiwa14_ik` (strict SRS — no scipy in its import chain). Local dev / regular CI has scipy installed transitively, masking the missing declaration.

## Fix

1. Declare `scipy>=1.13` in `[project.dependencies]`.
2. Extend the cibuildwheel `test-command` to a 3-step list:
   - Existing `iiwa14_ik` FK-roundtrip check (baseline)
   - **New**: `from ssik.prebuilt import franka_panda_ik; solve(fk(q))` — exercises HP, would have caught #252
   - **New**: `ssik --help` — exercises the CLI's full import surface

## Verification (local, fresh `uv venv`)

- `pip install ssik` (the built wheel): pulls scipy 1.17.1 transitively ✓
- `ssik --help`: clean output, all subcommands listed ✓
- All 8 `ssik.prebuilt` arms: 22–84 sols each, FK 1e-9 to 1e-16 ✓
- `pip install ssik[urdf]` + `ssik build tests/fixtures/ur5.urdf`: validates 100/100 poses at median 0.5 ms, max FK 6.10e-09 ✓

## Test plan
- [x] Local fresh-venv install + CLI + all 8 prebuilts + `ssik build` round-trip
- [x] `uv run pytest tests/test_prebuilt_sanity.py tests/test_cli.py` — 13 passed
- [x] ruff + mypy clean
- [ ] CI green (regular ci.yml; release.yml fires on rc3 tag after this merges)

Closes #252.