### PR TITLE
Automate GitHub Release on tag push + drop hand-bumped CFF version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,31 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  create_github_release:
+    name: Create GitHub Release
+    needs: publish_pypi
+    runs-on: ubuntu-latest
+    # Only on stable releases (non-RC). The GitHub Release is what fires
+    # the Zenodo GitHub-integration webhook, which mints a new version DOI
+    # (concept DOI stays constant). Without this step, tags exist but
+    # Zenodo never archives them.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+    permissions:
+      contents: write   # required to create the Release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed for auto-generated release notes
+
+      - name: Create Release
+        # action-gh-release is idempotent: if a Release already exists for
+        # this tag (e.g. created manually before the workflow finished),
+        # it updates rather than failing.
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ssik ${{ github.ref_name }}
+          generate_release_notes: true   # GitHub auto-generates from merged PRs since previous tag
+          draft: false
+          prerelease: false

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,11 @@
 # YAML 1.2 — Citation File Format 1.2.0
 # https://citation-file-format.github.io
+#
+# Per-release version metadata (which version, when released) lives in the
+# Zenodo deposit, not here. Zenodo derives both fields from the Git tag at
+# archive time; the concept DOI below always resolves to the latest version.
+# We deliberately omit ``version:`` and ``date-released:`` so this file
+# does not need to be hand-bumped on every release.
 cff-version: 1.2.0
 title: "ssik: Analytical inverse kinematics for 6R and 7R revolute arms"
 message: "If you use ssik in academic work, please cite it via this metadata."
@@ -16,8 +22,6 @@ authors:
 repository-code: "https://github.com/personalrobotics/ssik"
 url: "https://personalrobotics.github.io/ssik/"
 license: BSD-3-Clause
-version: 1.1.0
-date-released: 2026-05-15
 keywords:
   - robotics
   - inverse-kinematics


### PR DESCRIPTION
## Summary

Two changes that make v1.1.2 and beyond fully automated end-to-end (tag → PyPI → GitHub Release → Zenodo DOI), so the per-release manual work shrinks to just \`git tag && git push --tags\`.

1. **release.yml**: new \`create_github_release\` job that runs after \`publish_pypi\` on stable tags (non-RC). Uses \`softprops/action-gh-release@v2\` with \`generate_release_notes: true\`. The GitHub Release object is what fires the Zenodo webhook — without it, the tag pushes but Zenodo never archives. v1.1.1 needed a manual \`gh release create\` to mint the first DOI; v1.1.2+ won't.
2. **CITATION.cff**: drop \`version:\` and \`date-released:\` fields. Zenodo derives both from the Git tag at archive time (verified on the v1.1.1 deposit — it stored \`version: v1.1.1\` even though the CFF still said \`1.1.0\` at tag time). Header comment explains the rationale.

## Why drop CFF version

Keeping it requires a hand-edit on every release. Forgetting that step is silent — Zenodo still mints the correct version DOI from the tag, but the CFF citation drifts behind. Removing the duplication is simpler than auto-bumping.

## What's still manual after this lands

- \`git tag -a vX.Y.Z && git push --tags\`. That's it.
- Conda-forge feedstock bumps: once staged-recipes PR #33376 merges, \`regro-cf-autotick-bot\` opens feedstock PRs automatically on every PyPI version.

## Test plan

- [ ] CI green
- [ ] Workflow YAML lint clean
- [ ] Next stable tag (v1.1.2 or v1.2.0) creates the GitHub Release without manual intervention
- [ ] That Release auto-fires Zenodo, mints a new version DOI under the same concept DOI (10.5281/zenodo.20278005)