### PR TITLE
README: drop misleading inline import from tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/ssik.svg)](https://pypi.org/project/ssik/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 
-Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module — `import franka_panda_ik; franka_panda_ik.solve(T)` — that returns **every IK branch** at machine-precision FK closure.
+Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module that returns **every IK branch** at machine-precision FK closure.
 
 ## Install
 


### PR DESCRIPTION
Tagline showed `import franka_panda_ik` — but after `pip install ssik` that flat import raises `ModuleNotFoundError` (the actual prebuilt-path import is `from ssik.prebuilt import franka_panda_ik`, which the Quickstart at line 20 shows correctly).

Drop the inline-code from the tagline so it doesn't mislead readers; the Quickstart immediately below carries the actual usage shape.

Side benefit: pushing this triggers GitHub's image-proxy (Camo) to refresh the PyPI / Python-versions badges, which had been showing 'package or version not found' from cached pre-1.0.0 fetches.