### PR TITLE
Docs site: mkdocs-material + auto API reference + setup-your-robot guide (#266)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: Docs
+
+# Build + deploy mkdocs-material site to GitHub Pages on push to main.
+# The site lives at https://personalrobotics.github.io/ssik/.
+#
+# Pre-#266 docs were the in-repo docs/*.md only. The mkdocs site adds:
+#   - auto-generated API reference from docstrings via mkdocstrings[python]
+#   - getting-started + setting-up-your-robot narrative pages
+#   - long-form solver specs from docs/specs/
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
+      - "src/ssik/**"          # API reference is auto-generated from docstrings
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # hatch-vcs needs git history
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install docs dependency group
+        run: uv sync --group docs
+
+      - name: Build mkdocs site
+        run: uv run mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -280,8 +280,14 @@ Cython hot loops cover the leaf primitives (POE forward kinematics, the Levenber
 
 ## Documentation
 
-- [docs/arm_coverage.md](docs/arm_coverage.md) — per-arm fixture tables, tested speeds, source URDFs
-- [docs/architecture.md](docs/architecture.md) — solver tier catalog, dispatch flow, build artifact internals, algorithmic lineage
+Full docs site: **<https://personalrobotics.github.io/ssik/>**
+
+- [Quickstart](https://personalrobotics.github.io/ssik/quickstart/) — install, prebuilts, trajectory tracking, explain mode
+- [Setting up your robot](https://personalrobotics.github.io/ssik/setting_up_your_robot/) — URDF readiness, `--base`/`--ee` selection, tool baking, verification
+- [Arm coverage](https://personalrobotics.github.io/ssik/arm_coverage/) — per-arm fixtures, speeds, FK floors
+- [Architecture](https://personalrobotics.github.io/ssik/architecture/) — solver tier catalog, dispatch flow, algorithmic lineage
+- [API reference](https://personalrobotics.github.io/ssik/api/) — `Manipulator`, `Solution`, `Diagnostic`, `TolerancePolicy`
+- [Semver policy](https://personalrobotics.github.io/ssik/semver_policy/) — what's public, what counts as breaking
 - [CONTRIBUTING.md](CONTRIBUTING.md) — repo layout, dev setup, testing discipline
 
 ## Related libraries

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,70 @@
+# API reference
+
+Auto-generated from docstrings. The public surface is small by design — most users only touch `Manipulator`, `Solution`, and (when relevant) `TolerancePolicy` / `Diagnostic`.
+
+## Entry point: `Manipulator`
+
+::: ssik.Manipulator
+    options:
+      show_root_heading: false
+      members:
+        - from_urdf
+        - solve
+        - fk
+        - dof
+        - solver_name
+        - kinbody
+
+## Per-call return: `Solution`
+
+::: ssik.Solution
+    options:
+      show_root_heading: false
+
+## Diagnostic record: `Diagnostic`
+
+Returned alongside the solution list when `solve(T, explain=True)`.
+
+::: ssik.Diagnostic
+    options:
+      show_root_heading: false
+
+## Tuning: `TolerancePolicy`
+
+::: ssik.TolerancePolicy
+    options:
+      show_root_heading: false
+
+## Postprocess helpers
+
+The `solve()` pipeline already applies these by default (when `respect_limits=True`); they're exposed for callers who want a different order, an extra filter step, or to compose with collision/dexterity scoring.
+
+::: ssik.postprocess.respect_limits
+    options:
+      show_root_heading: false
+      show_root_full_path: false
+
+::: ssik.postprocess.wrap_to_limits
+    options:
+      show_root_heading: false
+      show_root_full_path: false
+
+::: ssik.postprocess.nearest_to_seed
+    options:
+      show_root_heading: false
+      show_root_full_path: false
+
+::: ssik.postprocess.take_first
+    options:
+      show_root_heading: false
+      show_root_full_path: false
+
+## CLI: `ssik build`
+
+```bash
+ssik build <urdf> --base <link> --ee <link> [--out <path>]
+ssik classify <urdf> --base <link> --ee <link>
+ssik add-arm <urdf> --base <link> --ee <link> --name <arm>
+```
+
+Full help: `ssik <command> --help`. See [Setting up your robot](setting_up_your_robot.md) for the full URDF-to-artifact workflow.

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -1,8 +1,8 @@
 # Arm coverage
 
-Per-arm tested fixture tables, dispatched solver, and measured speed. Numbers come from [`examples/04_compare_vs_eaik.py`](../examples/04_compare_vs_eaik.py) — 100 random reachable poses per arm, Apple M3 single-thread, mean ± 95% CI via 1000-resample bootstrap. The README's EAIK comparison table reports the same measurements; this doc breaks them down by kinematic class and points at where each arm's prebuilt lives.
+Per-arm tested fixture tables, dispatched solver, and measured speed. Numbers come from [`examples/04_compare_vs_eaik.py`](https://github.com/personalrobotics/ssik/blob/main/examples/04_compare_vs_eaik.py) — 100 random reachable poses per arm, Apple M3 single-thread, mean ± 95% CI via 1000-resample bootstrap. The README's EAIK comparison table reports the same measurements; this doc breaks them down by kinematic class and points at where each arm's prebuilt lives.
 
-**Status legend**: ✅ shipped in [`ssik.prebuilt`](../src/ssik/prebuilt/) and exercised by the test suite — 🔗 external URDF, fixture import pending — 📐 synthetic-only (no canonical commercial arm with this exact topology).
+**Status legend**: ✅ shipped in [`ssik.prebuilt`](https://github.com/personalrobotics/ssik/tree/main/src/ssik/prebuilt) and exercised by the test suite — 🔗 external URDF, fixture import pending — 📐 synthetic-only (no canonical commercial arm with this exact topology).
 
 ## 6R industrial arms (Pieper-class)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# ssik
+
+[![PyPI](https://img.shields.io/pypi/v/ssik.svg?v=1)](https://pypi.org/project/ssik/)
+[![Python](https://img.shields.io/pypi/pyversions/ssik.svg?v=1)](https://pypi.org/project/ssik/)
+[![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](https://github.com/personalrobotics/ssik/blob/main/LICENSE)
+
+Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module that returns **every IK branch** with FK closure well below typical robot repeatability — and tightenable to machine precision when needed.
+
+```bash
+pip install ssik
+```
+
+## Two-minute quickstart
+
+```python
+from ssik.prebuilt import franka_panda_ik
+import numpy as np
+
+T_target = np.eye(4)
+T_target[:3, 3] = [0.5, 0.1, 0.3]
+sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
+```
+
+8 prebuilt arms ship with the wheel: UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, Rizon 4, Kassow KR810. For other arms, run `ssik build <your.urdf>` once and import the emitted module.
+
+## Where to go next
+
+- **Just want to use it?** → [Quickstart](quickstart.md)
+- **Adapting to your robot?** → [Setting up your robot](setting_up_your_robot.md) — calibration, custom tools, link conventions
+- **Need the API surface?** → [API reference](api.md) — `Manipulator`, `Solution`, `Diagnostic`, `TolerancePolicy`, postprocess helpers
+- **Want to understand the dispatch?** → [Architecture](architecture.md) — solver tier catalog + algorithmic lineage
+- **Checking arm coverage?** → [Arm coverage](arm_coverage.md) — per-arm fixtures, speeds, FK floors
+
+## Why ssik exists
+
+Numerical-IK libraries take a seed, run damped least-squares to a **single** converged configuration, and stop. ssik returns **every analytical branch** at near-machine precision. Branch enumeration matters for motion planning (try every branch, pick the one with best clearance), for dexterity analysis (the manipulability ellipsoid is per-branch), and for trajectory continuation across kinematic singularities.
+
+ssik covers the kinematic classes that the subproblem-decomposition libraries (EAIK, IK-Geo) refuse: **non-Pieper 6R** (JACO 2's 55° twists), **non-SRS 7R** (Flexiv Rizon 4, Kassow KR810), **approximate-SRS** (Kinova Gen3, 12 mm offset). See the [README comparison table](https://github.com/personalrobotics/ssik#measured-comparison-vs-eaik) for measured numbers.
+
+## License
+
+[BSD-3-Clause](https://github.com/personalrobotics/ssik/blob/main/LICENSE). Clean-room reimplementations of algorithms from BSD-3-licensed IK-Geo and the academic publications of Raghavan–Roth (1990), Manocha–Canny (1994), Singh–Kreutz (1989), and Husty–Pfurner (2007). Algorithmic lineage documented in module docstrings.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart
+
+## Install
+
+```bash
+pip install ssik                  # core: library + 8 prebuilt arms + CLI
+pip install ssik[urdf]            # adds urchin + sympy for ssik build / Manipulator.from_urdf
+```
+
+Python 3.11+. Wheels for Linux x86_64, macOS arm64, macOS x86_64, Windows x86_64.
+
+## Use a prebuilt arm
+
+```python
+from ssik.prebuilt import franka_panda_ik
+import numpy as np
+
+T_target = np.eye(4)
+T_target[:3, 3] = [0.5, 0.1, 0.3]
+sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
+```
+
+`sols` is a `list[Solution]`. Each `Solution` carries `q` (the joint vector), `fk_residual` (`‖FK(q) − T‖_F`), and which polish path fired. Empty list = pose is unreachable.
+
+### Shipped prebuilts
+
+| Module | Arm | Class | base_link | ee_link |
+|---|---|---|---|---|
+| `ur5_ik` | Universal Robots UR5 | three-parallel 6R | `base_link` | `ee_link` |
+| `puma560_ik` | KUKA Puma 560 | Pieper 6R | `base_link` | `wrist_3_link` |
+| `jaco2_ik` | Kinova JACO 2 | non-Pieper 6R | `base_link` | `ee_link` |
+| `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R | `world` | `tool0` |
+| `gen3_ik` | Kinova Gen3 7-DOF | approximate-SRS 7R | `base_link` | `end_effector_link` |
+| `franka_panda_ik` | Franka Panda | anthropomorphic 7R | `base_link` | `ee_link` |
+| `rizon4_ik` | Flexiv Rizon 4 | non-SRS 7R | `base_link` | `flange` |
+| `kassow_kr810_ik` | Kassow KR810 | non-SRS 7R | `base` | `end_effector` |
+
+Each prebuilt exposes `BASE_LINK`, `EE_LINK`, `DOF`, `T_HOME` constants so you can verify the baked geometry matches your robot:
+
+```python
+from ssik.prebuilt import franka_panda_ik
+print(franka_panda_ik.BASE_LINK, "→", franka_panda_ik.EE_LINK)
+# base_link → ee_link
+print(franka_panda_ik.T_HOME[:3, 3])
+# array([0.088, 0., 0.926])    ← matches Franka's documented home
+```
+
+## Trajectory tracking pattern
+
+For real-time control / teleop, "give me the IK closest to where I am now":
+
+```python
+q_current = np.array([0.0, -0.5, 0.0, 0.7, 0.0, 1.2, 0.0])
+
+# max_solutions=1 + q_seed: visit lock-samples nearest q_current first,
+# short-circuit on the first in-limits branch. ~5-6x faster than full sweep.
+sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
+q_command = sols[0].q if sols else q_current
+```
+
+## When `solve()` returns an empty list
+
+Use `explain=True` to attribute the failure:
+
+```python
+import ssik
+arm = ssik.Manipulator.from_urdf("my_arm.urdf", base="base_link", ee="tool0")
+
+sols, diag = arm.solve(T_target, explain=True)
+if not sols:
+    print(diag.summary())
+    # solver: ikgeo.three_parallel (tier 0)
+    # dispatch: Three consecutive parallel axes at joints (1, 2, 3) ...
+    #   -> 0 raw candidates: pose appears unreachable
+```
+
+Distinguishes **unreachable** (zero raw candidates) from **all-filtered** (out-of-limits or below FK threshold) from **capped** (truncated by `max_solutions`).
+
+## Build an artifact for your own arm
+
+```bash
+ssik build my_arm.urdf --base base_link --ee tool0
+# → my_arm_ik.py
+```
+
+Build time:
+- **<1 s** for tier-0 closed-form (UR-class, Pieper, SRS-class 7R)
+- **~30 s** for non-Pieper 6R (Raghavan–Roth symbolic derivation)
+- **7–20 min** for non-SRS 7R (cached HP per lock sample)
+
+Then `import my_arm_ik` and use exactly like a prebuilt. See [Setting up your robot](setting_up_your_robot.md) for the full URDF-to-artifact workflow.

--- a/docs/semver_policy.md
+++ b/docs/semver_policy.md
@@ -1,0 +1,81 @@
+# Semantic versioning policy
+
+ssik follows [SemVer 2.0](https://semver.org/spec/v2.0.0.html): `MAJOR.MINOR.PATCH` where MAJOR is breaking, MINOR is additive, PATCH is bug-fix only.
+
+## What's public, what's not
+
+### Public (covered by semver)
+
+- **Top-level imports**: `ssik.Manipulator`, `ssik.Solution`, `ssik.Diagnostic`, `ssik.TolerancePolicy`, `ssik.DEFAULT_TOLERANCE_POLICY`
+- **Postprocess helpers**: `ssik.postprocess.{respect_limits, wrap_to_limits, nearest_to_seed, take_first}`
+- **Prebuilt artifacts** (`ssik.prebuilt.*`): their `solve(T, **kwargs)` signature, the four module constants `BASE_LINK / EE_LINK / DOF / T_HOME`, and the per-module `__all__`
+- **CLI**: `ssik build / classify / add-arm` argument shapes
+- **Wheel manifest**: support for cp311 / cp312 / cp313 × Linux x86_64 / macOS arm64 / macOS x86_64 / Windows x86_64
+
+### Not public (no semver guarantee)
+
+- Anything in `ssik.solvers.*` (use `Manipulator.solve` or a prebuilt)
+- Anything in `ssik.core.*` except names explicitly re-exported from the top level
+- `ssik.kinematics.*` (POE primitives, predicates, reverse-chain math)
+- `ssik.subproblems.*` (SP1–SP6 implementations)
+- `ssik.refinement.*` (LM polish internals)
+- `ssik.codegen.*` (artifact emission internals)
+- Leading-underscore modules: `ssik._kinbody`, `ssik._urdf`, `ssik._pencil`, `ssik._version`
+- The `_solve_algebraic`, `_KB`, `_LOCK_IDX`, `_LOCK_SAMPLES`, `_DISPATCH_CACHE` etc. in prebuilt artifacts (private to the codegen)
+
+If a downstream depends on a non-public name, that's a "fragile dependency" the user owns; we may rename or remove it in any release.
+
+## What counts as breaking
+
+A change is **MAJOR** (breaking) when:
+
+- A public symbol is removed, renamed, or moved to a different module
+- A public function's signature changes in a non-backward-compatible way (positional arg order, removed kwarg, kwarg name change)
+- A returned dataclass loses a field, or an existing field changes type
+- A bug fix that produces materially different IK behaviour for valid inputs (e.g. a previously-returned candidate is now filtered, or a previously-empty result is now populated). *Sub-machine-precision FK shifts within the documented tolerance policy are NOT breaking.*
+- The CLI's `--flag` semantics change in a way that breaks scripts pinning a major
+- Python version support drops (e.g. dropping cp311)
+- Wheel-platform support drops in a way that affects existing installs (e.g. dropping macOS arm64)
+
+A change is **MINOR** (additive) when:
+
+- A new top-level symbol is added
+- A new optional kwarg with a backward-compatible default is added
+- A new `Solution` / `Diagnostic` field is added (existing code that doesn't reference the new field keeps working)
+- A new prebuilt arm is added to `ssik.prebuilt`
+- A new platform is added (e.g. Linux aarch64 wheels)
+- A new CLI subcommand or flag with a backward-compatible default is added
+
+A change is **PATCH** when:
+
+- Bug fixes that don't change documented behaviour
+- Numerical precision improvements within the documented tolerance policy
+- Performance improvements
+- Documentation corrections
+- Internal refactors that don't touch the public surface
+
+## Build artifacts
+
+The codegen-emitted artifacts under `ssik.prebuilt` (and any user-built `<arm>_ik.py`) are byte-stable across same-version regenerations (enforced by `tests/test_artifact_snapshots.py`). Across versions:
+
+- **PATCH bump**: artifacts MAY differ byte-wise (e.g. updated docstring text, tighter constants) but the public surface (`solve`, `fk`, `BASE_LINK`, `EE_LINK`, `DOF`, `T_HOME`) stays compatible.
+- **MINOR bump**: same, plus new optional `solve()` kwargs may appear.
+- **MAJOR bump**: artifacts may need re-running `ssik build` against your URDF.
+
+User-emitted artifacts are frozen at the ssik version that built them. They keep working with future ssik versions — just won't pick up later solver improvements until you re-run `ssik build`.
+
+## Release-tag conventions
+
+- `v1.0.0`, `v1.1.0`, `v1.2.3` etc. are real releases (published to PyPI).
+- `v1.1.0rc1`, `v1.1.0rc2` etc. are release candidates published to TestPyPI for validation before promotion to PyPI.
+- Annotated tags only (`git tag -a`); the release workflow needs the tag annotation for hatch-vcs version derivation.
+
+## Deprecation policy
+
+- A public symbol marked deprecated in version `X.Y.Z` is removed no earlier than version `X+1.0.0`.
+- Deprecations are surfaced via `DeprecationWarning` at the first use of the symbol in a Python session.
+- Migration paths are documented in the release notes and in the symbol's docstring.
+
+## Reporting breakage
+
+If a PATCH or MINOR release breaks your code, that's a semver bug — file an issue with a minimal reproducer. A fix or a clarification on what's actually public will follow.

--- a/docs/setting_up_your_robot.md
+++ b/docs/setting_up_your_robot.md
@@ -1,0 +1,173 @@
+# Setting up your robot
+
+Guide for getting your specific arm working with ssik — beyond the 8 prebuilts. Three real-world friction points: **URDF readiness**, **link selection** (base + EE + tool), and **verification** (does the baked geometry match your robot?).
+
+## When a prebuilt is enough vs when to `ssik build`
+
+The 8 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
+
+- You're using the same URDF source we built against (ros-industrial, vendor reference, etc.)
+- Your robot's calibration matches the nominal kinematic parameters
+- Your end-effector IS the flange — no gripper / suction cup / custom tool past it
+- Your URDF link names match what we baked (see the [quickstart table](quickstart.md#shipped-prebuilts))
+
+If **any** is false, especially on a 7R arm with any tool attached, `ssik build` your own.
+
+## Step 1: get the URDF ready
+
+ssik's URDF loader (`ssik._urdf`, backed by `urchin`) is strict about valid URDFs but tolerant of common omissions:
+
+- ✅ Missing inertias and dynamics — ssik is kinematic-only
+- ✅ Missing collision meshes — not used by ssik
+- ✅ Missing visual meshes — not used by ssik
+- ❌ Non-orthonormal `rpy` quaternions — Xacro sometimes produces near-orthonormal that errors. Re-export from the source if you hit a `urchin` parse error.
+- ❌ Mid-chain fixed joints — must be either welded into adjacent revolute frames or expanded. Ssik treats the chain as 6R or 7R revolute; fixed joints break the chain.
+- ❌ Continuous joints without limits — ssik treats unset limits as `±2π`, which may produce out-of-range IKs. Set explicit `limit` tags.
+
+### Calibrated URDFs (UR's `.calibrated_urdf`, etc.)
+
+UR ships per-arm calibration offsets that nudge the nominal DH parameters by ~mm. Two paths:
+
+**Use the calibrated file with `ssik build`:**
+```bash
+ssik build my_ur5_calibrated.urdf --base base_link --ee tool0
+```
+The emitted artifact bakes the calibration. Specific to that physical robot.
+
+**Use the prebuilt with `respect_limits=False` + post-multiply:** if the calibration is small enough that the IK still converges, you can apply a per-call correction in T-space. Brittle; prefer the build-from-calibrated path.
+
+## Step 2: pick `--base` and `--ee`
+
+This is the most common gotcha. ssik solves IK from `--base` to `--ee` — meaning **`T_target` is the pose of `--ee` expressed in `--base`'s frame**.
+
+Convention varies by source URDF. Common patterns:
+
+| URDF source | Typical `--base` | Typical `--ee` |
+|---|---|---|
+| ros-industrial UR | `base_link` | `ee_link` (UR's `tool0` is past a fixed `tool0_joint`) |
+| Vendor UR | `base_link` | `tool0` |
+| Franka (`franka_description`) | `panda_link0` | `panda_hand` or `panda_link8` |
+| KUKA iiwa (mujoco_menagerie) | `world` | `tool0` |
+| MoveIt configs | usually `<arm>_base_link` | end of the kinematic group |
+
+**Verify your choice**:
+
+```python
+import ssik
+arm = ssik.Manipulator.from_urdf("your.urdf", base="base_link", ee="tool0")
+print(arm.solver_name, arm.dof)
+import numpy as np
+T_home = arm.fk(np.zeros(arm.dof))
+print(T_home[:3, 3])    # position at q=0; does it match your robot's documented home?
+```
+
+If `T_home` doesn't match what your robot's data sheet says about the q=0 pose, your `--base` / `--ee` is wrong (or your URDF is wrong).
+
+## Step 3: tool / gripper attachment
+
+If your end-effector isn't the bare flange — gripper, suction cup, weld torch, lidar — you have two options.
+
+### Option A (recommended): bake the tool into the URDF
+
+Add a fixed joint + tool link to your URDF before `ssik build`:
+
+```xml
+<link name="tool_tip"/>
+<joint name="tool_attachment" type="fixed">
+  <parent link="tool0"/>
+  <child link="tool_tip"/>
+  <origin xyz="0 0 0.15" rpy="0 0 0"/>    <!-- 15 cm gripper offset along z -->
+</joint>
+```
+
+Then `ssik build my_arm.urdf --base base_link --ee tool_tip`. The baked artifact's `T_target` is now the pose of `tool_tip` in `base_link` — no per-call math.
+
+### Option B: post-multiply T_target in Python
+
+If you can't edit the URDF, build the artifact against the flange and apply the tool offset in your own code:
+
+```python
+import numpy as np
+from ssik.prebuilt import ur5_ik
+
+T_tool_in_flange = np.eye(4)
+T_tool_in_flange[2, 3] = 0.15        # 15 cm along the flange's z-axis
+
+# We want: T_tool_in_base = arm.fk(q) @ T_tool_in_flange
+# Inverse direction for IK: arm.solve gets T_flange_in_base
+T_flange_in_base = T_tool_target_in_base @ np.linalg.inv(T_tool_in_flange)
+sols = ur5_ik.solve(T_flange_in_base)
+```
+
+Brittle if you ever change the tool — prefer Option A.
+
+## Step 4: verify the baked geometry
+
+Once you have `<your_arm>_ik.py`, sanity-check that:
+
+```python
+import my_arm_ik
+import numpy as np
+
+# 1. DOF matches your hardware
+assert my_arm_ik.DOF == 6   # or 7 for redundant arms
+
+# 2. Frame conventions match what you asked for
+print(my_arm_ik.BASE_LINK, "->", my_arm_ik.EE_LINK)
+
+# 3. Home pose matches the manufacturer spec
+print(my_arm_ik.T_HOME)
+
+# 4. FK and IK round-trip at a non-singular config
+q_test = np.array([0.1, 0.2, -0.3, 0.4, -0.5, 0.6])    # or DOF=7 equivalent
+T = my_arm_ik.fk(q_test)
+sols = my_arm_ik.solve(T)
+assert sols, "round-trip failed -- baked geometry is likely wrong"
+max_fk = max(s.fk_residual for s in sols)
+print(f"{len(sols)} sols, max FK residual = {max_fk:.2e}")
+# Should print ~10^-12 to 10^-5 depending on solver class (see arm_coverage)
+```
+
+If step 4 fails on a generic non-singular `q`, the URDF and ssik disagree on geometry. Common causes: wrong `--base` / `--ee`, missing fixed-joint expansion, non-orthonormal frames.
+
+## Step 5: optional — re-run `ssik build` after upgrades
+
+Old artifacts keep working when you `pip install -U ssik`, but they're frozen against the ssik version that built them. To pick up later solver fixes, re-run `ssik build`. Behaviour is byte-stable across same-ssik-version regenerations (verified by `tests/test_artifact_snapshots.py`).
+
+## Common failure modes
+
+### `ssik build` says "Best solver: husty_pfurner.general_6r"
+
+You have a non-Pieper 6R with no specialised solver. The HP universal fallback works but is slow (~25-200 ms per IK vs ~1 ms for tier-0). Two options:
+
+- Accept the slower solve time
+- File an issue with your DH parameters; if your arm matches one of the un-implemented specialist classes (e.g. a different non-Pieper structure than JACO 2), we can add support
+
+### Tighter FK closure than the default
+
+The default `subproblem_numerical = 1e-5` is appropriate for control (10 µm position error on a 1 m arm, well below typical robot repeatability). For machine precision (RL training, differentiable IK, sample-based planning), opt in:
+
+```python
+from ssik import TolerancePolicy
+tight = TolerancePolicy(
+    axis_parallel=1e-8, axis_intersect=1e-8,
+    subproblem_feasibility=1e-9, subproblem_numerical=1e-9,
+    subproblem_degeneracy=1e-12, subproblem_dedup=1e-3,
+)
+sols = my_arm_ik.solve(T_target, policy=tight, allow_refinement=True)
+# every returned IK FK-closes ~1e-10 (0.1 nm position scale)
+```
+
+See [Arm coverage → worst-case FK floor](arm_coverage.md#worst-case-fk-floor-under-adversarial-fuzz) for per-arm behaviour under each policy.
+
+### Joint limits cause `solve()` to return `[]`
+
+By default `solve()` runs `respect_limits=True`. If your URDF limits are tighter than the analytical IK can produce, the postprocess pass drops them all. Two diagnostics:
+
+```python
+sols = arm.solve(T, respect_limits=False)            # raw geometric set
+sols, diag = arm.solve(T, explain=True)              # attribution
+print(diag.dropped_by_limits, "filtered by limits")
+```
+
+If `dropped_by_limits == raw_candidates`, your limits are too tight or the pose is genuinely unreachable within them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,92 @@
+site_name: ssik
+site_description: Analytical inverse kinematics for 6R and 7R revolute robot arms
+site_url: https://personalrobotics.github.io/ssik/
+repo_url: https://github.com/personalrobotics/ssik
+repo_name: personalrobotics/ssik
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: sphinx
+            show_root_heading: true
+            show_source: true
+            members_order: source
+            heading_level: 2
+            separate_signature: true
+            show_signature_annotations: true
+            line_length: 88
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Quickstart: quickstart.md
+      - Setting up your robot: setting_up_your_robot.md
+  - Reference:
+      - Architecture: architecture.md
+      - Arm coverage: arm_coverage.md
+      - API reference: api.md
+      - Solver specs:
+          - SRS 7R (Singh-Kreutz): specs/srs_7r_singh_kreutz.md
+          - IK-Geo general 6R: specs/ikgeo_general_6r.md
+          - HP robustness notes: specs/hp_robustness_investigation.md
+  - Project:
+      - Semver policy: semver_policy.md


### PR DESCRIPTION
## Why

Last open v1.1.0 umbrella item ([#268](https://github.com/personalrobotics/ssik/issues/268) piece 4). Lives at **<https://personalrobotics.github.io/ssik/>** after merge.

## What lands

- **`mkdocs.yml`** — mkdocs-material with auto-generated API reference via `mkdocstrings[python]` (deps already in the `docs` group, just not wired). Light/dark theme, navigation tabs + sections, code-copy buttons, search.
- **`docs/index.md`** — landing page mirroring the README headline framing
- **`docs/quickstart.md`** — install + prebuilt usage + trajectory tracking + explain mode + `ssik build` pointer
- **`docs/setting_up_your_robot.md`** — the real-world friction guide:
    - URDF readiness (Xacro pitfalls, calibrated URDFs, mid-chain fixed joints)
    - `--base` / `--ee` conventions per URDF source (UR, Franka, KUKA, MoveIt)
    - Tool baking: URDF-edit (recommended) vs Python post-multiply
    - 5-step verification flow (DOF, frame, T_HOME, FK-IK round-trip)
    - Common failure modes (non-Pieper 6R fallback, tight FK, joint limits)
- **`docs/api.md`** — mkdocstrings shim rendering `Manipulator` / `Solution` / `Diagnostic` / `TolerancePolicy` / postprocess directly from source docstrings. No duplicated docs.
- **`docs/semver_policy.md`** — what's public vs private, breaking-change rules, build-artifact compatibility, deprecation policy
- **`.github/workflows/docs.yml`** — auto-build + auto-deploy to GitHub Pages on push to main (paths-filter on `mkdocs.yml` / `docs/**` / `src/ssik/**`)
- **Two link fixes** in `docs/arm_coverage.md`: repo-relative links rewritten to absolute GitHub URLs so mkdocs `--strict` builds clean
- **README `## Documentation`** updated with the site URLs

## Verified

- `uv sync --group docs` installs cleanly
- `uv run mkdocs build --strict` succeeds in 0.9s with zero warnings
- mkdocstrings rendered the `Manipulator` class with all 5 documented members + signatures

## One manual step after merge

GitHub Pages must be enabled once: **Settings → Pages → Source = GitHub Actions**. Same auto-created environment that #260 cleaned up before v1.0.0. After that the workflow runs on every push to main and the site stays current.

## Closes

#266. Last v1.1.0 umbrella item. After this lands, v1.1.0 is ready to tag.