### PR TITLE
Prebuilt discoverability: BASE_LINK / EE_LINK / DOF / T_HOME + frame-clarity README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,52 @@ There are two artifact paths:
 
 ### Use a prebuilt arm (`ssik.prebuilt`)
 
-The wheel ships 8 ready-to-import artifacts:
+The wheel ships 8 ready-to-import artifacts. Each was built against a specific URDF (or extracted spec); `T_target` is the pose of `EE_LINK` expressed in `BASE_LINK`:
 
-| Module | Arm | Class |
-|---|---|---|
-| `ur5_ik` | Universal Robots UR5 | three-parallel 6R |
-| `puma560_ik` | KUKA Puma 560 | Pieper 6R (spherical wrist) |
-| `jaco2_ik` | Kinova JACO 2 | **non-Pieper 6R** |
-| `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R |
-| `gen3_ik` | Kinova Gen3 7-DOF | **approximate-SRS 7R** |
-| `franka_panda_ik` | Franka Panda | anthropomorphic 7R |
-| `rizon4_ik` | Flexiv Rizon 4 | **non-SRS 7R** |
-| `kassow_kr810_ik` | Kassow KR810 | **non-SRS 7R** |
+| Module | Arm | Class | base_link | ee_link |
+|---|---|---|---|---|
+| `ur5_ik` | Universal Robots UR5 | three-parallel 6R | `base_link` | `ee_link` |
+| `puma560_ik` | KUKA Puma 560 | Pieper 6R (spherical wrist) | `base_link` | `wrist_3_link` |
+| `jaco2_ik` | Kinova JACO 2 | **non-Pieper 6R** | `base_link` | `ee_link` |
+| `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R | `world` | `tool0` |
+| `gen3_ik` | Kinova Gen3 7-DOF | **approximate-SRS 7R** | `base_link` | `end_effector_link` |
+| `franka_panda_ik` | Franka Panda | anthropomorphic 7R | `base_link` | `ee_link` |
+| `rizon4_ik` | Flexiv Rizon 4 | **non-SRS 7R** | `base_link` | `flange` |
+| `kassow_kr810_ik` | Kassow KR810 | **non-SRS 7R** | `base` | `end_effector` |
 
 ```python
 from ssik.prebuilt import iiwa14_ik
 sols = iiwa14_ik.solve(T_target)
 ```
+
+Every prebuilt exposes `BASE_LINK`, `EE_LINK`, `DOF`, and `T_HOME` (the 4×4 home pose, FK at `q = np.zeros(DOF)`) as module constants. Use them to verify the baked geometry matches your robot:
+
+```python
+from ssik.prebuilt import franka_panda_ik
+print(franka_panda_ik.BASE_LINK, "→", franka_panda_ik.EE_LINK, "(", franka_panda_ik.DOF, "DOF)")
+# base_link → ee_link ( 7 DOF)
+print(franka_panda_ik.T_HOME[:3, 3])
+# array([0.088, 0., 0.926])     ← Franka home pose; matches the spec
+```
+
+### When a prebuilt is right vs when to `ssik build`
+
+The 8 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
+
+- You're using the same URDF source we built against (ros-industrial, manufacturer reference, etc.)
+- Your robot's calibration matches the nominal kinematic parameters
+- Your end-effector is the flange itself — no gripper, suction cup, or custom tool past it
+- Your URDF link names match what we baked (see the table above)
+
+If **any** of those is false — and especially if you're a 7R arm with anything attached past the flange — build your own:
+
+```bash
+pip install ssik[urdf]
+ssik build <your.urdf> --base <your_base_link> --ee <your_actual_tool_link>
+# → <your_arm>_ik.py
+```
+
+`ssik build` reads your exact URDF, picks the right solver via the same dispatcher we use, and emits a single-file artifact correct for your kinematic chain. That artifact's import / API / public constants are identical to the prebuilts'.
 
 For trajectory tracking and IK-based teleop, the canonical pattern is "give me the IK closest to where the robot is now":
 

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from io import StringIO
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from ssik._kinbody import KinBody
     from ssik.core.dispatcher import DispatchPlan
@@ -172,6 +174,7 @@ def _render_thin_wrapper(
     buf.write(f"EXPECTED_MS_MEDIAN = {plan.expected_ms_median!r}\n")
     buf.write(f"FLOP_BUDGET = {plan.flop_budget}\n")
     buf.write(_render_dispatch_reason(plan.reason))
+    buf.write(_render_introspection_constants(kb))
     buf.write("\n")
     buf.write(_render_kinbody_constants(kb))
     buf.write("\n")
@@ -235,6 +238,7 @@ def _render_specialised(
     buf.write(f"EXPECTED_MS_MEDIAN = {plan.expected_ms_median!r}\n")
     buf.write(f"FLOP_BUDGET = {plan.flop_budget}\n")
     buf.write(_render_dispatch_reason(plan.reason))
+    buf.write(_render_introspection_constants(kb))
     buf.write("\n")
     buf.write(_render_kinbody_constants(kb))
     buf.write("\n")
@@ -1012,8 +1016,20 @@ def _render_header(module_name: str, arm_label: str, plan: DispatchPlan, kb: Kin
     which drifts between local checkouts and CI -- not actually stable.
     The artifact's ssik provenance lives in the parent repo's git history
     (e.g. ``git log -- tests/artifacts/ur5_ik.py``).
+
+    The docstring includes base / end-effector link names + DOF + home FK
+    so a downstream user can immediately see which kinematic frame their
+    ``T_target`` is expressed in (and whether the baked chain matches
+    their own URDF). ``T_target`` is the pose of ``EE_LINK`` in
+    ``BASE_LINK``; if the user's URDF disagrees on link selection
+    (calibrated geometry, custom tool past the flange, different
+    naming), they should run ``ssik build <their.urdf> --base X --ee Y``
+    rather than rely on this artifact.
     """
     digest_str = _kb_digest(kb)
+    base_link = kb.links[0].name
+    ee_link = kb.links[-1].name
+    dof = len(kb.joints)
     return textwrap.dedent(
         f'''\
         """Generated IK module for {arm_label}.
@@ -1024,7 +1040,13 @@ def _render_header(module_name: str, arm_label: str, plan: DispatchPlan, kb: Kin
         load a URDF or MJCF at runtime.
 
         Provenance: KinBody hash {digest_str} (sha256/12 of the input chain).
+        ``T_target`` is the pose of ``{ee_link}`` (end-effector link) in
+        ``{base_link}`` (base link). If your URDF differs (calibrated
+        geometry, custom tool past the flange, different link names),
+        run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+        produce an artifact correct for your hardware.
 
+        DOF: {dof}    BASE_LINK: "{base_link}"    EE_LINK: "{ee_link}"
         Solver: ``{plan.solver_name}`` (tier {plan.tier})
         Expected median IK time: ~{plan.expected_ms_median} ms on commodity
         single-thread hardware. FLOP budget: {plan.flop_budget:,} per solve.
@@ -1033,7 +1055,7 @@ def _render_header(module_name: str, arm_label: str, plan: DispatchPlan, kb: Kin
 
             import {module_name}
             import numpy as np
-            T_target = np.eye(4)  # 4x4 SE(3) pose
+            T_target = np.eye(4)  # 4x4 SE(3) pose of {ee_link} in {base_link}
             T_target[:3, 3] = [0.5, 0.1, 0.3]
             solutions = {module_name}.solve(T_target)
             for sol in solutions:
@@ -1042,6 +1064,10 @@ def _render_header(module_name: str, arm_label: str, plan: DispatchPlan, kb: Kin
         ``solve(T)`` returns ``list[Solution]``. Empty list iff no
         candidate closed within the solver's FK tolerance -- check
         ``if not solutions:`` for the "unreachable" case.
+
+        Sanity-check the baked geometry: ``{module_name}.T_HOME`` is the
+        4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+        your robot's home pose, the artifact is for a different URDF.
         """'''
     )
 
@@ -1050,6 +1076,35 @@ def _render_dispatch_reason(reason: str) -> str:
     """Bake the dispatcher's explanatory diagnostic as a module-level constant."""
     # ``repr`` keeps newlines and quoting safe inside the rendered source.
     return f"DISPATCH_REASON = {reason!r}\n"
+
+
+def _render_introspection_constants(kb: KinBody) -> str:
+    """Emit BASE_LINK / EE_LINK / DOF / T_HOME as public module constants.
+
+    These give downstream callers a way to see -- programmatically -- which
+    kinematic frame the artifact's ``T_target`` is expressed in, without
+    reading the source. ``T_HOME`` is the forward kinematics at
+    ``q = np.zeros(DOF)``: a 4x4 SE(3) pose a user can compare against
+    their robot's documented home pose to verify the baked geometry
+    matches their hardware.
+    """
+    from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+    base_link = kb.links[0].name
+    ee_link = kb.links[-1].name
+    dof = len(kb.joints)
+    t_home = poe_forward_kinematics(kb, np.zeros(dof, dtype=np.float64))
+    lines: list[str] = []
+    lines.append(f'BASE_LINK = "{base_link}"\n')
+    lines.append(f'EE_LINK = "{ee_link}"\n')
+    lines.append(f"DOF = {dof}\n")
+    lines.append(
+        "# Home pose: FK at q = np.zeros(DOF). Sanity-check this against\n"
+        "# your robot's documented home pose to verify the baked geometry\n"
+        "# matches your URDF.\n"
+    )
+    lines.append(f"T_HOME = np.array({t_home.tolist()!r}, dtype=np.float64)\n")
+    return "".join(lines)
 
 
 def _render_kinbody_constants(kb: KinBody) -> str:
@@ -1174,11 +1229,15 @@ def _render_solve_function(solver_short: str) -> str:
 def _render_all_export() -> str:
     return (
         "\n__all__ = ["
+        '\n    "BASE_LINK",'
         '\n    "DISPATCH_REASON",'
+        '\n    "DOF",'
+        '\n    "EE_LINK",'
         '\n    "EXPECTED_MS_MEDIAN",'
         '\n    "FLOP_BUDGET",'
         '\n    "SOLVER_NAME",'
         '\n    "SOLVER_TIER",'
+        '\n    "T_HOME",'
         '\n    "fk",'
         '\n    "solve",'
         "\n]\n"

--- a/src/ssik/prebuilt/franka_panda_ik.py
+++ b/src/ssik/prebuilt/franka_panda_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash d5f03f641ddf (sha256/12 of the input chain).
+``T_target`` is the pose of ``ee_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 7    BASE_LINK: "base_link"    EE_LINK: "ee_link"
 Solver: ``jointlock.seven_r`` (tier 1)
 Expected median IK time: ~50.0 ms on commodity
 single-thread hardware. FLOP budget: 30,274 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import franka_panda_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of ee_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = franka_panda_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``franka_panda_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -51,6 +61,13 @@ SOLVER_TIER = 1
 EXPECTED_MS_MEDIAN = 50.0
 FLOP_BUDGET = 30274
 DISPATCH_REASON = '7R revolute chain (non-SRS). Locking one joint\n(auto-selected by topology rank of the resulting 6R\nsub-chain) reduces this to a series of 6R IK problems.\nCovers Franka Panda, FR3, uFactory xArm7, and any other\nnon-SRS 7R revolute arm.'
+BASE_LINK = "base_link"
+EE_LINK = "ee_link"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[-0.7071068058785943, -0.7071067564945002, 0.0, 0.088], [-0.7071067564944993, 0.7071068058785934, -4.440892098500621e-16, -3.241851231905455e-17], [3.1401848077128287e-16, -3.140185027022262e-16, -0.9999999999999987, 0.9259999999999998], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -524,11 +541,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/gen3_ik.py
+++ b/src/ssik/prebuilt/gen3_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash 9a29063ad96b (sha256/12 of the input chain).
+``T_target`` is the pose of ``end_effector_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 7    BASE_LINK: "base_link"    EE_LINK: "end_effector_link"
 Solver: ``seven_r.srs_polished`` (tier 0)
 Expected median IK time: ~56.0 ms on commodity
 single-thread hardware. FLOP budget: 80,000 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import gen3_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of end_effector_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = gen3_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``gen3_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -45,6 +55,13 @@ SOLVER_TIER = 0
 EXPECTED_MS_MEDIAN = 56.0
 FLOP_BUDGET = 80000
 DISPATCH_REASON = 'Approximately-SRS 7R: shoulder axes meet within 11.8 mm, wrist axes meet within 0.4 mm.\nSingh-Kreutz on the relaxed pivots produces algebraic\ncandidates; LM polish recovers machine-precision FK\nagainst the original URDF. 16-30x faster than the\nuniversal jointlock+HP fallback on small-drift arms.\nCovers Kinova Gen3 (12 mm / 0.4 mm drift).'
+BASE_LINK = "base_link"
+EE_LINK = "end_effector_link"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, -8.326720029981853e-15, -2.1017948830410524e-16, -1.925826838264291e-16], [8.326718485692419e-15, 0.9999999999730148, -7.346410203412496e-06, -0.024859601294873888], [2.102406597994228e-16, 7.346410203412494e-06, 0.9999999999730148, 1.1873847699190918], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -191,11 +208,15 @@ def fk(q):
     return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/iiwa14_ik.py
+++ b/src/ssik/prebuilt/iiwa14_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash fd5922ca3dcc (sha256/12 of the input chain).
+``T_target`` is the pose of ``ee_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 7    BASE_LINK: "base_link"    EE_LINK: "ee_link"
 Solver: ``seven_r.srs`` (tier 0)
 Expected median IK time: ~8.5 ms on commodity
 single-thread hardware. FLOP budget: 1,900 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import iiwa14_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of ee_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = iiwa14_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``iiwa14_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -45,6 +55,13 @@ SOLVER_TIER = 0
 EXPECTED_MS_MEDIAN = 8.5
 FLOP_BUDGET = 1900
 DISPATCH_REASON = 'SRS-class 7R: shoulder axes (joints 0, 1, 2) meet at\none point + wrist axes (joints 4, 5, 6) meet at one\npoint + joint 3 is the elbow. Closed-form Singh-Kreutz\n1989 algorithm, parameterised by elbow swivel angle.\nCovers KUKA iiwa LBR (canonical strict-SRS).'
+BASE_LINK = "base_link"
+EE_LINK = "ee_link"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[0.9999999999999982, 0.0, 0.0, 0.0], [0.0, 0.9999999999999987, 4.4408920985006217e-16, 3.976818874207309e-16], [0.0, 4.440892098500621e-16, 0.9999999999999987, 1.3059999999999994], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -191,11 +208,15 @@ def fk(q):
     return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/jaco2_ik.py
+++ b/src/ssik/prebuilt/jaco2_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash 51772c059f98 (sha256/12 of the input chain).
+``T_target`` is the pose of ``ee_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 6    BASE_LINK: "base_link"    EE_LINK: "ee_link"
 Solver: ``ikgeo.general_6r`` (tier 2)
 Expected median IK time: ~5.0 ms on commodity
 single-thread hardware. FLOP budget: 30,000,000 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import jaco2_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of ee_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = jaco2_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``jaco2_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -57,6 +67,13 @@ SOLVER_TIER = 2
 EXPECTED_MS_MEDIAN = 5.0
 FLOP_BUDGET = 30000000
 DISPATCH_REASON = 'No tier-0 (Pieper-class) match.\nTier-2 numeric Raghavan-Roth + Manocha-Canny pipeline with AE-3 leftvar selection. Closes the EAIK coverage gap (Kinova JACO 2 classical, Agilex Piper, custom non-Pieper 6R).\nWeaker structural matches (not used):\n  - axes[1] parallel to axes[2] (would match tier-1 `two_parallel`, but tier-2 RR is ~50x faster)'
+BASE_LINK = "base_link"
+EE_LINK = "ee_link"
+DOF = 6
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[2.220446049250311e-16, 0.9999999999999989, 0.0, 0.0], [-0.9999999999999994, -2.2204460492503123e-16, -5.794811673164996e-17, 0.06426189529703795], [1.6653345369377343e-16, 3.697785493223493e-32, 0.9999999999999991, 0.3610789057492346], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -970,11 +987,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/kassow_kr810_ik.py
+++ b/src/ssik/prebuilt/kassow_kr810_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash c56989708c2d (sha256/12 of the input chain).
+``T_target`` is the pose of ``end_effector`` (end-effector link) in
+``base`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 7    BASE_LINK: "base"    EE_LINK: "end_effector"
 Solver: ``jointlock.seven_r`` (tier 1)
 Expected median IK time: ~50.0 ms on commodity
 single-thread hardware. FLOP budget: 30,274 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import kassow_kr810_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of end_effector in base
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = kassow_kr810_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``kassow_kr810_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -51,6 +61,13 @@ SOLVER_TIER = 1
 EXPECTED_MS_MEDIAN = 50.0
 FLOP_BUDGET = 30274
 DISPATCH_REASON = '7R revolute chain (non-SRS). Locking one joint\n(auto-selected by topology rank of the resulting 6R\nsub-chain) reduces this to a series of 6R IK problems.\nCovers Franka Panda, FR3, uFactory xArm7, and any other\nnon-SRS 7R revolute arm.'
+BASE_LINK = "base"
+EE_LINK = "end_effector"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.10935], [0.0, 0.0, 1.0, 1.2081000000000002], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -3411,11 +3428,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/puma560_ik.py
+++ b/src/ssik/prebuilt/puma560_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash d7fe5076cb07 (sha256/12 of the input chain).
+``T_target`` is the pose of ``wrist_3_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 6    BASE_LINK: "base_link"    EE_LINK: "wrist_3_link"
 Solver: ``ikgeo.spherical_two_parallel`` (tier 0)
 Expected median IK time: ~1.2 ms on commodity
 single-thread hardware. FLOP budget: 1,316 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import puma560_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of wrist_3_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = puma560_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``puma560_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -52,6 +62,13 @@ SOLVER_TIER = 0
 EXPECTED_MS_MEDIAN = 1.2
 FLOP_BUDGET = 1316
 DISPATCH_REASON = 'Spherical wrist at joints (3, 4, 5) AND axes[1] parallel to axes[2] AND ||p[1]|| ~= 0.\nBoth Pieper specialisations apply (e.g. Puma 560); the parallel-shoulder solver is preferred for slightly tighter elbow conditioning.'
+BASE_LINK = "base_link"
+EE_LINK = "wrist_3_link"
+DOF = 6
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, 0.0, 0.0, 0.4521], [0.0, 1.0, 0.0, -0.15005], [0.0, 0.0, 1.0, 0.4318], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -624,11 +641,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/rizon4_ik.py
+++ b/src/ssik/prebuilt/rizon4_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash b54beb48f15c (sha256/12 of the input chain).
+``T_target`` is the pose of ``flange`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 7    BASE_LINK: "base_link"    EE_LINK: "flange"
 Solver: ``jointlock.seven_r`` (tier 1)
 Expected median IK time: ~50.0 ms on commodity
 single-thread hardware. FLOP budget: 30,274 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import rizon4_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of flange in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = rizon4_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``rizon4_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -51,6 +61,13 @@ SOLVER_TIER = 1
 EXPECTED_MS_MEDIAN = 50.0
 FLOP_BUDGET = 30274
 DISPATCH_REASON = '7R revolute chain (non-SRS). Locking one joint\n(auto-selected by topology rank of the resulting 6R\nsub-chain) reduces this to a series of 6R IK problems.\nCovers Franka Panda, FR3, uFactory xArm7, and any other\nnon-SRS 7R revolute arm.'
+BASE_LINK = "base_link"
+EE_LINK = "flange"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[-2.0510342902014015e-10, 1.230620571007852e-09, 1.0, 0.09599999987939918], [-4.102068567782578e-10, 1.0, -1.2306205710919869e-09, -0.11300000010993543], [-1.0, -4.102068570306623e-10, -2.0510342851533115e-10, 1.2549999999833867], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -4211,11 +4228,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -6,7 +6,13 @@ per-arm KinBody constants are baked in below; you do not need to
 load a URDF or MJCF at runtime.
 
 Provenance: KinBody hash 18d616aad415 (sha256/12 of the input chain).
+``T_target`` is the pose of ``ee_link`` (end-effector link) in
+``base_link`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
 
+DOF: 6    BASE_LINK: "base_link"    EE_LINK: "ee_link"
 Solver: ``ikgeo.three_parallel`` (tier 0)
 Expected median IK time: ~1.6 ms on commodity
 single-thread hardware. FLOP budget: 2,519 per solve.
@@ -15,7 +21,7 @@ Usage:
 
     import ur5_ik
     import numpy as np
-    T_target = np.eye(4)  # 4x4 SE(3) pose
+    T_target = np.eye(4)  # 4x4 SE(3) pose of ee_link in base_link
     T_target[:3, 3] = [0.5, 0.1, 0.3]
     solutions = ur5_ik.solve(T_target)
     for sol in solutions:
@@ -24,6 +30,10 @@ Usage:
 ``solve(T)`` returns ``list[Solution]``. Empty list iff no
 candidate closed within the solver's FK tolerance -- check
 ``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``ur5_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
 """
 
 from __future__ import annotations
@@ -53,6 +63,13 @@ SOLVER_TIER = 0
 EXPECTED_MS_MEDIAN = 1.6
 FLOP_BUDGET = 2519
 DISPATCH_REASON = 'Three consecutive parallel axes at joints (1, 2, 3) -- the UR-class structure (UR3 / UR5 / UR10).\nClosed-form via SP6 (joints 0+4) + SP1 + SP3.'
+BASE_LINK = "base_link"
+EE_LINK = "ee_link"
+DOF = 6
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, 0.0, 0.0, -0.81725], [0.0, 6.123233995736766e-17, -1.0, -0.19145], [0.0, 1.0, 6.123233995736766e-17, -0.005490999999999996], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
 
 # --- baked KinBody constants ---
 
@@ -584,11 +601,15 @@ def solve(
 fk = _fk
 
 __all__ = [
+    "BASE_LINK",
     "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
     "EXPECTED_MS_MEDIAN",
     "FLOP_BUDGET",
     "SOLVER_NAME",
     "SOLVER_TIER",
+    "T_HOME",
     "fk",
     "solve",
 ]


### PR DESCRIPTION
## Why

After v1.0.0 shipped, a user who `pip install ssik` and reaches for a prebuilt has no easy way to discover which kinematic frame the artifact's `T_target` is in. The docstring said '4x4 SE(3) pose' without specifying *base* or *EE* link. For 7R arms with custom tool attachments — common in the wild — this is a real adoption risk: every prebuilt is **bare-flange IK against ONE specific URDF source**. A user with a calibrated geometry, attached gripper, or different link naming convention needs `ssik build`, not the prebuilt.

## Changes

### Codegen template (`src/ssik/core/codegen.py`)

- **`_render_header`** — docstring now states *"T_target is the pose of EE_LINK in BASE_LINK"* explicitly, lists DOF, points users at `ssik build` when their URDF differs, and tells them to sanity-check `T_HOME` against their robot's documented home pose.
- **New `_render_introspection_constants`** — emits `BASE_LINK`, `EE_LINK`, `DOF`, `T_HOME` (FK at `q = np.zeros(DOF)`) as module-level constants. Callers can verify the baked geometry programmatically without reading source:

```python
from ssik.prebuilt import franka_panda_ik
print(franka_panda_ik.BASE_LINK, "→", franka_panda_ik.EE_LINK, "(", franka_panda_ik.DOF, "DOF)")
# base_link → ee_link ( 7 DOF)
print(franka_panda_ik.T_HOME[:3, 3])
# array([0.088, 0., 0.926])    ← matches the Franka spec
```

- `__all__` updated to include the new constants.

### Prebuilt regeneration

All 8 prebuilts regenerated via `scripts/regen_artifacts.py --include-slow`. Rizon 4 + Kassow KR810 each rebuilt the cached-RR derivation (total ~11 min). `test_artifact_snapshots.py` is byte-equal to the new codegen template output.

### README

- **Prebuilts table** extended with `base_link` / `ee_link` columns so users see the frame conventions before they import.
- **New `### When a prebuilt is right vs when to \`ssik build\`` subsection** — honest about the prebuilts being nominal-geometry / bare-flange demos. Points users at `ssik build` for calibrated URDFs, custom tools, or different link selection. Lists the 4 conditions under which a prebuilt is correct for their robot, and the (very common) cases where it isn't.

## Verified locally

- [x] All 8 prebuilts expose `BASE_LINK` / `EE_LINK` / `DOF` / `T_HOME`
- [x] `test_prebuilt_sanity.py` + `test_artifact_snapshots.py`: **14 passed**
- [x] `scripts/check.sh --no-tests`: ruff + format + mypy green
- [x] Spot-check `T_HOME[:3, 3]` for franka matches manufacturer-spec home pose

## Out of scope (deferred)

- Source-URL provenance in each artifact docstring ("built from this URDF, this commit"). Would require plumbing a `source_info` arg through `ssik build` and `scripts/regen_artifacts.py`. Useful but additive; ship the introspection constants first.
- `compare_kinbody(prebuilt._KB, user_kb)` helper that warns of geometric mismatch. Nice-to-have for the case where a user is unsure if their URDF matches ours.

Slated as v1.0.1.