### PR TITLE
README: reorganize for install-first user flow (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,57 @@
 [![Python](https://img.shields.io/pypi/pyversions/ssik.svg)](https://pypi.org/project/ssik/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 
-Analytical inverse kinematics for 6R and 7R revolute robot arms. Returns **every IK branch** at machine-precision FK closure, dispatches the right solver automatically, and ships a per-arm build artifact that contains the full IK pipeline as a self-contained Python module.
+Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module — `import franka_panda_ik; franka_panda_ik.solve(T)` — that returns **every IK branch** at machine-precision FK closure.
+
+## Install
 
 ```bash
 pip install ssik
 ```
 
-## Quickstart — use a prebuilt artifact
+Python 3.11+. Wheels for Linux x86_64, macOS arm64, macOS x86_64, Windows x86_64.
 
-The wheel ships ready-to-use IK modules for 8 popular arms under `ssik.prebuilt`. Each is a self-contained `.py` with the per-arm KinBody constants, the dispatched solver, and any cached symbolic preprocessing already baked in — no URDF parsing, no `urchin` dependency, no `sympy` on the import path.
+## Quickstart
 
 ```python
 from ssik.prebuilt import franka_panda_ik
 import numpy as np
 
 T_target = np.eye(4); T_target[:3, 3] = [0.5, 0.1, 0.3]
-sols = franka_panda_ik.solve(T_target)                   # all IK branches; empty list = unreachable
+sols = franka_panda_ik.solve(T_target)      # every analytical IK branch
 ```
 
-The 8 prebuilts: `ur5_ik`, `puma560_ik`, `jaco2_ik`, `iiwa14_ik`, `gen3_ik`, `franka_panda_ik`, `rizon4_ik`, `kassow_kr810_ik`. For other arms, see "Build an artifact for your own arm" below.
+`sols` is a `list[Solution]`. Each `Solution` carries `q` (the joint vector), `fk_residual` (‖FK(q) − T‖), and which polish path fired. Empty list = pose is unreachable.
 
-### Trajectory tracking / IK-based teleop
+## The artifact model
 
-The canonical pattern for teleop and tracking is "give me the IK closest to where the robot is now":
+ssik is built around **per-arm artifact modules**. Each artifact is a single `.py` file with the per-arm KinBody constants, the dispatched solver, and any cached symbolic preprocessing already baked in. **No URDF parsing, no `urchin`, no `sympy` on the runtime import path.** A robot stack that imports `<arm>_ik.py` carries no algorithmic complexity beyond what the build pipeline already resolved.
+
+This is the same idea OpenRAVE's IKFast had — generate per-arm specialised IK code at design time, run pure numeric at deployment — but without IKFast's brittleness on non-Pieper geometries.
+
+There are two artifact paths:
+
+### Use a prebuilt arm (`ssik.prebuilt`)
+
+The wheel ships 8 ready-to-import artifacts:
+
+| Module | Arm | Class |
+|---|---|---|
+| `ur5_ik` | Universal Robots UR5 | three-parallel 6R |
+| `puma560_ik` | KUKA Puma 560 | Pieper 6R (spherical wrist) |
+| `jaco2_ik` | Kinova JACO 2 | **non-Pieper 6R** |
+| `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R |
+| `gen3_ik` | Kinova Gen3 7-DOF | **approximate-SRS 7R** |
+| `franka_panda_ik` | Franka Panda | anthropomorphic 7R |
+| `rizon4_ik` | Flexiv Rizon 4 | **non-SRS 7R** |
+| `kassow_kr810_ik` | Kassow KR810 | **non-SRS 7R** |
+
+```python
+from ssik.prebuilt import iiwa14_ik
+sols = iiwa14_ik.solve(T_target)
+```
+
+For trajectory tracking and IK-based teleop, the canonical pattern is "give me the IK closest to where the robot is now":
 
 ```python
 # Robot's current configuration (from joint sensors, last command, etc.).
@@ -35,61 +63,63 @@ q_current = np.array([0.0, -0.5, 0.0, 0.7, 0.0, 1.2, 0.0])
 # Target pose updates every control tick (VR controller, planner, etc.).
 T_target = ...
 
-# max_solutions=1 + q_seed: solver searches the 1-parameter redundancy
-# sweep starting from the lock-sample closest to q_current and short-
-# circuits on the first valid in-limits branch (~5-6x faster than
-# the full sweep on 7R jointlock arms; sub-ms on 6R / SRS arms).
+# max_solutions=1 + q_seed: solver visits lock-samples in nearest-to-seed
+# order and short-circuits on the first in-limits branch (~5-6× faster
+# than the full sweep on 7R jointlock arms; sub-ms on 6R / SRS arms).
 sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
-q_command = sols[0].q if sols else q_current             # empty list = unreachable
+q_command = sols[0].q if sols else q_current
 ```
 
-The same kwarg shape works on every prebuilt under `ssik.prebuilt`. By default `solve()` runs **`respect_limits=True`**: out-of-URDF-limit branches are dropped (with a `q ± 2π` rescue pass first). On 7R jointlock arms (Franka / Rizon / Kassow) the limits filter runs *during* the lock-sweep so `max_solutions=1` short-circuits on the first in-limits candidate rather than wasting samples on branches the postprocess would discard. Pass `respect_limits=False` for the raw geometric set when you want to filter yourself.
+### Build an artifact for your own arm
 
-## Returns all solutions, not one
-
-A single 6-DOF target pose admits up to **16 analytical IK branches** (8 typical for a Pieper-class arm: 4 shoulder × 2 elbow, with the wrist deterministic). For a 7R redundant arm the IK is a 1-parameter family; ssik discretises it into 32–256 branches per pose depending on the swivel-sample count. Every returned `Solution` carries `q`, the per-IK FK residual, and whether the Newton polish path fired (`refinement_used`).
-
-Numerical IK libraries take a seed, run damped least-squares to a single converged configuration, and stop. Branch enumeration matters for motion planning (try every branch, pick the one with best clearance), for dexterity analysis (the manipulability ellipsoid is per-branch), and for trajectory continuation across kinematic singularities.
-
-## Measured comparison vs EAIK
-
-EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-decomposition solvers. It is analytical on the kinematic families it recognises and refuses everything else. The numbers below come from [`examples/04_compare_vs_eaik.py`](examples/04_compare_vs_eaik.py) over 100 random reachable poses per arm, Apple M3 single-thread, mean ± 95% CI via bootstrap (1000 resamples). FK residual is the Frobenius norm `‖FK(q) − T‖` against the original URDF / spec FK.
-
-| Arm (class) | EAIK | ssik |
-|---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 556 ± 12 µs / FK 2e-9 / 4 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 1 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 2 sols |
-| iiwa14 (SRS 7R) | **refuses** ("only 1-6R robots are solvable") | 5.10 ± 0.07 ms / FK 4e-13 / 96 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.83 ± 1.15 ms / FK 1e-12 / 47 sols |
-| Franka Panda (anthropomorphic 7R) | **refuses** ("only 1-6R") | 28.03 ± 2.57 ms / FK 7e-13 / 9 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.88 ± 8.80 ms / FK 4e-9 / 35 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 28.06 ± 10.63 ms / FK 7e-8 / 24 sols |
-
-EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings are EAIK's actual error messages, captured verbatim by the bench harness. A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
-
-ssik FK residuals above are the algebraic candidates returned by `solve()` with default tolerance policy and `respect_limits=True`. Branch counts on 7R arms (iiwa14: 96, Franka: 9, Rizon: 35) reflect URDF-joint-limit filtering; pass `respect_limits=False` to get the full geometric set. The `allow_refinement=True` opt-in runs Levenberg–Marquardt polish per algebraic candidate at a few hundred microseconds per branch — useful when an algebraic candidate lands just above `fk_atol` near a kinematic singularity; it does not always reach machine precision on tier-2 RR arms whose polish basin is narrow.
-
-The algorithmic ingredients are not novel — Raghavan–Roth (1990), Manocha–Canny (1994), Singh–Kreutz (1989), Husty–Pfurner (2007). What's new is making the textbook pipelines survive on real ill-conditioned arms (AE-3 leftvar selection on JACO 2 drops `cond(m_quad)` from 3.75 × 10^16 to 127), composing them with a uniform dispatch layer, and packaging the whole thing as a deployable artifact.
-
-## Build an artifact for your own arm
+For any arm not in the prebuilt set, run `ssik build` once against the URDF:
 
 ```bash
 ssik build my_arm.urdf --base base_link --ee tool0
-# → my_arm_ik.py    (~1-5 min build, all symbolic preprocessing baked in)
+# → my_arm_ik.py
 ```
 
-The artifact is a single `.py` file containing:
+Build time depends on solver class:
+- **<1 s** for tier-0 closed-form (UR-class, Pieper, SRS-class 7R)
+- **~30 s** for non-Pieper 6R (Raghavan–Roth symbolic derivation)
+- **7–20 min** for non-SRS 7R (cached Husty–Pfurner per lock sample)
 
-- the per-arm KinBody constants inlined as numpy literals,
-- the dispatch choice baked at build time (no runtime classification),
-- for non-Pieper sub-chains, the cached Raghavan–Roth symbolic derivations as base85-encoded zlib-compressed pickle blobs.
+Ship the emitted `.py` alongside your robot stack. Once built, use it exactly like a prebuilt:
 
-Module-init takes ~5 s (deserialise + re-`lambdify` the cached blobs); every subsequent `solve()` call hits warm-cache speed. **No URDF parsing, no `urchin` dependency, no cold-cache symbolic preprocessing at runtime, no sympy on the import path of the deployed artifact.** A robot stack that imports `my_arm_ik.py` carries no algorithmic complexity beyond what the build pipeline already resolved.
+```python
+import my_arm_ik
+sols = my_arm_ik.solve(T_target)
+```
 
-This is the same idea OpenRAVE's IKFast had — generate per-arm specialised IK code at design time, run pure numeric at deployment — but without IKFast's brittleness on non-Pieper geometries.
+Re-run `ssik build` after `pip install -U ssik` if you want the latest solver fixes. Old artifacts keep working — they're frozen against the ssik version that built them. `ssik build` requires the URDF extras: `pip install ssik[urdf]`.
 
-Cython hot loops cover the leaf primitives (Rodrigues rotations, POE forward kinematics, SP1–SP6 subproblems); the rest is pure Python so it stays inspectable.
+### Development path: `Manipulator.from_urdf` (not for deployment)
+
+For one-off experiments before committing to a build artifact, ssik also exposes the runtime classifier as a Python class:
+
+```python
+import ssik
+arm = ssik.Manipulator.from_urdf("my_arm.urdf", base="base_link", ee="tool0")
+sols = arm.solve(T_target, max_solutions=1, q_seed=q_current)
+```
+
+Every fresh process re-runs URDF parsing, topology classification, and (for non-Pieper sub-chains) first-call sympy preprocessing — so this path is **strictly slower than the build-artifact path in production** and requires `urchin` + `sympy` on the runtime path (`pip install ssik[urdf]`). Once dispatch is settled, switch to `ssik build`.
+
+Contributors extending ssik's own test fixtures (vs deploying for their own arm) use `ssik add-arm`; see [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-arm-fixture).
+
+## What `solve()` returns
+
+A `list[Solution]`. Each `Solution` has:
+
+- `q` — joint-angle vector (length DOF)
+- `fk_residual` — `‖FK(q) − T‖_F` (Frobenius norm against the original URDF / spec FK)
+- `refinement_used` — `"none"` or `"lm"` if Levenberg–Marquardt polish fired
+
+A single 6-DOF target pose admits up to **16 analytical IK branches** (8 typical for a Pieper-class arm: 4 shoulder × 2 elbow, with the wrist deterministic). For 7R redundant arms the IK is a 1-parameter family; ssik discretises it into 32–256 branches per pose depending on the swivel-sample count.
+
+By default `solve()` runs **`respect_limits=True`**: out-of-URDF-limit branches are dropped (with a `q ± 2π` rescue pass first). On 7R jointlock arms the limits filter runs *during* the lock-sweep so `max_solutions=1` short-circuits on the first in-limits candidate rather than wasting samples on branches the postprocess would discard. Pass `respect_limits=False` for the raw geometric set.
+
+The `allow_refinement=True` opt-in runs LM polish per algebraic candidate at a few hundred microseconds per branch — useful when an algebraic candidate lands just above `fk_atol` near a kinematic singularity.
 
 ## Tuning knobs
 
@@ -111,7 +141,7 @@ policy = TolerancePolicy(
 sols = my_arm_ik.solve(T_target, policy=policy)
 ```
 
-The fields are named for *why* they exist so log messages can say `"SP6 sign branch rejected: closure 1.2e-4 > subproblem_numerical 1e-5"` instead of citing magic numbers. Tighten `subproblem_numerical` when you want stricter FK closure (at the cost of dropping more borderline branches); loosen `axis_parallel` / `axis_intersect` when an Xacro-derived URDF has axes mis-aligned by a few microradians and the dispatcher refuses to classify it.
+The fields are named for *why* they exist so log messages can say `"SP6 sign branch rejected: closure 1.2e-4 > subproblem_numerical 1e-5"` instead of citing magic numbers.
 
 ### `ssik.postprocess` — composable filters
 
@@ -129,35 +159,36 @@ sols = nearest_to_seed(sols, q_current)                 # sort by wrap-to-pi dis
 sols = take_first(sols, k=4)                            # top-k after ranking
 ```
 
-By default `solve()` already runs `wrap_to_limits` + `respect_limits` (see [Trajectory tracking](#trajectory-tracking--ik-based-teleop) above); the standalone helpers exist for callers who want a different order, a different metric, or to add their own filters (collision-aware filtering, dexterity scoring, custom seed metrics) between the layers.
+By default `solve()` already runs `wrap_to_limits` + `respect_limits`; the standalone helpers exist for callers who want a different order, a different metric, or to add their own filters (collision-aware filtering, dexterity scoring, custom seed metrics) between the layers.
 
-Out of scope: collision filtering (use FCL or similar at the application layer) and continuous-trajectory smoothness (typically a separate planner concern). The four shipped filters cover the standard "single-pose, robot-aware IK" case.
+Out of scope: collision filtering (use FCL or similar at the application layer) and continuous-trajectory smoothness (typically a separate planner concern).
 
-## Bulletproof discipline
+## How it compares
 
-Every solver lands with: N-way cross-solver agreement on shared fixtures, FK closure ≤ 1e-10 on every retained IK, 500+ Hypothesis-fuzzed random poses per fixture, and an explicit speed bench that has to clear a regression gate. The current suite has **1300+ tests across 11 fixture arms**. Negative-result spikes (a Cython estimate that misses by 2-5×, a codegen-bake on a part that's 0.3% of runtime) are published as closed issues with profile data so the next contributor doesn't repeat the path.
+Numerical-IK libraries take a seed, run damped least-squares to a **single** converged configuration, and stop. ssik returns **every analytical branch** at machine precision. Branch enumeration matters for motion planning (try every branch, pick the one with best clearance), for dexterity analysis (the manipulability ellipsoid is per-branch), and for trajectory continuation across kinematic singularities.
 
-## Install
+EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-decomposition solvers. It's analytical on the kinematic families it recognises and refuses everything else. Numbers below from [`examples/04_compare_vs_eaik.py`](examples/04_compare_vs_eaik.py) over 100 random reachable poses per arm, Apple M3 single-thread, mean ± 95% CI via 1000-resample bootstrap. FK residual is the Frobenius norm `‖FK(q) − T‖` against the original URDF / spec FK.
 
-```bash
-pip install ssik              # core + analytical solvers (everything you need at deployment)
-pip install ssik[urdf]        # adds urchin + sympy for `ssik build` and the dev/exploration path
-```
+| Arm (class) | EAIK | ssik |
+|---|---|---|
+| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 556 ± 12 µs / FK 2e-9 / 4 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 1 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 2 sols |
+| iiwa14 (SRS 7R) | **refuses** ("only 1-6R robots are solvable") | 5.10 ± 0.07 ms / FK 4e-13 / 96 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.83 ± 1.15 ms / FK 1e-12 / 47 sols |
+| Franka Panda (anthropomorphic 7R) | **refuses** ("only 1-6R") | 28.03 ± 2.57 ms / FK 7e-13 / 9 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.88 ± 8.80 ms / FK 4e-9 / 35 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 28.06 ± 10.63 ms / FK 7e-8 / 24 sols |
 
-Python 3.11+. Wheels for Linux x86_64 and macOS arm64.
+EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings are EAIK's actual error messages, captured verbatim by the bench harness. A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
 
-## Development & exploration: `Manipulator.from_urdf`
+## Under the hood
 
-For one-off experiments or fuzzing during solver development, the runtime classifier is also exposed as a Python class. It parses a URDF, dispatches a solver at construction time, and exposes the same `solve()` / `fk()` API as the artifact. Every fresh process re-runs URDF parsing, topology classification, and (for non-Pieper sub-chains) first-call sympy preprocessing — so it is strictly slower than the build-artifact path in production and requires `urchin` + `sympy` on the runtime path:
+The algorithmic ingredients are not novel — Raghavan–Roth (1990), Manocha–Canny (1994), Singh–Kreutz (1989), Husty–Pfurner (2007). What's new is making the textbook pipelines survive on real ill-conditioned arms (AE-3 leftvar selection on JACO 2 drops `cond(m_quad)` from 3.75 × 10^16 to 127), composing them with a uniform dispatch layer, and packaging the whole thing as a deployable artifact.
 
-```python
-import ssik
+Cython hot loops cover the leaf primitives (POE forward kinematics, the Levenberg–Marquardt polish and analytical Jacobian); the rest is pure Python so it stays inspectable.
 
-arm = ssik.Manipulator.from_urdf("my_arm.urdf", base="base_link", ee="tool0")
-sols = arm.solve(T_target, max_solutions=1, q_seed=q_current)
-```
-
-Once the dispatch is settled, switch to `ssik build my_arm.urdf` and import the artifact. Contributors extending ssik's test suite (vs deploying for their own arm) use `ssik add-arm`; see [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-arm-fixture).
+**Bulletproof testing**: every solver lands with N-way cross-solver agreement on shared fixtures, FK closure ≤ 1e-10 on every retained IK, 500+ Hypothesis-fuzzed random poses per fixture, and an explicit speed bench that has to clear a regression gate. The current suite has **1300+ tests across 11 fixture arms**. Negative-result spikes (a Cython estimate that misses by 2-5×, a codegen-bake on a part that's 0.3% of runtime) are published as closed issues with profile data so the next contributor doesn't repeat the path.
 
 ## Documentation
 


### PR DESCRIPTION
## Why

Current README runs 15 sections with `## Install` at section 11. Two parallel user paths (use a prebuilt vs. build your own) are separated by 3 unrelated sections (trajectory, philosophy, EAIK comparison). Reader landing on the page has to scroll past philosophy + competitive positioning to find install + their action.

## New structure

```
1.  # ssik + badges + tagline (emphasizes the artifact model in the first sentence)
2.  ## Install                            ← was 11
3.  ## Quickstart                          (3-line minimal example via a prebuilt)
4.  ## The artifact model                  ← central organizing concept
        ### Use a prebuilt arm (ssik.prebuilt) — arm table + teleop pattern
        ### Build an artifact for your own arm — build-time table + when to rebuild
        ### Development path: Manipulator.from_urdf (not for deployment)
5.  ## What solve() returns                (respect_limits, refinement here)
6.  ## Tuning knobs (TolerancePolicy + postprocess)
7.  ## How it compares                     ← merged old EAIK section
                                              + 'Returns all solutions' motivation
8.  ## Under the hood                      ← merged Bulletproof + algorithm refs
                                              + JACO 2 cond(m_quad) anecdote + Cython
9.  ## Documentation / Related / License / Citation
```

## Locked decisions
- **Built artifact is the primary path.** Both `ssik.prebuilt` and `ssik build` framed as the standard workflow; `Manipulator.from_urdf` is dev-only and flagged 'not for deployment'.
- **EAIK comparison stays at H2** (competitive positioning, not buried).
- **Three content cuts** moved to where they fit: `respect_limits` → "What solve() returns"; Cython hot loops → "Under the hood"; JACO 2 cond(m_quad) anecdote → "Under the hood".

## Surface changes
- New opening tagline shows the artifact model in the first sentence: *Each arm becomes a single self-contained Python module — `import franka_panda_ik; franka_panda_ik.solve(T)` — that returns every IK branch at machine-precision FK closure.*
- Prebuilts in a scannable table (module | arm | kinematic class) instead of a prose list
- Build-time table (<1 s tier-0 / ~30 s non-Pieper 6R / 7–20 min non-SRS 7R) instead of pickle-blob detail
- `Manipulator.from_urdf` demoted to a sub-section under "The artifact model" with explicit 'not for deployment' framing

## Test plan
- [x] No content lost: all sections of the previous README are present in the new structure, just relocated
- [x] Internal anchors still resolve
- [x] External links unchanged

Closes #253.