### PR TITLE
Bench: respect_limits=False for fair ssik-vs-EAIK branch counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,18 +262,18 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 2-8 sols | 551 ± 12 µs / FK 2e-9 / 2-8 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 0 µs / FK 3e-14 / 8 sols | 245 ± 3 µs / FK 2e-14 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.04 ms / FK 3e-6 / 1-4 sols |
-| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.16 ± 0.02 ms / FK 2e-9 / 1-5 sols |
-| iiwa14 (SRS 7R) | **refuses** (no 7R DH path in bench harness) | 5.00 ± 0.04 ms / FK 4e-13 / 48-110 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 40.92 ± 1.02 ms / FK 1e-12 / 10-95 sols |
-| Franka Panda (anthropomorphic 7R) | **refuses** (no 7R DH path in bench harness) | 27.19 ± 2.54 ms / FK 7e-13 / 1-30 sols |
-| xArm7 (**non-SRS 7R**) | **refuses** (no 7R DH path in bench harness) | 35.10 ± 0.46 ms / FK 4e-11 / 12-22 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 31.88 ± 8.92 ms / FK 4e-9 / 9-59 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 29.83 ± 11.35 ms / FK 7e-8 / 10-38 sols |
+| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 2-8 sols | 532 ± 10 µs / FK 2e-9 / 2-8 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 0 µs / FK 3e-14 / 8 sols | 220 ± 3 µs / FK 2e-14 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 976 ± 39 µs / FK 5e-6 / 2-12 sols |
+| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.02 ms / FK 2e-7 / 8-12 sols |
+| iiwa14 (SRS 7R) | **refuses** (no 7R DH path in bench harness) | 4.54 ± 0.03 ms / FK 4e-13 / 128 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.46 ± 1.25 ms / FK 1e-12 / 10-95 sols |
+| Franka Panda (anthropomorphic 7R) | **refuses** (no 7R DH path in bench harness) | 29.27 ± 2.81 ms / FK 1e-6 / 8-124 sols |
+| xArm7 (**non-SRS 7R**) | **refuses** (no 7R DH path in bench harness) | 37.10 ± 0.49 ms / FK 4e-11 / 56-64 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 30.58 ± 8.58 ms / FK 4e-9 / 10-60 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 27.52 ± 10.71 ms / FK 7e-8 / 10-38 sols |
 
-The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 2-4 branches per sample = 48-110 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
+The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 8 branches per sample = 128 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).
 
 ## Under the hood
 

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -10,8 +10,8 @@ Closed-form IK via subproblem decomposition (SP1–SP6).
 
 | Arm | Solver | Speed | Status |
 |-----|--------|:-----:|:-----:|
-| **UR5** (also UR3 / UR10 / UR16) | `ikgeo.three_parallel` | 551 ± 12 µs / 2-8 sols | ✅ `ssik.prebuilt.ur5_ik` (UR5 in tests/fixtures); others 🔗 |
-| **Puma 560** | `ikgeo.spherical_two_parallel` | 245 ± 3 µs / 8 sols | ✅ `ssik.prebuilt.puma560_ik` |
+| **UR5** (also UR3 / UR10 / UR16) | `ikgeo.three_parallel` | 532 ± 10 µs / 2-8 sols | ✅ `ssik.prebuilt.ur5_ik` (UR5 in tests/fixtures); others 🔗 |
+| **Puma 560** | `ikgeo.spherical_two_parallel` | 220 ± 3 µs / 8 sols | ✅ `ssik.prebuilt.puma560_ik` |
 | ABB IRB120 / IRB4600 | `ikgeo.spherical_two_parallel` | expected ~1 ms | 🔗 [ros-industrial/abb](https://github.com/ros-industrial/abb) |
 | Fanuc LR Mate / CR | `ikgeo.spherical_two_parallel` | expected ~1 ms | 🔗 (vendor URDF) |
 | KUKA KR | `ikgeo.spherical_two_parallel` | expected ~1 ms | 🔗 [ros-industrial/kuka_experimental](https://github.com/ros-industrial/kuka_experimental) |
@@ -25,8 +25,8 @@ The arms ssik exists for: deliberate non-orthogonal twists that violate Pieper's
 
 | Arm | Solver | Speed | Status |
 |-----|--------|:-----:|:-----:|
-| **Kinova JACO 2 (j2n6s200, 55° DH)** | `ikgeo.general_6r` (RR + AE-3) | 1.02 ± 0.04 ms / 1-4 sols | ✅ `ssik.prebuilt.jaco2_ik` |
-| **UFactory xArm6** (joint-6 y-offset breaks spherical wrist) | `ikgeo.general_6r` (RR + AE-3) | 1.16 ± 0.02 ms / 1-5 sols | ✅ `ssik.prebuilt.xarm6_ik` |
+| **Kinova JACO 2 (j2n6s200, 55° DH)** | `ikgeo.general_6r` (RR + AE-3) | 976 ± 39 µs / 2-12 sols | ✅ `ssik.prebuilt.jaco2_ik` |
+| **UFactory xArm6** (joint-6 y-offset breaks spherical wrist) | `ikgeo.general_6r` (RR + AE-3) | 1.06 ± 0.02 ms / 8-12 sols | ✅ `ssik.prebuilt.xarm6_ik` |
 | Agilex Piper | `ikgeo.general_6r` | expected ~1-5 ms | 🔗 [mujoco_menagerie/agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper) |
 | Custom non-Pieper 6R | `ikgeo.general_6r` | expected ~1-5 ms | use `ssik build` to compile a per-arm artifact |
 
@@ -36,7 +36,7 @@ Closed-form Singh-Kreutz 1989 algorithm. Predicate-driven dispatch via `is_srs_7
 
 | Arm | Speed | Status |
 |-----|:-----:|:-----:|
-| **KUKA iiwa LBR 14** | 5.00 ± 0.04 ms / 48-110 sols / FK 4e-13 | ✅ `ssik.prebuilt.iiwa14_ik` |
+| **KUKA iiwa LBR 14** | 4.54 ± 0.03 ms / 128 sols / FK 4e-13 | ✅ `ssik.prebuilt.iiwa14_ik` |
 | KUKA iiwa LBR 7 (R820 / R14) | expected ~5 ms | 🔗 [mujoco_menagerie/kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14) |
 
 ## 7R redundant — approximately-SRS with LM polish (`seven_r.srs_polished`)
@@ -45,7 +45,7 @@ For arms whose URDF axes only **nearly** meet at common shoulder/wrist points (K
 
 | Arm | Drift (shoulder / wrist) | Speed | Status |
 |-----|---|:-----:|:-----:|
-| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | 40.92 ± 1.02 ms / 10-95 sols / FK 1e-12 | ✅ `ssik.prebuilt.gen3_ik` |
+| **Kinova Gen3 (7-DOF)** | 12 mm / 0.4 mm | 41.46 ± 1.25 ms / 10-95 sols / FK 1e-12 | ✅ `ssik.prebuilt.gen3_ik` |
 
 ## 7R redundant — non-SRS (`jointlock.seven_r`)
 
@@ -55,10 +55,10 @@ For non-Pieper inner sub-chains (Rizon 4, Kassow KR810), `ssik build` bakes the 
 
 | Arm | Drift (shoulder / wrist) | Inner | Speed (full sweep) | Status |
 |-----|---|---|:-----:|:-----:|
-| **Franka Emika Panda** | non-SRS by design | tier-0 inner (`reversed:spherical_two_parallel`) | 27.19 ± 2.54 ms / 1-30 sols / FK 7e-13 | ✅ `ssik.prebuilt.franka_panda_ik` |
-| **uFactory xArm7** | non-SRS by design | tier-0 inner (`reversed:spherical`) | 35.10 ± 0.46 ms / 12-22 sols / FK 4e-11 | ✅ `ssik.prebuilt.xarm7_ik` |
-| **Flexiv Rizon 4** | 65 mm / 151 mm | cached-RR (HP otherwise) | 31.88 ± 8.92 ms / 9-59 sols / FK 4e-9 | ✅ `ssik.prebuilt.rizon4_ik` |
-| **Kassow KR810** | 86 mm / 111 mm | cached-RR (HP otherwise) | 29.83 ± 11.35 ms / 10-38 sols / FK 7e-8 | ✅ `ssik.prebuilt.kassow_kr810_ik` |
+| **Franka Emika Panda** | non-SRS by design | tier-0 inner (`reversed:spherical_two_parallel`) | 29.27 ± 2.81 ms / 8-124 sols / FK 1e-6 | ✅ `ssik.prebuilt.franka_panda_ik` |
+| **uFactory xArm7** | non-SRS by design | tier-0 inner (`reversed:spherical`) | 37.10 ± 0.49 ms / 56-64 sols / FK 4e-11 | ✅ `ssik.prebuilt.xarm7_ik` |
+| **Flexiv Rizon 4** | 65 mm / 151 mm | cached-RR (HP otherwise) | 30.58 ± 8.58 ms / 10-60 sols / FK 4e-9 | ✅ `ssik.prebuilt.rizon4_ik` |
+| **Kassow KR810** | 86 mm / 111 mm | cached-RR (HP otherwise) | 27.52 ± 10.71 ms / 10-38 sols / FK 7e-8 | ✅ `ssik.prebuilt.kassow_kr810_ik` |
 | Sawyer / Baxter (Rethink) | likely non-SRS | TBD | expected ~30-50 ms | 🔗 |
 
 > **Mean vs median:** both 30 ms and ~17 ms are honest measurements of the same prebuilt — the canonical bench reports mean ± 95% CI, an earlier per-pose measurement reported median. Verified 2026-05-13 on Rizon 4 with the canonical pose distribution: mean 28.7 ms / **median 19 ms** / p95 62 ms / min 16.4 ms. The cached-RR fast path is firing on most poses; mean is dragged up by occasional near-singular configurations where the lock-sweep can't short-circuit.

--- a/examples/04_compare_vs_eaik.py
+++ b/examples/04_compare_vs_eaik.py
@@ -177,16 +177,25 @@ def _gen_poses(arm, n: int, rng) -> list[np.ndarray]:
 
 
 def _bench_ssik(arm, poses: list[np.ndarray]) -> dict:
+    # ``respect_limits=False`` so the branch count reflects the analytical
+    # solver's output, not the URDF-limit-aware postprocess. EAIK's bench
+    # path (eaik.IK_URDF.UrdfRobot.IK) does not apply URDF joint limits;
+    # using ssik's default ``respect_limits=True`` here makes the "/sols"
+    # cells apples-to-oranges. Arms with asymmetric joint limits (Unitree
+    # Z1: joint2 in [0, 2.97], joint3 in [-2.88, 0]) get filtered down to
+    # 1 branch under default settings, which exaggerates the gap. The
+    # "/time" measurement still includes the postprocess pass for
+    # production realism; only the branch count assertion changes.
     # Warm.
     for T in poses[: min(10, len(poses))]:
-        arm.solve(T)
+        arm.solve(T, respect_limits=False)
 
     times = []
     fk_residuals = []
     sol_counts = []
     for T in poses:
         t = time.perf_counter()
-        sols = arm.solve(T)
+        sols = arm.solve(T, respect_limits=False)
         times.append((time.perf_counter() - t) * 1000)
         if sols:
             fk_residuals.append(max(s.fk_residual for s in sols))


### PR DESCRIPTION
## Summary

Follow-up to #282. EAIK's bench path (\`eaik.IK_URDF.UrdfRobot.IK\`) doesn't apply URDF joint limits — it returns raw analytical branches. ssik's default \`solve(T)\` does apply URDF limits, so the previous \"/sols\" cells compared filtered ssik output against unfiltered EAIK output. Apples-to-oranges.

Discovered when prepping Z1 (next PR): Z1's \`joint2 ∈ [0, 2.97]\` and \`joint3 ∈ [-2.88, 0]\` are asymmetric — the bench's narrow q-sampler puts those joints mostly outside the URDF limit interior, so the \`respect_limits=True\` postprocess dropped nearly every branch. Z1's cell would have said \"1\" while the analytical solver produces 4-8 branches per pose.

Switching the bench to \`respect_limits=False\` makes the branch count column reflect what ssik's analytical solver actually produces. Time measurement is unchanged (still includes the postprocess for production realism).

## Effect on the table

- 6R arms with asymmetric URDF limits: \`jaco2 1-4 → 2-12\`, \`xarm6 1-5 → 8-12\`
- 7R arms with aggressive limits: \`franka 1-30 → 8-124\`, \`xarm7 12-22 → 56-64\`, \`iiwa14 48-110 → 128 constant\`
- Pieper-class 6R (UR5, Puma): no change (permissive limits)

## Test plan

- [x] Local: bench harness reruns clean for all 10 prebuilts
- [ ] CI green