### PR TITLE
Add Zenodo DOI to citation metadata + README badge + outreach drafts

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,10 @@ cff-version: 1.2.0
 title: "ssik: Analytical inverse kinematics for 6R and 7R revolute arms"
 message: "If you use ssik in academic work, please cite it via this metadata."
 type: software
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.20278005"
+    description: "Concept DOI — always resolves to the latest released version."
 authors:
   - given-names: Siddhartha
     family-names: Srinivasa

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/ssik.svg?v=1)](https://pypi.org/project/ssik/)
 [![Python](https://img.shields.io/pypi/pyversions/ssik.svg?v=1)](https://pypi.org/project/ssik/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20278005.svg)](https://doi.org/10.5281/zenodo.20278005)
 
 Analytical inverse kinematics for 6R and 7R revolute robot arms. Each arm becomes a single self-contained Python module that returns **every IK branch** with FK closure well below typical robot repeatability — and tightenable to machine precision when needed.
 
@@ -311,9 +312,11 @@ If you use ssik in academic work, please cite it. Machine-readable metadata is i
 
 ```bibtex
 @software{ssik,
-  author = {Srinivasa, Siddhartha},
-  title  = {ssik: analytical inverse kinematics for 6R and 7R revolute arms},
-  url    = {https://github.com/personalrobotics/ssik},
-  year   = {2026},
+  author    = {Srinivasa, Siddhartha},
+  title     = {ssik: analytical inverse kinematics for 6R and 7R revolute arms},
+  url       = {https://github.com/personalrobotics/ssik},
+  doi       = {10.5281/zenodo.20278005},
+  year      = {2026},
+  publisher = {Zenodo},
 }
 ```

--- a/outreach/reddit-robotics.md
+++ b/outreach/reddit-robotics.md
@@ -39,6 +39,7 @@ Each `Solution` carries the joint vector, the FK residual against the target, an
 
 **Repo:** https://github.com/personalrobotics/ssik
 **Docs:** https://personalrobotics.github.io/ssik/
+**DOI:** https://doi.org/10.5281/zenodo.20278005
 **License:** BSD-3-Clause. Clean-room reimplementations from the academic literature; lineage documented per-module.
 
 Happy to answer questions about the algorithmic side or how it compares to whatever you're using.

--- a/outreach/robotics-worldwide.md
+++ b/outreach/robotics-worldwide.md
@@ -18,6 +18,7 @@ I'd like to announce **ssik**, an open-source Python library for analytical inve
   Repository:  https://github.com/personalrobotics/ssik
   Docs:        https://personalrobotics.github.io/ssik/
   Install:     pip install ssik
+  DOI:         https://doi.org/10.5281/zenodo.20278005
   License:     BSD-3-Clause
 
 ssik returns every analytical IK branch for a target end-effector pose. Eight commercial arms ship as prebuilt artifacts in the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa LBR 14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810); any other arm is supported via "ssik build my_arm.urdf", which emits a single-file Python artifact specialised to the URDF.

--- a/outreach/ros-discourse.md
+++ b/outreach/ros-discourse.md
@@ -76,6 +76,7 @@ The 8 prebuilts are built against nominal manufacturer geometry. For UR's `.cali
 - **Repo:** https://github.com/personalrobotics/ssik
 - **Docs:** https://personalrobotics.github.io/ssik/
 - **PyPI:** https://pypi.org/project/ssik/
+- **DOI:** https://doi.org/10.5281/zenodo.20278005
 - **License:** BSD-3-Clause
 
 Issues / questions welcome on the repo or in this thread.


### PR DESCRIPTION
## Summary

First Zenodo archive minted from the v1.1.1 GitHub Release. This PR lands the concept DOI (always-points-to-latest) in:

- `CITATION.cff` — top-level `identifiers:` entry so academic citation tooling picks up the DOI.
- `README` — Zenodo badge in the badge row + DOI in the BibTeX block.
- `outreach/{reddit-robotics,ros-discourse,robotics-worldwide}.md` — DOI in the canonical-links list so the announcement posts cite it.

## DOIs

- **Concept DOI** (cite this): https://doi.org/10.5281/zenodo.20278005
- **Version DOI** (v1.1.1 specifically): https://doi.org/10.5281/zenodo.20278006

## Test plan

- [ ] CI green
- [ ] Zenodo badge renders in README
- [ ] CITATION.cff still parses (GitHub sidebar widget renders)