### PR TITLE
README: cache-bust badge URLs to force Camo refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ssik
 
-[![PyPI](https://img.shields.io/pypi/v/ssik.svg)](https://pypi.org/project/ssik/)
-[![Python](https://img.shields.io/pypi/pyversions/ssik.svg)](https://pypi.org/project/ssik/)
+[![PyPI](https://img.shields.io/pypi/v/ssik.svg?v=1)](https://pypi.org/project/ssik/)
+[![Python](https://img.shields.io/pypi/pyversions/ssik.svg?v=1)](https://pypi.org/project/ssik/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 
 Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module that returns **every IK branch** at machine-precision FK closure.


### PR DESCRIPTION
After v1.0.0 published, the PyPI version badge refreshed but pyversions still showed 'package or version not found' from a Camo-cached pre-publish fetch.

shields.io itself returns the correct content for both:
```
$ curl -s https://img.shields.io/pypi/pyversions/ssik.svg | grep -oE 'python: [^<]+'
python: 3.11 | 3.12 | 3.13
```

GitHub's image proxy (Camo) keys per-URL; changing the URL (even with a meaningless query param like `?v=1`) makes Camo treat it as a new image and refetch.

Doc-only change; no CI.