### PR TITLE
Add CITATION.cff + outreach drafts for v1.1 adoption push

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,102 @@
+# YAML 1.2 — Citation File Format 1.2.0
+# https://citation-file-format.github.io
+cff-version: 1.2.0
+title: "ssik: Analytical inverse kinematics for 6R and 7R revolute arms"
+message: "If you use ssik in academic work, please cite it via this metadata."
+type: software
+authors:
+  - given-names: Siddhartha
+    family-names: Srinivasa
+    email: siddhartha.srinivasa@gmail.com
+    orcid: "https://orcid.org/0000-0002-5091-106X"
+repository-code: "https://github.com/personalrobotics/ssik"
+url: "https://personalrobotics.github.io/ssik/"
+license: BSD-3-Clause
+version: 1.1.0
+date-released: 2026-05-15
+keywords:
+  - robotics
+  - inverse-kinematics
+  - analytical-ik
+  - 6R-manipulator
+  - 7R-manipulator
+  - manipulation
+abstract: >
+  ssik is a Python library that produces every analytical inverse-kinematics
+  branch for 6R and 7R revolute manipulators. It ships eight prebuilt arms
+  (UR5, Puma 560, JACO 2, KUKA iiwa14, Kinova Gen3, Franka Panda, Flexiv
+  Rizon 4, Kassow KR810) and a "ssik build" CLI that emits a self-contained
+  per-arm artifact from a URDF. ssik covers kinematic classes that the
+  standard subproblem-decomposition libraries do not — non-Pieper 6R
+  (JACO 2's 55° twists), non-SRS 7R (Rizon 4, Kassow KR810), and
+  approximate-SRS 7R (Kinova Gen3) — via a tier-based dispatcher backed by
+  IK-Geo subproblems and a Husty-Pfurner Study-quaternion universal fallback.
+references:
+  - type: article
+    authors:
+      - family-names: Elias
+        given-names: Alexander J.
+      - family-names: Wen
+        given-names: John T.
+    title: "IK-Geo: Unified robot inverse kinematics using subproblem decomposition"
+    journal: "Mechanism and Machine Theory"
+    volume: 209
+    start: 105971
+    year: 2025
+    publisher:
+      name: "Elsevier"
+  - type: article
+    authors:
+      - family-names: Husty
+        given-names: Manfred L.
+      - family-names: Pfurner
+        given-names: Martin
+      - family-names: Schröcker
+        given-names: Hans-Peter
+    title: "A new and efficient algorithm for the inverse kinematics of a general serial 6R manipulator"
+    journal: "Mechanism and Machine Theory"
+    volume: 42
+    issue: 1
+    year: 2007
+    doi: 10.1016/j.mechmachtheory.2006.02.001
+  - type: article
+    authors:
+      - family-names: Raghavan
+        given-names: Madhusudan
+      - family-names: Roth
+        given-names: Bernard
+    title: "Inverse Kinematics of the General 6R Manipulator and Related Linkages"
+    journal: "Journal of Mechanical Design"
+    volume: 115
+    issue: 3
+    start: 502
+    end: 508
+    month: 9
+    year: 1993
+    issn: "1050-0472"
+    doi: 10.1115/1.2919218
+  - type: article
+    authors:
+      - family-names: Ostermeier
+        given-names: Daniel
+      - family-names: Külz
+        given-names: Jonathan
+      - family-names: Althoff
+        given-names: Matthias
+    title: "Automatic Geometric Decomposition for Analytical Inverse Kinematics"
+    journal: "IEEE Robotics and Automation Letters"
+    volume: 10
+    issue: 10
+    start: 9964
+    end: 9971
+    year: 2025
+    doi: 10.1109/LRA.2025.3597897
+  - type: thesis
+    authors:
+      - family-names: Diankov
+        given-names: Rosen
+    title: "Automated Construction of Robotic Manipulation Programs"
+    institution:
+      name: "Carnegie Mellon University, Robotics Institute"
+    thesis-type: "PhD thesis"
+    year: 2010

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ ssik does not compete with these on the arms they cover. Pick the right tool for
 
 ## Citation
 
+If you use ssik in academic work, please cite it. Machine-readable metadata is in [`CITATION.cff`](CITATION.cff); GitHub renders that as a "Cite this repository" button on the repo sidebar.
+
 ```bibtex
 @software{ssik,
   author = {Srinivasa, Siddhartha},

--- a/outreach/README.md
+++ b/outreach/README.md
@@ -1,0 +1,17 @@
+# Outreach drafts
+
+Draft copy + recipes for v1.1 adoption push. Nothing here is part of the published package; everything is for posting / submitting under Siddhartha's accounts.
+
+## Contents
+
+- `zenodo-setup.md` — one-time GitHub-Zenodo integration. ~10 minutes; requires Siddhartha's Zenodo + GitHub login.
+- `reddit-robotics.md` — draft post for `r/robotics`.
+- `ros-discourse.md` — draft post for `https://discourse.ros.org` (Category: General).
+- `robotics-worldwide.md` — draft post for the `robotics-worldwide@usc.edu` mailing list.
+- `conda-forge/` — staged-recipes draft + submission instructions.
+
+## Suggested order
+
+1. **Zenodo first** — flip the toggle now, then on the next tagged release the DOI gets minted automatically. Costs 10 minutes; unblocks "ssik has a DOI" in any later post.
+2. **Conda-forge second** — PR into `conda-forge/staged-recipes`. Review takes ~1 week of back-and-forth with conda-forge maintainers; getting it submitted early means it's live by the time the Reddit / ROS Discourse posts go up.
+3. **Announcements third** — once the DOI exists and conda install works, the posts cite both, which is a better story than "PyPI only, citation pending."

--- a/outreach/conda-forge/SUBMISSION.md
+++ b/outreach/conda-forge/SUBMISSION.md
@@ -1,0 +1,93 @@
+# Conda-forge submission instructions
+
+The recipe in `meta.yaml` is ready to PR into `conda-forge/staged-recipes`. Steps:
+
+## 1. Fork conda-forge/staged-recipes
+
+```bash
+gh repo fork conda-forge/staged-recipes --clone
+cd staged-recipes
+```
+
+Or via the web UI: https://github.com/conda-forge/staged-recipes — "Fork".
+
+## 2. Add the recipe
+
+```bash
+git checkout -b add-ssik
+mkdir -p recipes/ssik
+cp /Users/siddh/code/ikfastpy/outreach/conda-forge/meta.yaml recipes/ssik/meta.yaml
+git add recipes/ssik/meta.yaml
+```
+
+## 3. Open the PR
+
+```bash
+git commit -m "Add ssik recipe"
+git push --set-upstream origin add-ssik
+gh pr create \
+  --repo conda-forge/staged-recipes \
+  --title "Add ssik" \
+  --body "$(cat <<'EOF'
+Adds [ssik](https://github.com/personalrobotics/ssik), a Python library for analytical inverse kinematics on 6R and 7R revolute robot arms. v1.1.0 on PyPI.
+
+### Checklist
+
+- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
+- [x] License (BSD-3-Clause) and license-file are correct.
+- [x] Source is from official source (PyPI sdist).
+- [x] Package does not vendor outdated copies of conda-forge packages.
+- [x] If the package has compiled extensions: includes \`{{ compiler('c') }}\` in build requirements.
+- [x] No \`noarch: python\` because the package has Cython-compiled extensions.
+
+### Maintainer
+
+- @siddhss5
+EOF
+)"
+```
+
+## 4. Respond to the CI bot
+
+Conda-forge's `linter-action` and `boa` will comment with any recipe issues — common ones:
+
+- **Pinning style**: conda-forge prefers `python` (no version) in `host` + `run`, with the Python version range expressed only via `skip:` in `build`. Already correct in `meta.yaml`.
+- **`numpy` pinning**: must use `{{ pin_compatible('numpy') }}` in `run`. Already correct.
+- **`cython` in `run`**: conda-forge usually objects to runtime-cython for sdists with prebuilt extensions, but ssik's `pyproject.toml` lists cython as a runtime dependency because compiled-source modules `import cython` at module top (see the comment in `pyproject.toml` referring to issue #144). Be prepared to explain this in the PR thread; if the reviewer pushes back, the alternative is to gate the `import cython` lines on `try/except` and drop the runtime dep.
+- **License classifier**: the PEP 639 SPDX `license = "BSD-3-Clause"` in `pyproject.toml` (not the legacy classifier) — conda-forge handles this fine, but a reviewer may ask. It's correct.
+
+## 5. After merge
+
+Once `conda-forge/staged-recipes` merges the PR, the conda-forge bots:
+
+1. Create `conda-forge/ssik-feedstock` (a new repo).
+2. Build wheels for Linux x86_64, macOS arm64, macOS x86_64, Windows x86_64 × py3.11/3.12/3.13.
+3. Push them to anaconda.org/conda-forge.
+
+Users can then:
+
+```bash
+conda install -c conda-forge ssik
+mamba install -c conda-forge ssik
+```
+
+## 6. After conda-forge package is live
+
+Open a PR on `personalrobotics/ssik`:
+
+- Add a conda-forge badge to `README.md` next to the PyPI / Python / License badges.
+- Add a `conda install -c conda-forge ssik` line to the install section.
+
+## 7. Future version bumps
+
+The conda-forge `regro-cf-autotick-bot` watches PyPI. When a new ssik version is published to PyPI, the bot auto-opens a feedstock PR with the version + sha256 updated. We just need to:
+
+- Verify the bot's PR builds clean on CI.
+- Merge.
+
+If a release changes runtime deps (new package required, version bump beyond the existing pin), the bot's PR will need manual edits to `recipes/ssik/meta.yaml` before merge.
+
+## Notes
+
+- The `outreach/conda-forge/meta.yaml` here is the **draft** of what gets committed to `staged-recipes/recipes/ssik/meta.yaml`. After merge, the canonical recipe lives in `conda-forge/ssik-feedstock`, and updates happen there.
+- Review SLA on staged-recipes is typically ~1 week for first-time submissions. Subsequent feedstock bumps merge in hours.

--- a/outreach/conda-forge/meta.yaml
+++ b/outreach/conda-forge/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "ssik" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ff01a81f1885fae6ef9d31b6fdefe89a4a563c2d9c2666acc655c34470c7bd6b
+
+build:
+  number: 0
+  # Match the PyPI wheel matrix declared in pyproject.toml [tool.cibuildwheel]:
+  # cp311 / cp312 / cp313, skipping musllinux + 32-bit + PyPy + linux-aarch64.
+  # conda-forge already excludes musllinux + PyPy + 32-bit Windows by default,
+  # so only the Python-version skip needs an explicit selector.
+  skip: true  # [py<311 or py>313]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - ssik = ssik.cli:main
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - hatchling >=1.27
+    - hatch-vcs >=0.4
+    - cython >=3.1
+    - setuptools >=70
+    - numpy >=2.0
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - scipy >=1.13
+    - sympy >=1.10
+    - cython >=3.1
+
+test:
+  imports:
+    - ssik
+    - ssik.prebuilt.iiwa14_ik
+    - ssik.prebuilt.franka_panda_ik
+    - ssik.prebuilt.ur5_ik
+    - ssik.prebuilt.rizon4_ik
+  commands:
+    - ssik --help
+    - python -c "from ssik.prebuilt import iiwa14_ik; import numpy as np; q = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]); T = iiwa14_ik.fk(q); sols = iiwa14_ik.solve(T); assert sols and max(s.fk_residual for s in sols) < 1e-9, 'iiwa14_ik smoke failed'"
+    - python -c "from ssik.prebuilt import franka_panda_ik; import numpy as np; T = franka_panda_ik.fk(np.array([0.2, 0.3, -0.4, -1.2, 0.3, 1.4, 0.5])); sols = franka_panda_ik.solve(T); assert sols, 'franka_panda_ik returned no IK'"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/personalrobotics/ssik
+  summary: Analytical inverse kinematics for 6R and 7R revolute robot arms
+  description: |
+    ssik is a Python library that produces every analytical inverse-kinematics
+    branch for 6R and 7R revolute manipulators. Eight prebuilt arms ship in
+    the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa14, Kinova Gen3, Franka
+    Panda, Flexiv Rizon 4, Kassow KR810); any other arm is supported via the
+    ``ssik build`` CLI, which reads a URDF and emits a single-file Python
+    artifact specialised to the kinematic chain. ssik covers kinematic
+    classes that the standard subproblem-decomposition libraries do not —
+    non-Pieper 6R (JACO 2), non-SRS 7R (Rizon 4, Kassow KR810), and
+    approximate-SRS 7R (Kinova Gen3) — via a tier-based dispatcher backed by
+    IK-Geo subproblems and a Husty-Pfurner Study-quaternion universal fallback.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  doc_url: https://personalrobotics.github.io/ssik/
+  dev_url: https://github.com/personalrobotics/ssik
+
+extra:
+  recipe-maintainers:
+    - siddhss5

--- a/outreach/reddit-robotics.md
+++ b/outreach/reddit-robotics.md
@@ -1,0 +1,53 @@
+# Draft: r/robotics post
+
+**Subreddit:** r/robotics
+**Suggested flair:** Software / Open Source
+**Suggested title:** `ssik: analytical IK for 6R/7R arms — every branch, machine-precision FK, pip install`
+
+---
+
+## Title
+
+`ssik: analytical IK for 6R/7R arms — every branch, machine-precision FK, pip install`
+
+## Body
+
+I've open-sourced **ssik**, a Python library that returns every analytical inverse-kinematics branch for 6R and 7R robot arms.
+
+```bash
+pip install ssik
+```
+
+```python
+from ssik.prebuilt import franka_panda_ik
+import numpy as np
+
+T = np.eye(4); T[:3, 3] = [0.5, 0.1, 0.3]
+sols = franka_panda_ik.solve(T)    # every IK branch
+```
+
+Each `Solution` carries the joint vector, the FK residual against the target, and which polish path fired. Empty list = pose is unreachable.
+
+**Arms shipped:** UR5, Puma 560, Kinova JACO 2, KUKA iiwa14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810. For anything else: `ssik build my_arm.urdf` emits a single-file Python artifact for your URDF.
+
+**What's different from existing tools:**
+- vs **numerical IK** (TracIK, MINK, KDL): those run damped least-squares to *one* converged config and stop. ssik enumerates every analytical branch — important for motion planning (try every branch, pick best clearance), dexterity analysis (per-branch manipulability), trajectory continuation across singularities.
+- vs **IKFast**: same per-arm specialised codegen idea, but ssik solves arms IKFast can't (non-Pieper 6R like JACO 2's 55° twists). Pure Python at runtime, no C++ codegen.
+- vs **IK-Geo / EAIK**: those refuse non-Pieper 6R and non-SRS 7R. ssik dispatches to those libraries' subproblem decomposition where it applies, falls back to a Husty-Pfurner Study-quaternion solver where it doesn't.
+
+**Honest perf numbers:** ~0.2-5 ms/IK for closed-form classes (UR5, iiwa14), ~25-200 ms/IK for the non-SRS 7R fallback path (Rizon 4, Kassow). FK closure ~1e-8 default, tightenable to ~1e-12 via the `TolerancePolicy` knobs.
+
+**Repo:** https://github.com/personalrobotics/ssik
+**Docs:** https://personalrobotics.github.io/ssik/
+**License:** BSD-3-Clause. Clean-room reimplementations from the academic literature; lineage documented per-module.
+
+Happy to answer questions about the algorithmic side or how it compares to whatever you're using.
+
+---
+
+## Notes for posting
+
+- Subreddit rules ban self-promotion that isn't clearly contributory. The angle "I open-sourced this, technical Q&A welcome" reads fine; "go upvote my PyPI" does not.
+- Best post times: weekday mornings US Pacific (broad audience awake worldwide).
+- Reply to early comments quickly — engagement in the first hour heavily weights ranking.
+- If asked "why not just use EAIK / IK-Geo": answer is the non-Pieper 6R + non-SRS 7R + approximate-SRS Gen3 coverage gap. Do not bash competitors.

--- a/outreach/robotics-worldwide.md
+++ b/outreach/robotics-worldwide.md
@@ -1,0 +1,71 @@
+# Draft: robotics-worldwide mailing list post
+
+**List:** robotics-worldwide@usc.edu (subscribe / archives at https://duerer.usc.edu/mailman/listinfo.cgi/robotics-worldwide)
+**Suggested subject:** `[Software] ssik: open-source analytical inverse kinematics for 6R and 7R revolute manipulators`
+
+---
+
+## Subject
+
+`[Software] ssik: open-source analytical inverse kinematics for 6R and 7R revolute manipulators`
+
+## Body
+
+Dear robotics-worldwide,
+
+I'd like to announce **ssik**, an open-source Python library for analytical inverse kinematics on 6R and 7R revolute manipulators.
+
+  Repository:  https://github.com/personalrobotics/ssik
+  Docs:        https://personalrobotics.github.io/ssik/
+  Install:     pip install ssik
+  License:     BSD-3-Clause
+
+ssik returns every analytical IK branch for a target end-effector pose. Eight commercial arms ship as prebuilt artifacts in the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa LBR 14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810); any other arm is supported via "ssik build my_arm.urdf", which emits a single-file Python artifact specialised to the URDF.
+
+The library is intended for tasks where branch enumeration matters: motion planning (search over branches for clearance / manipulability), dexterity analysis, trajectory continuation across kinematic singularities, and reinforcement-learning environments where IK ground truth is part of the reward / observation. Numerical IK libraries that converge to a single configuration are not substitutes for this use case.
+
+### Algorithmic coverage
+
+ssik dispatches by kinematic class. The novel coverage relative to the subproblem-decomposition libraries (IK-Geo, EAIK) is the kinematic classes those libraries refuse:
+
+  - non-Pieper 6R, e.g. Kinova JACO 2 with 55° DH twists between joints 4 and 5;
+  - non-SRS 7R, e.g. Flexiv Rizon 4 and Kassow KR810 with offset wrists;
+  - approximate-SRS 7R, e.g. Kinova Gen3's 12 mm offset.
+
+The implementation is a clean-room reimplementation of algorithms from:
+
+  - Elias & Wen (2022/2025), "IK-Geo: Unified Robot Inverse Kinematics Using Subproblem Decomposition" — six canonical subproblems + composition rules, the closed-form path for Pieper / SRS classes.
+  - Husty, Pfurner, Schröcker (2007), "A new and efficient algorithm for the inverse kinematics of a general serial 6R manipulator", Mechanism and Machine Theory — Study-quaternion degree-16 univariate, the universal 6R fallback.
+  - Raghavan & Roth (1993), "Inverse Kinematics of the General 6R Manipulator and Related Linkages", J. Mech. Des. — Sylvester resultant + numerical eigenvalue path.
+  - Singh & Kreutz-Delgado (1989) — closed-form 7R analytical IK for the SRS class.
+
+Algorithmic lineage is documented in each module's docstring. ssik does not vendor LGPL code from OpenRAVE / IKFast.
+
+### Numerical behaviour
+
+Forward-kinematics closure ‖FK(q) − T‖_F is below 1e-5 by default (10 µm position error on a 1 m arm, well below typical commercial-robot repeatability) and tightenable to ~1e-12 (0.1 nm scale) via the public TolerancePolicy with opt-in Levenberg-Marquardt polish. Hypothesis-driven fuzz tests at 500+ random poses per arm document the worst-case FK floor per kinematic class.
+
+### Architecture
+
+The runtime is pure NumPy + (for non-Pieper 6R and non-SRS 7R) SciPy. Per-arm symbolic preprocessing runs once at "ssik build" time and produces numeric coefficients that are baked into the emitted Python module; sympy is not on the runtime import path. Two Cython hot-loops (POE forward kinematics; LM refinement) are compiled to native extensions in the published wheels.
+
+### Use cases I'd value feedback on
+
+  - Motion-planning groups doing branch enumeration today via numerical IK + restart-from-perturbed-seeds — ssik enumerates the analytical set directly.
+  - Researchers reporting "IKFast cannot solve our arm" results — ssik may; happy to investigate specific URDFs.
+  - Teaching contexts (kinematics, mechanisms): the per-arm artifact is a single readable Python file, suitable for assignments / labs.
+
+Issues, PRs, and questions welcome on the repo. I'd particularly value feedback from anyone who has tried IKFast or the subproblem libraries on an arm those did not cover.
+
+Best,
+Siddhartha Srinivasa
+Personal Robotics Laboratory, University of Washington
+https://goodrobot.ai
+
+---
+
+## Notes for posting
+
+- robotics-worldwide is a moderated, low-volume academic list. The subject-line prefix "[Software]" is the convention for tool announcements.
+- One post per major release is well within community norms; do not post for every PATCH.
+- Expected replies: comparison questions (IKFast, IK-Geo, EAIK, OPW); requests for specific arms; bug reports. Be ready to handle each with a specific reference back to the docs.

--- a/outreach/ros-discourse.md
+++ b/outreach/ros-discourse.md
@@ -1,0 +1,90 @@
+# Draft: ROS Discourse post
+
+**Site:** https://discourse.ros.org
+**Category:** General → "Release announcements" (or "Packages" if that fits better; the General/Release-announcements subcategory is the standard)
+**Suggested title:** `ssik 1.1 — analytical inverse kinematics for 6R / 7R arms (PyPI, Python)`
+
+---
+
+## Title
+
+`ssik 1.1 — analytical inverse kinematics for 6R / 7R arms (PyPI, Python)`
+
+## Body
+
+I'd like to introduce **ssik**, a Python library for analytical inverse kinematics on 6R and 7R revolute manipulators. Version 1.1 just shipped to PyPI.
+
+```bash
+pip install ssik
+```
+
+### What it does
+
+ssik returns **every analytical IK branch** for a target pose — not one converged config like a numerical IK does. Each branch is a complete `q` plus the FK residual against the original target.
+
+```python
+from ssik.prebuilt import ur5_ik
+import numpy as np
+
+T_target = np.eye(4); T_target[:3, 3] = [0.5, 0.1, 0.3]
+sols = ur5_ik.solve(T_target)    # up to 8 branches for a Pieper-class arm
+```
+
+For trajectory tracking / teleop, the standard pattern is "give me the IK closest to where the robot is now":
+
+```python
+q_current = np.array([...])    # current joint state from /joint_states
+sols = ur5_ik.solve(T_target, max_solutions=1, q_seed=q_current)
+q_command = sols[0].q if sols else q_current
+```
+
+### Arms supported
+
+Eight prebuilt arms ship with the wheel:
+
+| Arm | Class |
+|---|---|
+| Universal Robots UR5 | three-parallel 6R |
+| KUKA Puma 560 | Pieper 6R |
+| Kinova JACO 2 | non-Pieper 6R |
+| KUKA iiwa LBR 14 | SRS 7R |
+| Kinova Gen3 | approximate-SRS 7R |
+| Franka Panda | anthropomorphic 7R |
+| Flexiv Rizon 4 | non-SRS 7R |
+| Kassow KR810 | non-SRS 7R |
+
+For any other arm: `ssik build my_arm.urdf --base base_link --ee tool0` emits a single-file Python artifact that imports just like the prebuilts.
+
+### Where this fits in the ROS ecosystem
+
+ssik is a **standalone Python library**, not a ROS package — there's no `package.xml` and no `rclpy` dependency. It's intended to be imported from Python nodes / planners / control code where a closed-form per-arm IK is more useful than a generic numerical solver.
+
+Comparison to what's commonly used in ROS:
+
+- **MoveIt's KDL plugin (default):** numerical seed-and-solve. Returns one branch. ssik returns all of them and is faster on every arm we've measured for the comparable "pick one nearest the seed" pattern.
+- **TracIK:** SQP + Jacobian, numerical. Same one-branch semantics. The maintained Python binding (`pytracik`) currently ships a broken arm64 wheel; the ROS-native binding works fine inside ROS.
+- **MoveIt's IKFast plugin:** same per-arm-codegen idea as ssik. IKFast is the closest analog; ssik solves arms IKFast cannot (non-Pieper 6R, non-SRS 7R) and ships as `pip install` instead of a C++ codegen pipeline.
+
+A MoveIt plugin that uses ssik as the backend is feasible but not yet built; if anyone wants to take that on, please file an issue and I'll review the PR.
+
+### Calibration / non-nominal URDFs
+
+The 8 prebuilts are built against nominal manufacturer geometry. For UR's `.calibrated_urdf` per-arm offsets, attached grippers / suction cups, or any non-nominal kinematic chain, run `ssik build` against your URDF — the emitted artifact bakes the exact geometry.
+
+### Links
+
+- **Repo:** https://github.com/personalrobotics/ssik
+- **Docs:** https://personalrobotics.github.io/ssik/
+- **PyPI:** https://pypi.org/project/ssik/
+- **License:** BSD-3-Clause
+
+Issues / questions welcome on the repo or in this thread.
+
+---
+
+## Notes for posting
+
+- ROS Discourse expects a measured tone. The "Release announcements" subcategory has a regular cadence of similar posts; format matches.
+- Specifically *do not* claim ssik replaces TracIK or KDL. It complements them; the analytical-branch enumeration is the differentiator.
+- Be ready to answer: "MoveIt plugin?", "ROS 2 launch file example?", "BSD vs LGPL?", "calibration support?". All covered in the body but expect to repeat in replies.
+- Tag the post with `inverse-kinematics`, `motion-planning`, `python` if the category allows.

--- a/outreach/zenodo-setup.md
+++ b/outreach/zenodo-setup.md
@@ -1,0 +1,39 @@
+# Zenodo DOI setup
+
+One-time configuration so every future tagged GitHub release is auto-archived to Zenodo and assigned a DOI.
+
+## Steps (your accounts, ~10 min)
+
+1. **Sign in to Zenodo with GitHub OAuth.**
+   - Go to https://zenodo.org/login/.
+   - Click "Sign in with GitHub". Approve the OAuth scope (read repo metadata + create releases).
+   - This links the Zenodo account to the `siddhss5` GitHub user. (Zenodo can archive any repo you have admin on, including org repos.)
+
+2. **Enable Zenodo for `personalrobotics/ssik`.**
+   - Go to https://zenodo.org/account/settings/github/.
+   - Find `personalrobotics/ssik` in the list (you may need to click "Sync now" first, top-right).
+   - Flip the toggle to **ON**.
+
+3. **Cut a new release to trigger the first archive.**
+   Zenodo only archives releases created **after** the toggle was flipped. The v1.1.0 release is not automatically backdated. Two options:
+   - **Cheapest:** wait until the next release (v1.1.1 or v1.2.0) and the DOI gets minted then.
+   - **If you want a DOI on v1.1.0 now:** manually re-tag — `git tag -a v1.1.0.1 -m "rebuild for Zenodo archive" && git push --tags`, let the release workflow run, and Zenodo will pick it up. Then update CITATION.cff + the README badge to point to that DOI.
+
+4. **Once the DOI is minted, add the badge.** Zenodo shows the badge markdown on the deposit page; it looks like:
+   ```markdown
+   [![DOI](https://zenodo.org/badge/<repo_id>.svg)](https://zenodo.org/badge/latestdoi/<repo_id>)
+   ```
+   Add it to the top of `README.md` next to the PyPI / Python version badges, and update `CITATION.cff` with the concept DOI (the version-independent one):
+   ```yaml
+   identifiers:
+     - type: doi
+       value: "10.5281/zenodo.XXXXXXX"
+       description: "Concept DOI — points to the latest version."
+   ```
+
+## Notes
+
+- Zenodo mints two DOIs per release: a **concept DOI** (stable across versions, always resolves to the latest) and a **version DOI** (frozen at one release). Papers should cite the concept DOI unless they need to pin a specific version.
+- Maximum deposit size is 50 GB (well under any wheel size we'd ever ship).
+- The Zenodo metadata is auto-populated from `CITATION.cff` if present, which is why we landed that file first.
+- Zenodo's GitHub integration documentation: https://help.zenodo.org/docs/profile/linking-github-account/.


### PR DESCRIPTION
## Summary

Lands citation metadata + announcement scaffolding for the Theme A adoption push following v1.1.0 going public.

- `CITATION.cff` with verified academic-lineage references: IK-Geo (Elias & Wen, MMT 2025), Husty-Pfurner (MMT 2007), Raghavan-Roth (JMD 1993), EAIK (Ostermeier, Külz, Althoff, RA-L 2025), Diankov (CMU thesis 2010). GitHub renders the *Cite this repository* button on the sidebar from this file.
- README citation section now points at `CITATION.cff`.
- `outreach/` collects draft copy for three announcement venues (r/robotics, ROS Discourse, robotics-worldwide@usc.edu), a Zenodo-GitHub integration walkthrough, and a conda-forge staged-recipes recipe + submission instructions. Nothing under `outreach/` ships in the wheel — it's collateral for posting / submitting under personal accounts.

## Why now

Cutting this as v1.1.1 triggers the first Zenodo archive (the GitHub-Zenodo toggle was just enabled; v1.1.0 predates the integration and won't be auto-backdated). Once the DOI is minted, we add the Zenodo badge + DOI to the announcement drafts before posting.

## Test plan

- [ ] CI green
- [ ] `CITATION.cff` parses (GitHub's sidebar widget renders)
- [ ] Confirm the *Cite this repository* button appears after merge
- [ ] After tag-and-release, confirm Zenodo creates a deposit and mints a DOI
- [ ] Add the Zenodo concept DOI to `CITATION.cff` + README badge in a follow-up PR