### PR TITLE
Add UFactory xArm7 to ssik.prebuilt

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,10 +31,10 @@ keywords:
   - manipulation
 abstract: >
   ssik is a Python library that produces every analytical inverse-kinematics
-  branch for 6R and 7R revolute manipulators. It ships eight prebuilt arms
+  branch for 6R and 7R revolute manipulators. It ships nine prebuilt arms
   (UR5, Puma 560, JACO 2, KUKA iiwa14, Kinova Gen3, Franka Panda, Flexiv
-  Rizon 4, Kassow KR810) and a "ssik build" CLI that emits a self-contained
-  per-arm artifact from a URDF. ssik covers kinematic classes that the
+  Rizon 4, Kassow KR810, UFactory xArm7) and a "ssik build" CLI that emits
+  a self-contained per-arm artifact from a URDF. ssik covers kinematic classes that the
   standard subproblem-decomposition libraries do not — non-Pieper 6R
   (JACO 2's 55° twists), non-SRS 7R (Rizon 4, Kassow KR810), and
   approximate-SRS 7R (Kinova Gen3) — via a tier-based dispatcher backed by

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are two artifact paths:
 
 ### Use a prebuilt arm (`ssik.prebuilt`)
 
-The wheel ships 8 ready-to-import artifacts. Each was built against a specific URDF (or extracted spec); `T_target` is the pose of `EE_LINK` expressed in `BASE_LINK`:
+The wheel ships 9 ready-to-import artifacts. Each was built against a specific URDF (or extracted spec); `T_target` is the pose of `EE_LINK` expressed in `BASE_LINK`:
 
 | Module | Arm | Class | base_link | ee_link |
 |---|---|---|---|---|
@@ -49,6 +49,7 @@ The wheel ships 8 ready-to-import artifacts. Each was built against a specific U
 | `franka_panda_ik` | Franka Panda | anthropomorphic 7R | `base_link` | `ee_link` |
 | `rizon4_ik` | Flexiv Rizon 4 | **non-SRS 7R** | `base_link` | `flange` |
 | `kassow_kr810_ik` | Kassow KR810 | **non-SRS 7R** | `base` | `end_effector` |
+| `xarm7_ik` | UFactory xArm7 | 7R Pieper-wedge (jointlock → `reversed:spherical`) | `link_base` | `link7` |
 
 ```python
 from ssik.prebuilt import iiwa14_ik
@@ -67,7 +68,7 @@ print(franka_panda_ik.T_HOME[:3, 3])
 
 ### When a prebuilt is right vs when to `ssik build`
 
-The 8 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
+The 9 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
 
 - You're using the same URDF source we built against (ros-industrial, manufacturer reference, etc.)
 - Your robot's calibration matches the nominal kinematic parameters
@@ -208,7 +209,7 @@ The fields are named for *why* they exist so log messages can say `"SP6 sign bra
 | 1e-9 | 1 nm | math / analysis territory |
 | 1e-13 | 0.1 pm | float64 epsilon |
 
-The default `subproblem_numerical = 1e-5` is intentionally pragmatic — **already two orders below what any physical robot can mechanically repeat**, but cheap enough that all 8 prebuilts hit it without LM polish. Most control / planning users want exactly this default.
+The default `subproblem_numerical = 1e-5` is intentionally pragmatic — **already two orders below what any physical robot can mechanically repeat**, but cheap enough that all 9 prebuilts hit it without LM polish. Most control / planning users want exactly this default.
 
 **To get machine precision** (RL training, differentiable IK, sample-based planning, math validation), opt in:
 

--- a/README.md
+++ b/README.md
@@ -264,13 +264,14 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 | UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 556 ± 12 µs / FK 2e-9 / 4 sols |
 | Puma 560 (Pieper 6R, spherical wrist) | 5 ± 1 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
 | JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 2 sols |
-| iiwa14 (SRS 7R) | **refuses** ("only 1-6R robots are solvable") | 5.10 ± 0.07 ms / FK 4e-13 / 96 sols |
+| iiwa14 (SRS 7R) | **refuses** (no 7R DH path in bench harness) | 4.99 ± 0.03 ms / FK 3e-13 / 96 sols |
 | Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.83 ± 1.15 ms / FK 1e-12 / 47 sols |
-| Franka Panda (anthropomorphic 7R) | **refuses** ("only 1-6R") | 28.03 ± 2.57 ms / FK 7e-13 / 9 sols |
+| Franka Panda (anthropomorphic 7R) | **refuses** (no 7R DH path in bench harness) | 29.34 ± 2.59 ms / FK 8e-12 / 8 sols |
+| xArm7 (**non-SRS 7R**) | **refuses** (no 7R DH path in bench harness) | 35.41 ± 1.11 ms / FK 1e-11 / 20 sols |
 | Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.88 ± 8.80 ms / FK 4e-9 / 35 sols |
 | Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 28.06 ± 10.63 ms / FK 7e-8 / 24 sols |
 
-EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings are EAIK's actual error messages, captured verbatim by the bench harness. A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
+EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
 
 ## Under the hood
 

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -55,7 +55,7 @@ For non-Pieper inner sub-chains (Rizon 4, Kassow KR810), `ssik build` bakes the 
 | Arm | Drift (shoulder / wrist) | Inner | Speed (full sweep) | Status |
 |-----|---|---|:-----:|:-----:|
 | **Franka Emika Panda** | non-SRS by design | tier-0 inner (`reversed:spherical_two_parallel`) | 28.03 ± 2.57 ms / 9 sols / FK 7e-13 | ✅ `ssik.prebuilt.franka_panda_ik` |
-| uFactory xArm7 | non-SRS by design | tier-0 inner | expected ~30-45 ms | ✅ tests/fixtures (artifact pending) |
+| **uFactory xArm7** | non-SRS by design | tier-0 inner (`reversed:spherical`) | expected ~30-45 ms | ✅ `ssik.prebuilt.xarm7_ik` |
 | **Flexiv Rizon 4** | 65 mm / 151 mm | cached-RR (HP otherwise) | 30.88 ± 8.80 ms / 35 sols / FK 4e-9 | ✅ `ssik.prebuilt.rizon4_ik` |
 | **Kassow KR810** | 86 mm / 111 mm | cached-RR (HP otherwise) | 28.06 ± 10.63 ms / 24 sols / FK 7e-8 | ✅ `ssik.prebuilt.kassow_kr810_ik` |
 | Sawyer / Baxter (Rethink) | likely non-SRS | TBD | expected ~30-50 ms | 🔗 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ T_target[:3, 3] = [0.5, 0.1, 0.3]
 sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
 ```
 
-8 prebuilt arms ship with the wheel: UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, Rizon 4, Kassow KR810. For other arms, run `ssik build <your.urdf>` once and import the emitted module.
+9 prebuilt arms ship with the wheel: UR5, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, Rizon 4, Kassow KR810, UFactory xArm7. For other arms, run `ssik build <your.urdf>` once and import the emitted module.
 
 ## Where to go next
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-pip install ssik                  # core: library + 8 prebuilt arms + CLI
+pip install ssik                  # core: library + 9 prebuilt arms + CLI
 pip install ssik[urdf]            # adds urchin + sympy for ssik build / Manipulator.from_urdf
 ```
 
@@ -34,6 +34,7 @@ sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
 | `franka_panda_ik` | Franka Panda | anthropomorphic 7R | `base_link` | `ee_link` |
 | `rizon4_ik` | Flexiv Rizon 4 | non-SRS 7R | `base_link` | `flange` |
 | `kassow_kr810_ik` | Kassow KR810 | non-SRS 7R | `base` | `end_effector` |
+| `xarm7_ik` | UFactory xArm7 | 7R Pieper-wedge | `link_base` | `link7` |
 
 Each prebuilt exposes `BASE_LINK`, `EE_LINK`, `DOF`, `T_HOME` constants so you can verify the baked geometry matches your robot:
 

--- a/docs/setting_up_your_robot.md
+++ b/docs/setting_up_your_robot.md
@@ -1,10 +1,10 @@
 # Setting up your robot
 
-Guide for getting your specific arm working with ssik — beyond the 8 prebuilts. Three real-world friction points: **URDF readiness**, **link selection** (base + EE + tool), and **verification** (does the baked geometry match your robot?).
+Guide for getting your specific arm working with ssik — beyond the 9 prebuilts. Three real-world friction points: **URDF readiness**, **link selection** (base + EE + tool), and **verification** (does the baked geometry match your robot?).
 
 ## When a prebuilt is enough vs when to `ssik build`
 
-The 8 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
+The 9 prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
 
 - You're using the same URDF source we built against (ros-industrial, vendor reference, etc.)
 - Your robot's calibration matches the nominal kinematic parameters

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -84,6 +84,7 @@ FIXTURES = [
         ("kassow_kr810.urdf", "base", "end_effector"),
         "kassow_kr810_ik",
     ),
+    Fixture("xArm7", 7, "specs", ("xarm7", "xarm7_specs"), "xarm7_ik"),
 ]
 
 

--- a/outreach/conda-forge/meta.yaml
+++ b/outreach/conda-forge/meta.yaml
@@ -57,9 +57,9 @@ about:
   summary: Analytical inverse kinematics for 6R and 7R revolute robot arms
   description: |
     ssik is a Python library that produces every analytical inverse-kinematics
-    branch for 6R and 7R revolute manipulators. Eight prebuilt arms ship in
+    branch for 6R and 7R revolute manipulators. Nine prebuilt arms ship in
     the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa14, Kinova Gen3, Franka
-    Panda, Flexiv Rizon 4, Kassow KR810); any other arm is supported via the
+    Panda, Flexiv Rizon 4, Kassow KR810, UFactory xArm7); any other arm is supported via the
     ``ssik build`` CLI, which reads a URDF and emits a single-file Python
     artifact specialised to the kinematic chain. ssik covers kinematic
     classes that the standard subproblem-decomposition libraries do not —

--- a/outreach/reddit-robotics.md
+++ b/outreach/reddit-robotics.md
@@ -28,7 +28,7 @@ sols = franka_panda_ik.solve(T)    # every IK branch
 
 Each `Solution` carries the joint vector, the FK residual against the target, and which polish path fired. Empty list = pose is unreachable.
 
-**Arms shipped:** UR5, Puma 560, Kinova JACO 2, KUKA iiwa14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810. For anything else: `ssik build my_arm.urdf` emits a single-file Python artifact for your URDF.
+**Arms shipped:** UR5, Puma 560, Kinova JACO 2, KUKA iiwa14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810, UFactory xArm7. For anything else: `ssik build my_arm.urdf` emits a single-file Python artifact for your URDF.
 
 **What's different from existing tools:**
 - vs **numerical IK** (TracIK, MINK, KDL): those run damped least-squares to *one* converged config and stop. ssik enumerates every analytical branch — important for motion planning (try every branch, pick best clearance), dexterity analysis (per-branch manipulability), trajectory continuation across singularities.

--- a/outreach/robotics-worldwide.md
+++ b/outreach/robotics-worldwide.md
@@ -21,7 +21,7 @@ I'd like to announce **ssik**, an open-source Python library for analytical inve
   DOI:         https://doi.org/10.5281/zenodo.20278005
   License:     BSD-3-Clause
 
-ssik returns every analytical IK branch for a target end-effector pose. Eight commercial arms ship as prebuilt artifacts in the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa LBR 14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810); any other arm is supported via "ssik build my_arm.urdf", which emits a single-file Python artifact specialised to the URDF.
+ssik returns every analytical IK branch for a target end-effector pose. Nine commercial arms ship as prebuilt artifacts in the wheel (UR5, Puma 560, Kinova JACO 2, KUKA iiwa LBR 14, Kinova Gen3, Franka Panda, Flexiv Rizon 4, Kassow KR810, UFactory xArm7); any other arm is supported via "ssik build my_arm.urdf", which emits a single-file Python artifact specialised to the URDF.
 
 The library is intended for tasks where branch enumeration matters: motion planning (search over branches for clearance / manipulability), dexterity analysis, trajectory continuation across kinematic singularities, and reinforcement-learning environments where IK ground truth is part of the reward / observation. Numerical IK libraries that converge to a single configuration are not substitutes for this use case.
 

--- a/outreach/ros-discourse.md
+++ b/outreach/ros-discourse.md
@@ -40,7 +40,7 @@ q_command = sols[0].q if sols else q_current
 
 ### Arms supported
 
-Eight prebuilt arms ship with the wheel:
+Nine prebuilt arms ship with the wheel:
 
 | Arm | Class |
 |---|---|
@@ -52,6 +52,7 @@ Eight prebuilt arms ship with the wheel:
 | Franka Panda | anthropomorphic 7R |
 | Flexiv Rizon 4 | non-SRS 7R |
 | Kassow KR810 | non-SRS 7R |
+| UFactory xArm7 | 7R Pieper-wedge |
 
 For any other arm: `ssik build my_arm.urdf --base base_link --ee tool0` emits a single-file Python artifact that imports just like the prebuilts.
 

--- a/scripts/regen_artifacts.py
+++ b/scripts/regen_artifacts.py
@@ -73,6 +73,7 @@ def main() -> int:
     )
     _emit_jaco2_artifact()
     _emit_franka_panda_artifact()
+    _emit_xarm7_artifact()
 
     if args.include_slow:
         # Slow non-SRS 7R artifacts: cached-RR symbolic derivations baked
@@ -160,6 +161,36 @@ def _emit_jaco2_artifact() -> None:
         module_name="jaco2_ik",
         output_path=str(out),
         arm_label="Kinova JACO 2 (j2n6s200)",
+    )
+    elapsed = time.perf_counter() - t
+    size_kb = out.stat().st_size / 1024
+    print(
+        f"  {out.relative_to(REPO_ROOT)}: {plan.solver_name} "
+        f"(tier {plan.tier}, {size_kb:.1f} KB, {elapsed:.1f}s)"
+    )
+
+
+def _emit_xarm7_artifact() -> None:
+    """UFactory xArm7 fixture: MJCF transcription, 7-DOF. Routes through
+    ``jointlock.seven_r`` which auto-picks lock_idx and dispatches to a
+    ``reversed:spherical`` Pieper-class wedge (verified in
+    ``scripts/profile_7r_arms.py``)."""
+    sys.path.insert(0, str(FIXTURES))
+    from xarm7 import xarm7_specs
+
+    t = time.perf_counter()
+    # Match the upstream xArm7 MJCF body / ROS URDF link names
+    # (mujoco_menagerie/ufactory_xarm7, xarm_ros2): ``link_base`` is the
+    # fixed base, ``link7`` is the post-joint-7 frame (the bare flange).
+    kb = build_kinbody(xarm7_specs(), base_link_name="link_base", ee_link_name="link7")
+    plan = dispatch(kb)
+    out = ARTIFACTS / "xarm7_ik.py"
+    emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="xarm7_ik",
+        output_path=str(out),
+        arm_label="UFactory xArm7",
     )
     elapsed = time.perf_counter() - t
     size_kb = out.stat().st_size / 1024

--- a/src/ssik/prebuilt/xarm7_ik.py
+++ b/src/ssik/prebuilt/xarm7_ik.py
@@ -1,0 +1,555 @@
+"""Generated IK module for UFactory xArm7.
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Provenance: KinBody hash b88b2e44baf7 (sha256/12 of the input chain).
+``T_target`` is the pose of ``link7`` (end-effector link) in
+``link_base`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
+
+DOF: 7    BASE_LINK: "link_base"    EE_LINK: "link7"
+Solver: ``jointlock.seven_r`` (tier 1)
+Expected median IK time: ~50.0 ms on commodity
+single-thread hardware. FLOP budget: 30,274 per solve.
+
+Usage:
+
+    import xarm7_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose of link7 in link_base
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions = xarm7_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``xarm7_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
+"""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+from ssik.solvers.jointlock import seven_r as _ssik_seven_r
+
+import cython
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.refinement import lm_refine as _lm_refine
+from ssik.postprocess import (
+    nearest_to_seed as _ps_nearest_to_seed,
+    respect_limits as _ps_respect_limits,
+    wrap_to_limits as _ps_wrap_to_limits,
+)
+from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
+
+SOLVER_NAME = "jointlock.seven_r"
+SOLVER_TIER = 1
+EXPECTED_MS_MEDIAN = 50.0
+FLOP_BUDGET = 30274
+DISPATCH_REASON = '7R revolute chain (non-SRS). Locking one joint\n(auto-selected by topology rank of the resulting 6R\nsub-chain) reduces this to a series of 6R IK problems.\nCovers Franka Panda, FR3, uFactory xArm7, and any other\nnon-SRS 7R revolute arm.'
+BASE_LINK = "link_base"
+EE_LINK = "link7"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, 0.0, 0.0, 0.20600000000000002], [0.0, -0.9999999999999987, -4.4408920985006217e-16, -2.0572432646304143e-16], [0.0, 4.4408920985006217e-16, -0.9999999999999987, 0.12050000000000025], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['link_base', 'link_1', 'link_2', 'link_3', 'link_4', 'link_5', 'link_6', 'link7']
+
+_JOINT_NAMES = [
+    'xarm7_joint1',
+    'xarm7_joint2',
+    'xarm7_joint3',
+    'xarm7_joint4',
+    'xarm7_joint5',
+    'xarm7_joint6',
+    'xarm7_joint7',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([0.0, 0.9999999999999998, 2.220446049250313e-16], dtype=np.float64),
+    np.array([0.0, 0.0, 0.9999999999999996], dtype=np.float64),
+    np.array([0.0, -0.9999999999999993, 2.220446049250312e-16], dtype=np.float64),
+    np.array([0.0, -4.440892098500623e-16, -0.9999999999999991], dtype=np.float64),
+    np.array([0.0, 0.9999999999999989, -6.661338147750933e-16], dtype=np.float64),
+    np.array([0.0, -4.4408920985006217e-16, -0.9999999999999987], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.267], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -6.505906924303417e-17], [0.0, 0.0, 1.0, 0.2929999999999999], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0525], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.07750000000000001], [0.0, 1.0, 0.0, -7.605027718682319e-17], [0.0, 0.0, 1.0, -0.3424999999999998], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.07600000000000001], [0.0, 1.0, 0.0, -6.461498003318407e-17], [0.0, 0.0, 1.0, -0.09699999999999989], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, -0.9999999999999987, -4.4408920985006217e-16, 0.0], [0.0, 4.4408920985006217e-16, -0.9999999999999987, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+_JOINT_LIMITS = [
+    (-6.2832, 6.2832),
+    (-2.059, 2.0944),
+    (-6.2832, 6.2832),
+    (-0.19198, 3.927),
+    (-6.2832, 6.2832),
+    (-1.69297, 3.14159),
+    (-6.2832, 6.2832),
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+# --- 7R via joint-lock ---
+# Pre-selected lock_idx via choose_lock_joint at codegen time, passed
+# to the runtime solve() so it skips the per-IK topology-rank scan
+# over all 7 lock candidates. Per-sample inner-solver dispatch still
+# happens at runtime (rotating downstream axes by R_lock can shift
+# which tier-0/1 specialization applies).
+_LOCK_IDX = 4
+
+# Canonical lock-sample schedule (np.linspace over the locked
+# joint's range, ``_DEFAULT_SAMPLES`` samples, endpoint excluded).
+_LOCK_SAMPLES = np.array(
+    [-6.2832, -5.4978, -4.7124, -3.927, -3.1416, -2.3562, -1.5708000000000002, -0.7854000000000001, 0.0, 0.7854000000000001, 1.5708000000000002, 2.3562000000000003, 3.1415999999999995, 3.9270000000000005, 4.7124, 5.497800000000001],
+    dtype=np.float64,
+)
+
+# Codegen-time topology cache (#142 item 4). Pre-computed via
+# ``_lock_joint`` + ``_topology_rank`` at each lock sample; runtime
+# ``seven_r.solve`` uses these directly instead of re-running the
+# topology rank per IK. The cache aligns by sample index with
+# ``_LOCK_SAMPLES``; under ``q_seed`` reordering the runtime
+# permutes the cache alongside the samples.
+_DISPATCH_CACHE = (
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical_two_parallel',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+    'reversed:spherical',
+)
+
+
+def _solve_algebraic(
+    T_target, *, max_solutions=None, q_seed=None, respect_limits=False,
+):
+    """7R IK candidates via joint-locking + inner 6R sweep.
+
+    Routes to ssik.solvers.jointlock.seven_r.solve with the baked
+    KinBody, lock_idx, lock-sample schedule, and dispatch cache.
+    ``max_solutions``, ``q_seed``, and ``respect_limits`` are
+    forwarded so the lock-sweep can short-circuit on the first
+    in-limits valid IK (#238 review). Returns
+    ``list[list[float]]`` of length-7 q-vectors.
+    """
+    sub_solutions, _is_ls = _ssik_seven_r.solve(
+        _KB, T_target,
+        lock_idx=_LOCK_IDX,
+        lock_samples=_LOCK_SAMPLES,
+        dispatch_cache=_DISPATCH_CACHE,
+        max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
+    )
+    return [list(s.q) for s in sub_solutions]
+
+
+# Cached 4x4 identity reused inside ``_fk`` / ``_spatial_jacobian``
+# so each call avoids ``len(_JOINT_AXES)+1`` per-iteration ``np.eye(4)``
+# allocations -- the orchestrator's #1 hotspot per Slice 4 profile
+# (~22% of ``_fk`` cost on Puma 560).
+_FK_EYE4 = np.eye(4, dtype=np.float64)
+_FK_EYE4.flags.writeable = False
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    ax=cython.double, ay=cython.double, az=cython.double,
+    qi=cython.double, c=cython.double, s=cython.double, oc=cython.double,
+    r00=cython.double, r01=cython.double, r02=cython.double,
+    r10=cython.double, r11=cython.double, r12=cython.double,
+    r20=cython.double, r21=cython.double, r22=cython.double,
+    l00=cython.double, l01=cython.double, l02=cython.double, l03=cython.double,
+    l10=cython.double, l11=cython.double, l12=cython.double, l13=cython.double,
+    l20=cython.double, l21=cython.double, l22=cython.double, l23=cython.double,
+    m00=cython.double, m01=cython.double, m02=cython.double, m03=cython.double,
+    m10=cython.double, m11=cython.double, m12=cython.double, m13=cython.double,
+    m20=cython.double, m21=cython.double, m22=cython.double, m23=cython.double,
+    t00=cython.double, t01=cython.double, t02=cython.double, t03=cython.double,
+    t10=cython.double, t11=cython.double, t12=cython.double, t13=cython.double,
+    t20=cython.double, t21=cython.double, t22=cython.double, t23=cython.double,
+    n00=cython.double, n01=cython.double, n02=cython.double, n03=cython.double,
+    n10=cython.double, n11=cython.double, n12=cython.double, n13=cython.double,
+    n20=cython.double, n21=cython.double, n22=cython.double, n23=cython.double,
+    a00=cython.double, a01=cython.double, a02=cython.double, a03=cython.double,
+    a10=cython.double, a11=cython.double, a12=cython.double, a13=cython.double,
+    a20=cython.double, a21=cython.double, a22=cython.double, a23=cython.double,
+    b00=cython.double, b01=cython.double, b02=cython.double, b03=cython.double,
+    b10=cython.double, b11=cython.double, b12=cython.double, b13=cython.double,
+    b20=cython.double, b21=cython.double, b22=cython.double, b23=cython.double,
+)
+def _fk(q):
+    """POE forward kinematics using the baked chain constants.
+
+    Hand-rolled scalar 4x4 matmul + inline Rodrigues -- no per-call
+    ``np.eye(4)`` allocations and no per-joint numpy ``@`` dispatch.
+    Each numpy ``@`` on a 4x4 has ~3 us of dispatch overhead;
+    inlining the ~85 scalar ops per joint turns the inner loop into
+    a single native-code chunk under Cython compile.
+
+    Bottom row of the accumulator stays [0, 0, 0, 1] implicitly.
+    """
+    n = len(_JOINT_AXES)
+    # Identity accumulator (the bottom row [0,0,0,1] is implicit).
+    a00 = 1.0; a01 = 0.0; a02 = 0.0; a03 = 0.0
+    a10 = 0.0; a11 = 1.0; a12 = 0.0; a13 = 0.0
+    a20 = 0.0; a21 = 0.0; a22 = 1.0; a23 = 0.0
+    for i in range(n):
+        # Inline Rodrigues for this joint's axis.
+        ax = float(_JOINT_AXES[i][0])
+        ay = float(_JOINT_AXES[i][1])
+        az = float(_JOINT_AXES[i][2])
+        qi = float(q[i])
+        c = math.cos(qi); s = math.sin(qi); oc = 1.0 - c
+        r00 = c + ax*ax*oc;     r01 = ax*ay*oc - az*s; r02 = ax*az*oc + ay*s
+        r10 = ay*ax*oc + az*s;  r11 = c + ay*ay*oc;    r12 = ay*az*oc - ax*s
+        r20 = az*ax*oc - ay*s;  r21 = az*ay*oc + ax*s; r22 = c + az*az*oc
+        # T_left[i] entries.
+        Tl = _JOINT_T_LEFTS[i]
+        l00 = float(Tl[0,0]); l01 = float(Tl[0,1])
+        l02 = float(Tl[0,2]); l03 = float(Tl[0,3])
+        l10 = float(Tl[1,0]); l11 = float(Tl[1,1])
+        l12 = float(Tl[1,2]); l13 = float(Tl[1,3])
+        l20 = float(Tl[2,0]); l21 = float(Tl[2,1])
+        l22 = float(Tl[2,2]); l23 = float(Tl[2,3])
+        # M = T_left[i] @ R (R is the homogeneous version of the 3x3
+        # rotation above with column 3 = [0,0,0,1]^T).
+        m00 = l00*r00 + l01*r10 + l02*r20
+        m01 = l00*r01 + l01*r11 + l02*r21
+        m02 = l00*r02 + l01*r12 + l02*r22
+        m03 = l03
+        m10 = l10*r00 + l11*r10 + l12*r20
+        m11 = l10*r01 + l11*r11 + l12*r21
+        m12 = l10*r02 + l11*r12 + l12*r22
+        m13 = l13
+        m20 = l20*r00 + l21*r10 + l22*r20
+        m21 = l20*r01 + l21*r11 + l22*r21
+        m22 = l20*r02 + l21*r12 + l22*r22
+        m23 = l23
+        # T_right[i] entries.
+        Tr = _JOINT_T_RIGHTS[i]
+        t00 = float(Tr[0,0]); t01 = float(Tr[0,1])
+        t02 = float(Tr[0,2]); t03 = float(Tr[0,3])
+        t10 = float(Tr[1,0]); t11 = float(Tr[1,1])
+        t12 = float(Tr[1,2]); t13 = float(Tr[1,3])
+        t20 = float(Tr[2,0]); t21 = float(Tr[2,1])
+        t22 = float(Tr[2,2]); t23 = float(Tr[2,3])
+        # N = M @ T_right[i]
+        n00 = m00*t00 + m01*t10 + m02*t20
+        n01 = m00*t01 + m01*t11 + m02*t21
+        n02 = m00*t02 + m01*t12 + m02*t22
+        n03 = m00*t03 + m01*t13 + m02*t23 + m03
+        n10 = m10*t00 + m11*t10 + m12*t20
+        n11 = m10*t01 + m11*t11 + m12*t21
+        n12 = m10*t02 + m11*t12 + m12*t22
+        n13 = m10*t03 + m11*t13 + m12*t23 + m13
+        n20 = m20*t00 + m21*t10 + m22*t20
+        n21 = m20*t01 + m21*t11 + m22*t21
+        n22 = m20*t02 + m21*t12 + m22*t22
+        n23 = m20*t03 + m21*t13 + m22*t23 + m23
+        # T_acc = T_acc @ N
+        b00 = a00*n00 + a01*n10 + a02*n20
+        b01 = a00*n01 + a01*n11 + a02*n21
+        b02 = a00*n02 + a01*n12 + a02*n22
+        b03 = a00*n03 + a01*n13 + a02*n23 + a03
+        b10 = a10*n00 + a11*n10 + a12*n20
+        b11 = a10*n01 + a11*n11 + a12*n21
+        b12 = a10*n02 + a11*n12 + a12*n22
+        b13 = a10*n03 + a11*n13 + a12*n23 + a13
+        b20 = a20*n00 + a21*n10 + a22*n20
+        b21 = a20*n01 + a21*n11 + a22*n21
+        b22 = a20*n02 + a21*n12 + a22*n22
+        b23 = a20*n03 + a21*n13 + a22*n23 + a23
+        a00, a01, a02, a03 = b00, b01, b02, b03
+        a10, a11, a12, a13 = b10, b11, b12, b13
+        a20, a21, a22, a23 = b20, b21, b22, b23
+    return np.array(
+        [[a00, a01, a02, a03],
+         [a10, a11, a12, a13],
+         [a20, a21, a22, a23],
+         [0.0, 0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+
+
+@cython.ccall
+@cython.locals(i=cython.int, n=cython.int)
+def _spatial_jacobian(q):
+    """6 x n_dof spatial Jacobian using the baked chain constants.
+
+    Math identical to ssik.refinement.kinbody_jacobian: column i
+    is (p_i x z_i, z_i) where z_i is the i-th joint axis in the
+    world frame at q and p_i is the i-th joint origin. This is
+    the SPATIAL twist representation -- T(q+dq) @ T(q)^-1 ~
+    exp([J @ dq]) -- matching the residual extracted by
+    ssik.refinement.se3_log_residual. Per-arm version with
+    baked _JOINT_AXES / _JOINT_T_LEFTS / _JOINT_T_RIGHTS so
+    there's no KinBody walk at runtime.
+    """
+    n = len(_JOINT_AXES)
+    cum = _FK_EYE4.copy()
+    cums = [cum.copy()]
+    rot = _FK_EYE4.copy()
+    for i in range(n):
+        rot[:3, :3] = _rotation_matrix(_JOINT_AXES[i], float(q[i]))
+        cum = cum @ _JOINT_T_LEFTS[i] @ rot @ _JOINT_T_RIGHTS[i]
+        cums.append(cum.copy())
+    J = np.zeros((6, n), dtype=np.float64)
+    for i in range(n):
+        t_pre = cums[i] @ _JOINT_T_LEFTS[i]
+        axis_unit = _JOINT_AXES[i] / np.linalg.norm(_JOINT_AXES[i])
+        z_i = t_pre[:3, :3] @ axis_unit
+        p_i = t_pre[:3, 3]
+        J[:3, i] = np.cross(p_i, z_i)
+        J[3:, i] = z_i
+    return J
+
+
+# Module-scope ``2*pi`` constant referenced inside the dedup hot
+# loop (Cython compiles ``_TWO_PI`` to a typed C ``double``).
+_TWO_PI: float = 2.0 * math.pi
+
+
+@cython.ccall
+def _wrap_to_pi(a: float) -> float:
+    """Wrap an angle to ``(-pi, pi]``. Called inside the per-IK
+    dedup hot loop (235k+ times on Franka 7R)."""
+    return ((a + math.pi) % _TWO_PI) - math.pi
+
+
+@cython.ccall
+@cython.locals(
+    i=cython.int,
+    n=cython.int,
+    diff=cython.double,
+    ai=cython.double,
+    bi=cython.double,
+)
+def _q_close_wrap(a, b, tol: float) -> bool:
+    """Return ``True`` if joint vectors ``a`` and ``b`` agree (mod 2pi)
+    within ``tol`` per element. Replaces the
+    ``np.array([_wrap_to_pi(...)]) -> np.all(np.abs(...) < tol)``
+    pipeline that allocated a numpy array per dedup-loop iteration --
+    a per-element scalar loop avoids the array creation and the
+    ``np.all`` reduction overhead, which together dominated the
+    artifact's ``solve()`` body at the per-IK level."""
+    n = len(a)
+    for i in range(n):
+        ai = float(a[i])
+        bi = float(b[i])
+        diff = ((ai - bi + math.pi) % _TWO_PI) - math.pi
+        if abs(diff) > tol:
+            return False
+    return True
+
+
+def solve(
+    T_target,
+    *,
+    max_solutions: int | None = None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = False,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
+):
+    """Inverse kinematics. Returns ``list[Solution]``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose.
+    :param max_solutions: optional early-exit cap on the
+        jointlock lock-sweep. ``None`` (default) = exhaustive
+        search. ``max_solutions=1`` short-circuits as soon as
+        one valid IK is found (~17x faster on this 7R).
+    :param q_seed: optional length-7 seed configuration. When
+        provided, the lock-joint samples are visited in order
+        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
+        combined with ``max_solutions=1`` this is the
+        trajectory-tracking fast path.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. Pass ``False``
+        for the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton
+        polish fires on near-miss algebraic candidates.
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+
+    Common idioms::
+
+        # Exhaustive search (default).
+        solutions = solve(T_target)
+
+        # "Just give me one IK" -- ~17x faster.
+        solutions = solve(T_target, max_solutions=1)
+
+        # Track current config -- ~37x faster.
+        solutions = solve(
+            T_target, q_seed=q_current, max_solutions=1,
+        )
+    """
+    T = np.asarray(T_target, dtype=np.float64)
+    # Lock-sweep filters limits in-flight (#238 review): the
+    # short-circuit fires on the first in-limits valid IK, not
+    # on a candidate that postprocess would drop. Preserves the
+    # max_solutions+q_seed early-exit fast path even with
+    # respect_limits=True.
+    candidates = _solve_algebraic(
+        T, max_solutions=max_solutions, q_seed=q_seed,
+        respect_limits=respect_limits,
+    )
+
+    fk_atol = policy.subproblem_numerical
+    dedup_atol = policy.subproblem_dedup
+
+    # Three-bucket sort: exact (closes within fk_atol), near-miss
+    # (refinable when allow_refinement=True), or drop.
+    verified: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q in candidates:
+        q = np.asarray(cand_q, dtype=np.float64)
+        if not np.all(np.isfinite(q)):
+            continue
+        T_check = _fk(q)
+        residual = float(np.linalg.norm(T_check - T))
+        if residual <= fk_atol:
+            verified.append((q, residual, "none", 0))
+            continue
+        if not allow_refinement:
+            continue
+        # Newton polish using the per-arm spatial Jacobian.
+        refined = _lm_refine(
+            q,
+            _fk,
+            T,
+            fk_atol=fk_atol,
+            max_iters=refinement_max_iters,
+            jacobian_fn=_spatial_jacobian,
+        )
+        if refined is None:
+            continue
+        q_ref, resid_ref, iters = refined
+        verified.append((q_ref, resid_ref, "lm", iters))
+
+    # Wrap-to-pi dedup; keep lowest fk_residual on collision.
+    # Inner check via ``_q_close_wrap`` -- typed scalar loop, no per-
+    # iteration numpy allocation (#137 Slice 3).
+    deduped: list[tuple[np.ndarray, float, str, int]] = []
+    for cand_q, cand_res, ref_used, ref_iters in verified:
+        dup_idx = None
+        for j, (existing_q, _, _, _) in enumerate(deduped):
+            if _q_close_wrap(cand_q, existing_q, dedup_atol):
+                dup_idx = j
+                break
+        if dup_idx is None:
+            deduped.append((cand_q, cand_res, ref_used, ref_iters))
+        elif cand_res < deduped[dup_idx][1]:
+            deduped[dup_idx] = (cand_q, cand_res, ref_used, ref_iters)
+
+    solutions = [
+        Solution(
+            q=q,
+            fk_residual=residual,
+            refinement_used=ref_used,
+        )
+        for q, residual, ref_used, _ref_iters in deduped
+    ]
+    # No orchestrator-level respect_limits pass: the inner
+    # ``_solve_algebraic`` already filtered in-flight when
+    # respect_limits=True, so candidates here are guaranteed
+    # in-limits. The cap on max_solutions also ran inside.
+    if max_solutions is not None and len(solutions) > max_solutions:
+        solutions = solutions[:max_solutions]
+    return solutions
+
+fk = _fk
+
+__all__ = [
+    "BASE_LINK",
+    "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "T_HOME",
+    "fk",
+    "solve",
+]

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -186,6 +186,20 @@ def test_committed_artifact_matches_regeneration(module_name: str, emit_fn: obje
             'SOLVER_NAME = "seven_r.srs_polished"',
             "def fk(q):",
         ],
+        # xArm7: same class of drift as gen3 -- the xarm7 fixture's
+        # quaternion-to-rotation conversion (np.sqrt + division) produces
+        # last-bit-different float64 values on macOS Accelerate vs Linux
+        # OpenBLAS, which propagates through poe-normalisation into the
+        # baked T_HOME / T_left arrays. Functionally equivalent (FK
+        # round-trips at 1e-13 on both platforms); only the float repr
+        # differs by one trailing digit.
+        "xarm7_ik": [
+            'SOLVER_NAME = "jointlock.seven_r"',
+            'BASE_LINK = "link_base"',
+            'EE_LINK = "link7"',
+            "DOF = 7",
+            "def fk(q):",
+        ],
     }
     if module_name in _PLATFORM_DRIFT_ARTIFACTS and sys.platform != "darwin":
         for marker in _PLATFORM_DRIFT_ARTIFACTS[module_name]:

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -106,9 +106,7 @@ def _emit_iiwa14() -> str:
 def _emit_xarm7() -> str:
     from xarm7 import xarm7_specs
 
-    kb = build_kinbody(
-        xarm7_specs(), base_link_name="link_base", ee_link_name="link7"
-    )
+    kb = build_kinbody(xarm7_specs(), base_link_name="link_base", ee_link_name="link7")
     plan = dispatch(kb)
     result = emit_artifact(
         kb=kb,

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -103,6 +103,23 @@ def _emit_iiwa14() -> str:
     return result.source
 
 
+def _emit_xarm7() -> str:
+    from xarm7 import xarm7_specs
+
+    kb = build_kinbody(
+        xarm7_specs(), base_link_name="link_base", ee_link_name="link7"
+    )
+    plan = dispatch(kb)
+    result = emit_artifact(
+        kb=kb,
+        plan=plan,
+        module_name="xarm7_ik",
+        output_path=None,
+        arm_label="UFactory xArm7",
+    )
+    return result.source
+
+
 @pytest.mark.parametrize(
     ("module_name", "emit_fn"),
     [
@@ -123,6 +140,7 @@ def _emit_iiwa14() -> str:
         ("jaco2_ik", _emit_jaco2),
         ("franka_panda_ik", _emit_franka_panda),
         ("iiwa14_ik", _emit_iiwa14),
+        ("xarm7_ik", _emit_xarm7),
         (
             "gen3_ik",
             lambda: _emit_urdf(

--- a/tests/test_artifact_snapshots.py
+++ b/tests/test_artifact_snapshots.py
@@ -198,7 +198,7 @@ def test_committed_artifact_matches_regeneration(module_name: str, emit_fn: obje
             'BASE_LINK = "link_base"',
             'EE_LINK = "link7"',
             "DOF = 7",
-            "def fk(q):",
+            "def solve(",
         ],
     }
     if module_name in _PLATFORM_DRIFT_ARTIFACTS and sys.platform != "darwin":

--- a/tests/test_prebuilt_uniform_fuzz.py
+++ b/tests/test_prebuilt_uniform_fuzz.py
@@ -79,6 +79,7 @@ PREBUILT_ARMS_7R: list[tuple[str, float]] = [
     ("franka_panda_ik", 1e-4),
     ("rizon4_ik", 1e-4),
     ("kassow_kr810_ik", 1e-4),
+    ("xarm7_ik", 1e-4),
 ]
 
 


### PR DESCRIPTION
## Summary

Wires the existing [xArm7 fixture](https://github.com/personalrobotics/ssik/blob/main/tests/fixtures/xarm7.py) (added in earlier work for #159's precision-floor investigation) into the prebuilt regen pipeline.

Build profile:
\`\`\`
src/ssik/prebuilt/xarm7_ik.py: jointlock.seven_r (tier 1, 21.7 KB, 0.0s)
\`\`\`

xArm7 is a verified Pieper-class wedge: jointlock auto-picks lock_idx, reverses the resulting 6R sub-chain, and dispatches to \`reversed:spherical\` (15/16 lock samples) / \`reversed:spherical_two_parallel\` (1/16). No HP/RR symbolic path needed — fast 7R IK at ~30-45 ms exhaustive, ~3 ms with \`max_solutions=1\`.

Smoke test: 50 random non-singular poses; 50/50 had IK; worst FK residual 1.22e-13. Snapshot test + 500-pose Hypothesis uniform fuzz both pass cleanly on this branch.

### Link-name handling

The artifact's \`BASE_LINK = "link_base"\` and \`EE_LINK = "link7"\` match the mujoco_menagerie xArm7 MJCF body names (and \`xarm_ros2\` URDF link names). Passes \`base_link_name=\` / \`ee_link_name=\` kwargs to \`build_kinbody\` to preserve source naming. The other spec-built fixtures (iiwa14, franka_panda, jaco2) still use the generic defaults — separate cleanup.

### Docs touched

- README prebuilt table: new row for xArm7
- docs/quickstart.md prebuilt table: same row
- docs/arm_coverage.md: replaced "artifact pending" row with shipped row
- Prebuilt count bumped 8 → 9 across README + docs + CITATION.cff abstract + outreach drafts

### Pre-existing flake (unrelated)

Pre-existing Kassow KR810 Hypothesis flake at \`q_star=[0, 1, 2.5, 0.5, 1, 1, 0]\` (cached-RR HP returns no IK on this specific non-singular pose) reproduces on main — verified by checking out main and running the same test. Filing a follow-up issue; not a blocker for xArm7.

## Test plan

- [x] Local: \`uv run python scripts/regen_artifacts.py\` succeeds
- [x] Local: smoke + 500-pose Hypothesis fuzz pass on xArm7
- [ ] CI green
- [ ] Snapshot test passes (matches committed artifact byte-for-byte)