### PR TITLE
Cross-compile macOS x86_64 wheel from arm64 runner (#132)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Linux x86_64 (manylinux), macOS arm64 (M-runner), macOS x86_64
-        # (Intel runner), Windows x86_64. Python versions cp311/cp312/cp313
-        # are configured in pyproject.toml's [tool.cibuildwheel].
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        # Linux x86_64 (manylinux), macOS arm64 + x86_64 (both from the
+        # M-class runner via cibuildwheel cross-compile -- see
+        # [tool.cibuildwheel.macos] in pyproject.toml), Windows x86_64.
+        # GitHub's Intel macOS runner pool (macos-13) has multi-hour
+        # queue latency as Intel hosts are deprecated; cross-compiling
+        # x86_64 from arm64 avoids the bottleneck without dropping
+        # Intel-Mac wheel coverage.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ build = "cp311-* cp312-* cp313-*"
 # Skip targets we don't ship in v1.0 (#132 "Deferred to v1.1+"): musllinux,
 # 32-bit Linux, 32-bit Windows, PyPy. Linux aarch64 is also deferred.
 skip = ["*-musllinux_*", "*-manylinux_i686", "*-win32", "pp*", "*linux_aarch64"]
+# x86_64 wheels are cross-compiled from the arm64 macos-latest runner
+# (see [tool.cibuildwheel.macos]); cibuildwheel can build them but can't
+# run them on arm64 hardware, so skip the test-command for x86_64 only.
+# The arm64 wheel is fully built + smoke-tested in the same job.
+test-skip = "*-macosx_x86_64"
 build-verbosity = 1
 test-requires = ["numpy>=2.0"]
 # Wheel smoke gate. Runs in the cibuildwheel test venv against the BUILT
@@ -129,6 +134,16 @@ test-command = [
 [tool.cibuildwheel.linux]
 # manylinux_2_28 ships GCC 14; sufficient for Cython 3.x.
 manylinux-x86_64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+# Build both arm64 (native) and x86_64 (cross-compiled) on the macos-latest
+# (M-class) runner. Dropping macos-13 from the release matrix because the
+# Intel runner queue has multi-hour latency as GitHub deprecates Intel hosts;
+# cibuildwheel's cross-compile path is well-trodden and the resulting wheel
+# is the same as what an Intel runner would produce (same compiler invocation,
+# same flags, just hosted on a different CPU). Test-skip above prevents
+# cibuildwheel from trying to RUN the x86_64 wheel on arm64.
+archs = ["arm64", "x86_64"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Why

rc3's release workflow sat 3+ hours waiting for GitHub's Intel macOS runner (macos-13). The other 4 jobs all completed in <10 minutes. GitHub is deprecating Intel macOS runners; queue latencies are getting worse and unpredictable.

## Fix

Build both arm64 and x86_64 macOS wheels from the **single arm64 runner** (macos-latest, M-class) via cibuildwheel's cross-compile path. Drop macos-13 from the matrix.

### Changes

- `pyproject.toml [tool.cibuildwheel.macos]` → `archs = ["arm64", "x86_64"]`
- `pyproject.toml [tool.cibuildwheel]` → `test-skip = "*-macosx_x86_64"` (the arm64 runner can build x86_64 but can't run it for the smoke test; the smoke test still gates the arm64 wheel)
- `.github/workflows/release.yml` → drop `macos-13` from the OS matrix

## Trade-off accepted

The x86_64 wheel isn't smoke-tested on native Intel at build time. Mitigants:
- cibuildwheel's cross-compile path is well-trodden (numpy, scipy, pandas all use it)
- The cross-compile uses the same `clang -arch x86_64` flags a native Intel build would; resulting binary is bit-equivalent on Intel hosts
- The arm64 wheel IS smoke-tested in the same job (catches Cython compile / scipy / HP import issues across the package)
- Intel Macs are a shrinking install base (Apple stopped selling them in 2023)
- sdist remains available for users who want to build natively

## Test plan
- [x] ruff + mypy clean
- [ ] CI green on this PR (regular ci.yml)
- [ ] After merge: tag v1.0.0rc4 to verify the release workflow now produces all platforms in ~10 minutes total

Closes the macos-13 bottleneck on #132.