### PR TITLE
Bench: report sols range (min-max) in EAIK comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,18 +262,18 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 4 sols | 556 ± 12 µs / FK 2e-9 / 4 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 1 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 2 sols |
-| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.13 ± 0.04 ms / FK 2e-9 / 2 sols |
-| iiwa14 (SRS 7R) | **refuses** (no 7R DH path in bench harness) | 4.99 ± 0.03 ms / FK 3e-13 / 96 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.83 ± 1.15 ms / FK 1e-12 / 47 sols |
-| Franka Panda (anthropomorphic 7R) | **refuses** (no 7R DH path in bench harness) | 29.34 ± 2.59 ms / FK 8e-12 / 8 sols |
-| xArm7 (**non-SRS 7R**) | **refuses** (no 7R DH path in bench harness) | 35.41 ± 1.11 ms / FK 1e-11 / 20 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.88 ± 8.80 ms / FK 4e-9 / 35 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 28.06 ± 10.63 ms / FK 7e-8 / 24 sols |
+| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 2-8 sols | 551 ± 12 µs / FK 2e-9 / 2-8 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 0 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 1-4 sols |
+| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.16 ± 0.02 ms / FK 2e-9 / 1-5 sols |
+| iiwa14 (SRS 7R) | **refuses** (no 7R DH path in bench harness) | 5.00 ± 0.04 ms / FK 4e-13 / 48-110 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 40.92 ± 1.02 ms / FK 1e-12 / 10-95 sols |
+| Franka Panda (anthropomorphic 7R) | **refuses** (no 7R DH path in bench harness) | 27.19 ± 2.54 ms / FK 7e-13 / 1-30 sols |
+| xArm7 (**non-SRS 7R**) | **refuses** (no 7R DH path in bench harness) | 35.10 ± 0.46 ms / FK 4e-11 / 12-22 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 31.88 ± 8.92 ms / FK 4e-9 / 9-59 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 29.83 ± 11.35 ms / FK 7e-8 / 10-38 sols |
 
-EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
+The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 2-4 branches per sample = 48-110 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
 
 ## Under the hood
 

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -10,7 +10,7 @@ Closed-form IK via subproblem decomposition (SP1–SP6).
 
 | Arm | Solver | Speed | Status |
 |-----|--------|:-----:|:-----:|
-| **UR5** (also UR3 / UR10 / UR16) | `ikgeo.three_parallel` | 556 ± 12 µs / 4 sols | ✅ `ssik.prebuilt.ur5_ik` (UR5 in tests/fixtures); others 🔗 |
+| **UR5** (also UR3 / UR10 / UR16) | `ikgeo.three_parallel` | 551 ± 12 µs / 2-8 sols | ✅ `ssik.prebuilt.ur5_ik` (UR5 in tests/fixtures); others 🔗 |
 | **Puma 560** | `ikgeo.spherical_two_parallel` | 245 ± 3 µs / 8 sols | ✅ `ssik.prebuilt.puma560_ik` |
 | ABB IRB120 / IRB4600 | `ikgeo.spherical_two_parallel` | expected ~1 ms | 🔗 [ros-industrial/abb](https://github.com/ros-industrial/abb) |
 | Fanuc LR Mate / CR | `ikgeo.spherical_two_parallel` | expected ~1 ms | 🔗 (vendor URDF) |
@@ -25,8 +25,8 @@ The arms ssik exists for: deliberate non-orthogonal twists that violate Pieper's
 
 | Arm | Solver | Speed | Status |
 |-----|--------|:-----:|:-----:|
-| **Kinova JACO 2 (j2n6s200, 55° DH)** | `ikgeo.general_6r` (RR + AE-3) | 1.02 ± 0.04 ms / 2 sols | ✅ `ssik.prebuilt.jaco2_ik` |
-| **UFactory xArm6** (joint-6 y-offset breaks spherical wrist) | `ikgeo.general_6r` (RR + AE-3) | 1.13 ± 0.04 ms / 2 sols | ✅ `ssik.prebuilt.xarm6_ik` |
+| **Kinova JACO 2 (j2n6s200, 55° DH)** | `ikgeo.general_6r` (RR + AE-3) | 1.02 ± 0.04 ms / 1-4 sols | ✅ `ssik.prebuilt.jaco2_ik` |
+| **UFactory xArm6** (joint-6 y-offset breaks spherical wrist) | `ikgeo.general_6r` (RR + AE-3) | 1.16 ± 0.02 ms / 1-5 sols | ✅ `ssik.prebuilt.xarm6_ik` |
 | Agilex Piper | `ikgeo.general_6r` | expected ~1-5 ms | 🔗 [mujoco_menagerie/agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper) |
 | Custom non-Pieper 6R | `ikgeo.general_6r` | expected ~1-5 ms | use `ssik build` to compile a per-arm artifact |
 
@@ -36,7 +36,7 @@ Closed-form Singh-Kreutz 1989 algorithm. Predicate-driven dispatch via `is_srs_7
 
 | Arm | Speed | Status |
 |-----|:-----:|:-----:|
-| **KUKA iiwa LBR 14** | 5.10 ± 0.07 ms / 96 sols / FK 4e-13 | ✅ `ssik.prebuilt.iiwa14_ik` |
+| **KUKA iiwa LBR 14** | 5.00 ± 0.04 ms / 48-110 sols / FK 4e-13 | ✅ `ssik.prebuilt.iiwa14_ik` |
 | KUKA iiwa LBR 7 (R820 / R14) | expected ~5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
 
 ## 7R redundant — approximately-SRS with LM polish (`seven_r.srs_polished`)
@@ -45,7 +45,7 @@ For arms whose URDF axes only **nearly** meet at common shoulder/wrist points (K
 
 | Arm | Drift (shoulder / wrist) | Speed | Status |
 |-----|---|:-----:|:-----:|
-| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | 41.83 ± 1.15 ms / 47 sols / FK 1e-12 | ✅ `ssik.prebuilt.gen3_ik` |
+| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | 40.92 ± 1.02 ms / 10-95 sols / FK 1e-12 | ✅ `ssik.prebuilt.gen3_ik` |
 
 ## 7R redundant — non-SRS (`jointlock.seven_r`)
 
@@ -55,10 +55,10 @@ For non-Pieper inner sub-chains (Rizon 4, Kassow KR810), `ssik build` bakes the 
 
 | Arm | Drift (shoulder / wrist) | Inner | Speed (full sweep) | Status |
 |-----|---|---|:-----:|:-----:|
-| **Franka Emika Panda** | non-SRS by design | tier-0 inner (`reversed:spherical_two_parallel`) | 28.03 ± 2.57 ms / 9 sols / FK 7e-13 | ✅ `ssik.prebuilt.franka_panda_ik` |
-| **uFactory xArm7** | non-SRS by design | tier-0 inner (`reversed:spherical`) | expected ~30-45 ms | ✅ `ssik.prebuilt.xarm7_ik` |
-| **Flexiv Rizon 4** | 65 mm / 151 mm | cached-RR (HP otherwise) | 30.88 ± 8.80 ms / 35 sols / FK 4e-9 | ✅ `ssik.prebuilt.rizon4_ik` |
-| **Kassow KR810** | 86 mm / 111 mm | cached-RR (HP otherwise) | 28.06 ± 10.63 ms / 24 sols / FK 7e-8 | ✅ `ssik.prebuilt.kassow_kr810_ik` |
+| **Franka Emika Panda** | non-SRS by design | tier-0 inner (`reversed:spherical_two_parallel`) | 27.19 ± 2.54 ms / 1-30 sols / FK 7e-13 | ✅ `ssik.prebuilt.franka_panda_ik` |
+| **uFactory xArm7** | non-SRS by design | tier-0 inner (`reversed:spherical`) | 35.10 ± 0.46 ms / 12-22 sols / FK 4e-11 | ✅ `ssik.prebuilt.xarm7_ik` |
+| **Flexiv Rizon 4** | 65 mm / 151 mm | cached-RR (HP otherwise) | 31.88 ± 8.92 ms / 9-59 sols / FK 4e-9 | ✅ `ssik.prebuilt.rizon4_ik` |
+| **Kassow KR810** | 86 mm / 111 mm | cached-RR (HP otherwise) | 29.83 ± 11.35 ms / 10-38 sols / FK 7e-8 | ✅ `ssik.prebuilt.kassow_kr810_ik` |
 | Sawyer / Baxter (Rethink) | likely non-SRS | TBD | expected ~30-50 ms | 🔗 |
 
 > **Mean vs median:** both 30 ms and ~17 ms are honest measurements of the same prebuilt — the canonical bench reports mean ± 95% CI, an earlier per-pose measurement reported median. Verified 2026-05-13 on Rizon 4 with the canonical pose distribution: mean 28.7 ms / **median 19 ms** / p95 62 ms / min 16.4 ms. The cached-RR fast path is firing on most poses; mean is dragged up by occasional near-singular configurations where the lock-sweep can't short-circuit.

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -85,6 +85,7 @@ FIXTURES = [
         "kassow_kr810_ik",
     ),
     Fixture("xArm7", 7, "specs", ("xarm7", "xarm7_specs"), "xarm7_ik"),
+    Fixture("xArm6", 6, "urdf", ("xarm6.urdf", "link_base", "link_eef"), "xarm6_ik"),
 ]
 
 
@@ -199,6 +200,8 @@ def _bench_ssik(arm, poses: list[np.ndarray]) -> dict:
         "ci95_ms": half,
         "max_fk": float(max(fk_residuals)) if fk_residuals else float("nan"),
         "median_sols": int(np.median(sol_counts)) if sol_counts else 0,
+        "min_sols": int(min(sol_counts)) if sol_counts else 0,
+        "max_sols": int(max(sol_counts)) if sol_counts else 0,
         "n_solved": len(sol_counts),
         "n_total": len(poses),
     }
@@ -279,6 +282,8 @@ def _bench_eaik(fx: Fixture, poses: list[np.ndarray]) -> dict:
         "ci95_ms": half,
         "max_fk": float(max(fk_residuals)) if fk_residuals else float("nan"),
         "median_sols": int(np.median(sol_counts)) if sol_counts else 0,
+        "min_sols": int(min(sol_counts)) if sol_counts else 0,
+        "max_sols": int(max(sol_counts)) if sol_counts else 0,
         "n_solved": len(sol_counts),
         "n_total": len(poses),
     }
@@ -311,8 +316,11 @@ def _cell_fk(r: dict) -> str:
 def _cell_sols(r: dict) -> str:
     if not r.get("supported"):
         return "—"
-    n = r.get("median_sols", 0)
-    return f"{n}" if n else "—"
+    lo = r.get("min_sols", 0)
+    hi = r.get("max_sols", 0)
+    if hi == 0:
+        return "—"
+    return f"{lo}-{hi}" if hi > lo else f"{lo}"
 
 
 def _format_row(fx: Fixture, ssik_r: dict, eaik_r: dict) -> str:


### PR DESCRIPTION
## Summary

The \"sols\" column in the EAIK comparison table was a single median number, which hid wide pose-to-pose variability. JACO 2 cell said \"2 sols\" but the actual range across the 100-pose bench is **1-4**. xArm6 said \"2\" — actual range **1-5**. iiwa14 said \"96\" — actual range **48-110** because the discretised-redundancy sweep produces different branch counts per pose.

## Changes

- \`examples/04_compare_vs_eaik.py\`:
  - \`_bench_ssik\` / \`_bench_eaik\` record \`min_sols\` + \`max_sols\` alongside \`median_sols\`.
  - \`_cell_sols\` renders as \`\"min-max\"\` (e.g. \`\"1-4\"\`) when range > 1, or just \`\"N\"\` when constant (Puma 8/8).
  - Added xArm6 to \`FIXTURES\` (was missing — \`main\` only had xArm7).
- README EAIK comparison table: regenerated from the new bench output. Added a footnote explaining what the range means (spurious-root falloff for non-Pieper 6R; discretised-redundancy sweep for 7R).
- \`docs/arm_coverage.md\`: refreshed all sols cells with new ranges. Filled in xArm7's row with real bench numbers — previously said \"expected ~30-45 ms\".

## New table (excerpt)

| Arm | ssik (sols) | What the range means |
|---|---|---|
| Puma 560 | 8 (constant) | Pieper-class: every reachable pose has 4 shoulder × 2 elbow = 8 branches |
| JACO 2 | 1-4 | Non-Pieper: degree-8 univariate's spurious-root count varies with pose |
| iiwa14 | 48-110 | 7R: 16-sample swivel × {2-8} branches per sample |

## Test plan

- [x] Local: bench harness runs against all 10 prebuilts
- [x] Local: ssik tests unchanged (no test code touched)
- [ ] CI green