### PR TITLE
Diagnostic mode: solve(T, explain=True) on Manipulator (#265 phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ By default `solve()` runs **`respect_limits=True`**: out-of-URDF-limit branches 
 
 The `allow_refinement=True` opt-in runs LM polish per algebraic candidate at a few hundred microseconds per branch — useful when an algebraic candidate lands just above `fk_atol` near a kinematic singularity.
 
+### Diagnosing an empty result — `explain=True`
+
+If `solve()` returns `[]`, you can attribute the failure with `explain=True` instead of guessing:
+
+```python
+import ssik
+arm = ssik.Manipulator.from_urdf("my_arm.urdf", base="base_link", ee="tool0")
+sols, diag = arm.solve(T_target, explain=True)
+if not sols:
+    print(diag.summary())
+    # solver: ikgeo.three_parallel (tier 0)
+    # dispatch: Three consecutive parallel axes at joints (1, 2, 3) ...
+    #   -> 0 raw candidates: pose appears unreachable
+    #      (or outside this solver's analytical envelope)
+```
+
+The `Diagnostic` record distinguishes:
+- **Unreachable** (`raw_candidates == 0`) — pose is outside the solver's analytical envelope
+- **All-filtered** (`raw_candidates > 0`, `final_count == 0`) — try `respect_limits=False` for the raw geometric set
+- **Capped** (`dropped_by_max_solutions > 0`) — pass a larger `max_solutions`
+
+Available on `ssik.Manipulator.solve` today; per-prebuilt explain mode tracked in [#265](https://github.com/personalrobotics/ssik/issues/265).
+
 ## Tuning knobs
 
 ### `TolerancePolicy` — six thresholds, one object

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -40,6 +40,7 @@ diagnostics::
 import logging as _logging
 
 from ssik._version import __version__
+from ssik.core.diagnostic import Diagnostic
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.manipulator import Manipulator
@@ -51,6 +52,7 @@ _logging.getLogger(__name__).addHandler(_logging.NullHandler())
 
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",
+    "Diagnostic",
     "Manipulator",
     "Solution",
     "TolerancePolicy",

--- a/src/ssik/core/diagnostic.py
+++ b/src/ssik/core/diagnostic.py
@@ -1,0 +1,130 @@
+"""Diagnostic record for ``solve(T, explain=True)`` (#265).
+
+Today's failure mode for ``solve(T)`` is opaque: callers get an empty
+``list[Solution]`` and have to guess whether the pose was unreachable,
+near-singular, filtered by joint limits, or hit a solver bug. The
+``Diagnostic`` returned alongside the solutions on explain mode lets the
+caller attribute failures concretely.
+
+Counts are aggregate-only by default (cheap); per-candidate dispositions
+are out of scope for the v1.1.0 introduction. Per-IK ``Solution.fk_residual``
+already lets a caller inspect individual survivors.
+
+Usage::
+
+    arm = ssik.prebuilt.iiwa14_ik
+    sols, diag = arm.solve(T_target, explain=True)
+    if not sols:
+        print(diag.summary())
+        # solver: seven_r.srs (tier 0)
+        # 0 raw candidates -> 0 returned (pose appears unreachable
+        # within tolerance policy.subproblem_numerical = 1e-05).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """Per-call diagnostic record from ``solve(T, explain=True)``.
+
+    All counts are post-filter aggregates -- the solver's own
+    enumeration cost (number of raw algebraic candidates before any
+    filtering) is in ``raw_candidates``; each subsequent filter is a
+    delta. ``final_count == len(returned_solutions)``.
+
+    The fields are deliberately data-only (no methods that re-run the
+    solve, no live references to the kinbody). A diagnostic is a
+    snapshot, safe to log / serialise.
+    """
+
+    solver_name: str
+    """Dispatched solver, e.g. ``"ikgeo.three_parallel"``."""
+
+    solver_tier: int
+    """0 = closed-form, 1 = univariate search, 2 = bivariate search."""
+
+    dispatch_reason: str
+    """Human-readable explanation of why the dispatcher picked this solver.
+    Often the most useful field for 'why did ssik refuse my arm?' triage."""
+
+    raw_candidates: int
+    """Raw analytical candidate count returned by the inner solver, before
+    any post-processing. ``0`` means the solver itself returned nothing --
+    pose is outside the analytical reach or the solver's preconditions
+    aren't met. ``>0`` with ``final_count == 0`` means every candidate was
+    filtered (limits, etc.)."""
+
+    dropped_by_limits: int
+    """Candidates that fell outside URDF joint limits (after the ``q ± 2π``
+    rescue pass). ``0`` when ``respect_limits=False`` was passed."""
+
+    dropped_by_max_solutions: int
+    """Surviving candidates truncated by the ``max_solutions`` cap."""
+
+    final_count: int
+    """Number of solutions in the returned list."""
+
+    max_fk_residual: float
+    """Worst ``fk_residual`` among returned solutions. ``nan`` when
+    ``final_count == 0``."""
+
+    refinement_engaged: int
+    """How many candidates ran through Levenberg-Marquardt polish (when
+    ``allow_refinement=True`` was passed). ``0`` when refinement was off."""
+
+    fk_atol: float
+    """The FK-closure threshold the solver used. Useful when the user
+    customised the tolerance policy and wants the live value back."""
+
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    """Optional conditioning / robustness flags raised during the solve.
+    Empty tuple in the common-path. Today: forward-compatible reservation;
+    populated by the HP / RR solvers once they wire up conditioning checks
+    (#178)."""
+
+    def summary(self) -> str:
+        """One-paragraph human-readable summary for logging / triage.
+
+        Distinguishes the four common cases:
+        - reachable (returned >=1 IK)
+        - unreachable (0 raw candidates)
+        - all-filtered (raw candidates > 0, final 0 -- joint limits etc.)
+        - capped (max_solutions truncation)
+        """
+        lines = [
+            f"solver: {self.solver_name} (tier {self.solver_tier})",
+            f"dispatch: {self.dispatch_reason}",
+        ]
+        if self.final_count > 0:
+            lines.append(
+                f"  -> {self.raw_candidates} candidates "
+                f"-> {self.final_count} returned (max FK {self.max_fk_residual:.1e}, "
+                f"threshold {self.fk_atol:.0e})"
+            )
+            if self.dropped_by_limits:
+                lines.append(f"  filtered by joint limits: {self.dropped_by_limits}")
+            if self.dropped_by_max_solutions:
+                lines.append(f"  capped by max_solutions: {self.dropped_by_max_solutions}")
+        elif self.raw_candidates == 0:
+            lines.append(
+                "  -> 0 raw candidates: pose appears unreachable "
+                "(or outside this solver's analytical envelope)"
+            )
+        else:
+            lines.append(f"  -> {self.raw_candidates} raw candidates, all filtered:")
+            if self.dropped_by_limits:
+                lines.append(
+                    f"     dropped by joint limits: {self.dropped_by_limits} "
+                    f"(pass respect_limits=False for the raw geometric set)"
+                )
+        if self.refinement_engaged:
+            lines.append(f"  LM polish engaged on {self.refinement_engaged} candidates")
+        for w in self.warnings:
+            lines.append(f"  warning: {w}")
+        return "\n".join(lines)
+
+
+__all__ = ["Diagnostic"]

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -27,12 +27,13 @@ from __future__ import annotations
 import importlib
 import inspect
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 from ssik._kinbody import KinBody
+from ssik.core.diagnostic import Diagnostic
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
@@ -215,10 +216,12 @@ class Manipulator:
     # Inverse kinematics
     # ------------------------------------------------------------------
 
+    @overload
     def solve(
         self,
         T_target: ArrayLike,
         *,
+        explain: Literal[False] = False,
         max_solutions: int | None = None,
         q_seed: ArrayLike | None = None,
         respect_limits: bool = True,
@@ -226,10 +229,43 @@ class Manipulator:
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
         **solver_kwargs: Any,
-    ) -> list[Solution]:
+    ) -> list[Solution]: ...
+
+    @overload
+    def solve(
+        self,
+        T_target: ArrayLike,
+        *,
+        explain: Literal[True],
+        max_solutions: int | None = None,
+        q_seed: ArrayLike | None = None,
+        respect_limits: bool = True,
+        allow_refinement: bool = False,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+        refinement_max_iters: int = 15,
+        **solver_kwargs: Any,
+    ) -> tuple[list[Solution], Diagnostic]: ...
+
+    def solve(
+        self,
+        T_target: ArrayLike,
+        *,
+        explain: bool = False,
+        max_solutions: int | None = None,
+        q_seed: ArrayLike | None = None,
+        respect_limits: bool = True,
+        allow_refinement: bool = False,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+        refinement_max_iters: int = 15,
+        **solver_kwargs: Any,
+    ) -> list[Solution] | tuple[list[Solution], Diagnostic]:
         """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
 
         :param T_target: 4x4 SE(3) target pose.
+        :param explain: when ``True``, returns ``(sols, Diagnostic)``
+            instead of just ``sols``. The diagnostic carries dispatch +
+            filter attribution for triaging empty-list failures. Default
+            ``False`` preserves the v1.0 return signature.
         :param max_solutions: optional cap on returned IKs (post-dedup,
             post-limits filter). ``None`` = full redundancy enumeration.
             ``1`` combined with ``q_seed`` is the trajectory-tracking idiom.
@@ -259,7 +295,9 @@ class Manipulator:
             Empty list iff no candidate FK-closed within
             ``policy.subproblem_numerical`` (or all IKs were filtered by
             ``respect_limits=True``). Check ``if not sols:`` for
-            "unreachable target".
+            "unreachable target". When ``explain=True``, returns
+            ``(sols, Diagnostic)`` -- inspect ``Diagnostic.summary()``
+            to attribute empty-list failures.
 
         :raises ValueError: if ``T_target.shape != (4, 4)`` or
             ``len(q_seed) != dof`` when ``q_seed`` is given.
@@ -307,6 +345,7 @@ class Manipulator:
         # tuple at the public-API boundary. `is_ls` is redundant with
         # `len(sols) == 0` in every shipped solver -- ssik #238 item 1.
         sols, _is_ls = self._solver_module.solve(self._kb, T, **kwargs)
+        raw_candidate_count = len(sols)
 
         # Cross-arm postprocess pass: solvers that didn't honour kwargs
         # natively get them applied here so the public API is uniform.
@@ -317,10 +356,34 @@ class Manipulator:
         # (the JACO 2 case).
         if respect_limits:
             sols = _ps_wrap_to_limits(sols, self._kb)
+            pre_limit_count = len(sols)
             sols = _ps_respect_limits(sols, self._kb)
+            dropped_by_limits = pre_limit_count - len(sols)
+        else:
+            dropped_by_limits = 0
         if q_seed_arr is not None:
             sols = _ps_nearest_to_seed(sols, q_seed_arr)
         if max_solutions is not None and len(sols) > max_solutions:
+            dropped_by_max_solutions = len(sols) - max_solutions
             sols = sols[:max_solutions]
+        else:
+            dropped_by_max_solutions = 0
         result: list[Solution] = sols
-        return result
+        if not explain:
+            return result
+
+        refinement_engaged = sum(1 for s in result if s.refinement_used == "lm")
+        max_fk = max((s.fk_residual for s in result), default=float("nan"))
+        diag = Diagnostic(
+            solver_name=self._plan.solver_name,
+            solver_tier=self._plan.tier,
+            dispatch_reason=self._plan.reason,
+            raw_candidates=raw_candidate_count,
+            dropped_by_limits=dropped_by_limits,
+            dropped_by_max_solutions=dropped_by_max_solutions,
+            final_count=len(result),
+            max_fk_residual=max_fk,
+            refinement_engaged=refinement_engaged,
+            fk_atol=policy.subproblem_numerical,
+        )
+        return result, diag

--- a/tests/test_explain_mode.py
+++ b/tests/test_explain_mode.py
@@ -1,0 +1,137 @@
+"""Diagnostic / explain mode on Manipulator.solve (#265).
+
+Smoke-tests for ``Manipulator.solve(T, explain=True) -> (sols, Diagnostic)``.
+The diagnostic record attributes empty-list failures to a concrete cause
+(unreachable / out-of-limits / capped) so callers don't have to guess.
+
+Per-prebuilt explain mode (codegen-template work, three templates total)
+is tracked separately as a follow-up; only the Manipulator path is
+covered here.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import ssik
+from ssik import Diagnostic, Manipulator
+
+FIXTURES = Path(__file__).parent / "fixtures"
+sys.path.insert(0, str(FIXTURES))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ur5() -> Manipulator:
+    return ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+
+
+# ---------------------------------------------------------------------------
+# Default path: explain=False preserves the list-only return signature.
+# ---------------------------------------------------------------------------
+
+
+def test_default_returns_list_not_tuple(ur5: Manipulator) -> None:
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    result = ur5.solve(T)
+    assert isinstance(result, list)
+    assert all(hasattr(s, "q") for s in result)
+
+
+def test_explain_false_explicitly_returns_list(ur5: Manipulator) -> None:
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    result = ur5.solve(T, explain=False)
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Explain=True: returns a (sols, Diagnostic) tuple.
+# ---------------------------------------------------------------------------
+
+
+def test_explain_true_returns_tuple_with_diagnostic(ur5: Manipulator) -> None:
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    result = ur5.solve(T, explain=True)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    sols, diag = result
+    assert isinstance(sols, list)
+    assert isinstance(diag, Diagnostic)
+
+
+def test_explain_diagnostic_fields_on_reachable_pose(ur5: Manipulator) -> None:
+    """A reachable pose: raw_candidates > 0, final_count > 0, FK is finite."""
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    sols, diag = ur5.solve(T, explain=True)
+    assert sols
+    assert diag.solver_name == "ikgeo.three_parallel"
+    assert diag.solver_tier == 0
+    assert diag.raw_candidates >= len(sols)
+    assert diag.final_count == len(sols)
+    assert diag.max_fk_residual < 1e-6
+    assert math.isfinite(diag.max_fk_residual)
+    assert diag.dispatch_reason  # non-empty
+    assert diag.fk_atol > 0
+    assert diag.refinement_engaged == 0  # no LM by default on tier-0
+
+
+def test_explain_diagnostic_summary_is_renderable(ur5: Manipulator) -> None:
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    _, diag = ur5.solve(T, explain=True)
+    summary = diag.summary()
+    assert isinstance(summary, str)
+    assert "ikgeo.three_parallel" in summary
+    assert "tier 0" in summary
+
+
+# ---------------------------------------------------------------------------
+# Empty-list attribution: explain mode distinguishes unreachable from filtered.
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_pose_diagnostic_reports_zero_raw_candidates(ur5: Manipulator) -> None:
+    """Far-away pose: solver returns 0 raw candidates -> diagnostic
+    attributes the empty list to 'unreachable', not to filtering."""
+    T_unreachable = np.eye(4)
+    T_unreachable[:3, 3] = [10.0, 10.0, 10.0]  # outside UR5's ~1m reach
+    sols, diag = ur5.solve(T_unreachable, explain=True)
+    assert not sols
+    assert diag.raw_candidates == 0
+    assert diag.final_count == 0
+    assert "unreachable" in diag.summary().lower()
+
+
+def test_diagnostic_reports_max_solutions_truncation(ur5: Manipulator) -> None:
+    """``max_solutions=N`` truncation is reflected in dropped_by_max_solutions."""
+    q = np.array([0.3, -0.5, 0.7, 0.2, 0.4, -0.1])
+    T = ur5.fk(q)
+    sols_full, diag_full = ur5.solve(T, explain=True)
+    sols_capped, diag_capped = ur5.solve(T, max_solutions=1, explain=True)
+    assert len(sols_full) > 1, "test setup requires a multi-branch pose"
+    assert len(sols_capped) == 1
+    assert diag_capped.dropped_by_max_solutions == len(sols_full) - 1
+    assert diag_full.dropped_by_max_solutions == 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level export.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_exposed_at_top_level() -> None:
+    """``ssik.Diagnostic`` is the canonical import path for type checks."""
+    assert ssik.Diagnostic is Diagnostic


### PR DESCRIPTION
## Why

Today's failure mode for `solve(T)` is opaque — callers get an empty `list[Solution]` and have to guess whether the pose was unreachable, near-singular, filtered by joint limits, capped by `max_solutions`, or hit a solver bug.

## What this PR adds

`Manipulator.solve(T, explain=True)` returns a `(list[Solution], Diagnostic)` tuple. The `Diagnostic` record carries:

- `solver_name` / `solver_tier` / `dispatch_reason` — what solver fired and why
- `raw_candidates` — how many candidates the inner solver returned pre-filter
- `dropped_by_limits` / `dropped_by_max_solutions` — per-filter drop counts
- `final_count` / `max_fk_residual` / `refinement_engaged` / `fk_atol`
- `warnings: tuple[str, ...]` — forward-compat slot for #178's HP / RR conditioning flags
- `.summary()` — one-paragraph human-readable triage output

Default `explain=False` preserves the v1.0 return signature exactly (`@overload` stubs make mypy happy with both shapes).

## Sample output

```python
sols, diag = arm.solve(T_unreachable, explain=True)
print(diag.summary())
# solver: ikgeo.three_parallel (tier 0)
# dispatch: Three consecutive parallel axes at joints (1, 2, 3) ...
#   -> 0 raw candidates: pose appears unreachable
#      (or outside this solver's analytical envelope)
```

## Scope

**Phase A** (this PR): `Manipulator.solve` only.

**Phase B** (tracked in #269): per-prebuilt explain mode via codegen-template work. Prebuilts use 3 separate templates (thin wrapper / 6R specialised / 7R jointlock specialised) that each need parallel changes. Worth its own PR — Phase A is the API + dataclass + Manipulator integration; Phase B is the codegen sweep.

## Verified

- [x] 8 new tests in `tests/test_explain_mode.py`: default-list, explain-true tuple, reachable-pose fields, unreachable-pose attribution, max_solutions truncation accounting, top-level export
- [x] `scripts/check.sh --no-tests`: ruff + format + mypy green
- [x] No change to existing solver internals
- [x] @overload stubs preserve the v1.0 return signature for `explain=False` callers

Closes #265 phase A. Continues into #269 for the prebuilt codegen work.