### PR TITLE
PR 1/6 (#290): Add MANIFEST.toml + loader for prebuilt arms

### DIFF
--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -1,0 +1,428 @@
+# MANIFEST.toml — single source of truth for prebuilt arm metadata.
+#
+# Every arm shipped under ``ssik.prebuilt.*`` has an entry here. Doc
+# tables (README, docs/, outreach/, CITATION.cff), test parametrisations
+# (test_prebuilt_uniform_fuzz.py, test_prebuilt_sanity.py,
+# test_artifact_snapshots.py), bench fixtures
+# (examples/04_compare_vs_eaik.py), and the build orchestration
+# (scripts/regen_artifacts.py) all read from this file.
+#
+# Adding a new arm: prefer ``ssik add-arm <urdf> --name ... --base ... --ee ...``
+# (it benches + populates this entry + regenerates docs end-to-end).
+#
+# Editing an existing arm: bump the relevant fields here, then run
+# ``scripts/regen_docs.py`` to propagate. CI's drift-gate will fail any
+# PR whose manifest edits and doc tables are out of sync.
+#
+# Schema reference:
+#   display_name        Human-readable manufacturer + model
+#   short_name          Compact-prose form (table cells, abstract lists)
+#   fixture             Path under tests/fixtures/ (urdf file or .py module name)
+#   fixture_kind        "urdf" | "specs"
+#   specs_fn            Function name in tests/fixtures/<fixture>.py (specs kind only)
+#   base_link           Chain base link name (also baked into the artifact's BASE_LINK)
+#   ee_link             Chain end-effector link name (also baked into EE_LINK)
+#   dof                 6 | 7
+#   solver              ssik.solvers.* module path (matches artifact's SOLVER_NAME)
+#   tier                0 | 1 | 2
+#   kinematic_class     User-facing class string in README's prebuilt table
+#   short_class         Compact form for the README EAIK comparison table
+#   class_tags          Drives class-exemplar lists in commentary
+#   slow_build          true = gated behind ``regen_artifacts.py --include-slow``
+#   build_time_sec      Approximate per-regen wall-clock build time (informational)
+#   artifact_size_kb    Approximate emitted file size (informational)
+#   sample_q            6/7-element list; used by test_prebuilt_sanity.py round-trip
+#   fk_ceiling_fuzz     test_prebuilt_uniform_fuzz.py per-arm max FK assertion
+#   platform_drift      true = artifact bytes differ across platforms; structural
+#                              smoke check instead of byte-equality on non-macOS
+#   drift_markers       Required substrings in the artifact (platform_drift = true only)
+#   [bench]             Latest measurements from examples/04_compare_vs_eaik.py
+#   [known_gaps]        Optional xfail entries for the uniform fuzz test
+
+[arms.ur5_ik]
+display_name = "Universal Robots UR5"
+short_name = "UR5"
+fixture = "ur5.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "ee_link"
+dof = 6
+solver = "ikgeo.three_parallel"
+tier = 0
+kinematic_class = "three-parallel 6R"
+short_class = "Pieper 6R, three-parallel"
+class_tags = ["three-parallel", "6R", "Pieper"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 26
+sample_q = [0.3, -0.5, 0.7, 0.2, 0.4, -0.1]
+fk_ceiling_fuzz = 1e-7
+platform_drift = false
+
+[arms.ur5_ik.bench]
+ms_mean = 0.532
+ms_ci95 = 0.010
+max_fk = 2.0e-9
+sols_min = 2
+sols_max = 8
+
+[arms.puma560_ik]
+display_name = "KUKA Puma 560"
+short_name = "Puma 560"
+fixture = "puma560.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "wrist_3_link"
+dof = 6
+solver = "ikgeo.spherical_two_parallel"
+tier = 0
+kinematic_class = "Pieper 6R (spherical wrist)"
+short_class = "Pieper 6R, spherical wrist"
+class_tags = ["spherical-wrist", "6R", "Pieper"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 27
+sample_q = [0.4, -0.6, 0.8, 1.0, -0.4, 0.3]
+fk_ceiling_fuzz = 1e-12
+platform_drift = false
+
+[arms.puma560_ik.bench]
+ms_mean = 0.220
+ms_ci95 = 0.003
+max_fk = 2.0e-14
+sols_min = 8
+sols_max = 8
+
+[arms.jaco2_ik]
+display_name = "Kinova JACO 2 (j2n6s200)"
+short_name = "JACO 2"
+fixture = "jaco2"
+fixture_kind = "specs"
+specs_fn = "jaco2_specs"
+base_link = "base_link"
+ee_link = "ee_link"
+dof = 6
+solver = "ikgeo.general_6r"
+tier = 2
+kinematic_class = "non-Pieper 6R"
+short_class = "non-Pieper 6R"
+class_tags = ["non-Pieper", "6R"]
+slow_build = false
+build_time_sec = 25
+artifact_size_kb = 73
+sample_q = [0.5, -0.8, 0.9, 1.1, -0.5, 0.4]
+fk_ceiling_fuzz = 1e-4
+platform_drift = true
+drift_markers = [
+    "_solve_algebraic",
+    "_build_pq_matrices",
+    'SOLVER_NAME = "ikgeo.general_6r"',
+]
+
+[arms.jaco2_ik.bench]
+ms_mean = 0.976
+ms_ci95 = 0.039
+max_fk = 5.0e-6
+sols_min = 2
+sols_max = 12
+
+[arms.iiwa14_ik]
+display_name = "KUKA iiwa LBR 14"
+short_name = "iiwa14"
+fixture = "kuka_iiwa14"
+fixture_kind = "specs"
+specs_fn = "kuka_iiwa14_specs"
+base_link = "base_link"
+ee_link = "ee_link"
+dof = 7
+solver = "seven_r.srs"
+tier = 0
+kinematic_class = "SRS 7R"
+short_class = "SRS 7R"
+class_tags = ["SRS", "7R"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 9
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-10
+platform_drift = false
+
+[arms.iiwa14_ik.bench]
+ms_mean = 4.54
+ms_ci95 = 0.03
+max_fk = 4.0e-13
+sols_min = 128
+sols_max = 128
+
+[arms.gen3_ik]
+display_name = "Kinova Gen3 (7-DOF)"
+short_name = "Gen3"
+fixture = "gen3.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "end_effector_link"
+dof = 7
+solver = "seven_r.srs_polished"
+tier = 0
+kinematic_class = "approximate-SRS 7R"
+short_class = "approximate-SRS 7R, 12 mm offset"
+class_tags = ["approximate-SRS", "7R"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 10
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-9
+platform_drift = true
+drift_markers = [
+    "_solver_solve",
+    'SOLVER_NAME = "seven_r.srs_polished"',
+    "def fk(q):",
+]
+
+[arms.gen3_ik.bench]
+ms_mean = 41.46
+ms_ci95 = 1.25
+max_fk = 1.0e-12
+sols_min = 10
+sols_max = 95
+
+[arms.franka_panda_ik]
+display_name = "Franka Emika Panda (no hand)"
+short_name = "Franka Panda"
+fixture = "franka_panda"
+fixture_kind = "specs"
+specs_fn = "franka_panda_specs"
+base_link = "base_link"
+ee_link = "ee_link"
+dof = 7
+solver = "jointlock.seven_r"
+tier = 1
+kinematic_class = "anthropomorphic 7R"
+short_class = "anthropomorphic 7R"
+class_tags = ["non-SRS", "anthropomorphic", "7R"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 22
+sample_q = [0.2, 0.3, -0.4, -1.2, 0.3, 1.4, 0.5]
+fk_ceiling_fuzz = 1e-4
+platform_drift = false
+
+[arms.franka_panda_ik.bench]
+ms_mean = 29.27
+ms_ci95 = 2.81
+max_fk = 1.0e-6
+sols_min = 8
+sols_max = 124
+
+[arms.xarm7_ik]
+display_name = "UFactory xArm7"
+short_name = "xArm7"
+fixture = "xarm7"
+fixture_kind = "specs"
+specs_fn = "xarm7_specs"
+base_link = "link_base"
+ee_link = "link7"
+dof = 7
+solver = "jointlock.seven_r"
+tier = 1
+kinematic_class = "7R Pieper-wedge (jointlock → `reversed:spherical`)"
+short_class = "non-SRS 7R"
+class_tags = ["non-SRS", "Pieper-wedge", "7R"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 22
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-4
+platform_drift = true
+drift_markers = [
+    'SOLVER_NAME = "jointlock.seven_r"',
+    'BASE_LINK = "link_base"',
+    'EE_LINK = "link7"',
+    "DOF = 7",
+    "def solve(",
+]
+
+[arms.xarm7_ik.bench]
+ms_mean = 37.10
+ms_ci95 = 0.49
+max_fk = 4.0e-11
+sols_min = 56
+sols_max = 64
+
+[arms.xarm6_ik]
+display_name = "UFactory xArm6"
+short_name = "xArm6"
+fixture = "xarm6.urdf"
+fixture_kind = "urdf"
+base_link = "link_base"
+ee_link = "link_eef"
+dof = 6
+solver = "ikgeo.general_6r"
+tier = 2
+kinematic_class = "non-Pieper 6R (joint 6 y-offset)"
+short_class = "non-Pieper 6R"
+class_tags = ["non-Pieper", "6R"]
+slow_build = false
+build_time_sec = 15
+artifact_size_kb = 70
+sample_q = [0.3, 1.0, -0.8, 0.2, 0.4, -0.1]
+fk_ceiling_fuzz = 1e-4
+platform_drift = true
+drift_markers = [
+    "_solve_algebraic",
+    "_build_pq_matrices",
+    'SOLVER_NAME = "ikgeo.general_6r"',
+]
+
+[arms.xarm6_ik.bench]
+ms_mean = 1.06
+ms_ci95 = 0.02
+max_fk = 2.0e-7
+sols_min = 8
+sols_max = 12
+
+[arms.z1_ik]
+display_name = "Unitree Z1"
+short_name = "Z1"
+fixture = "z1.urdf"
+fixture_kind = "urdf"
+base_link = "link00"
+ee_link = "link06"
+dof = 6
+solver = "ikgeo.three_parallel"
+tier = 0
+kinematic_class = "three-parallel 6R (UR-class)"
+short_class = "Pieper 6R, three-parallel"
+class_tags = ["three-parallel", "6R", "Pieper"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 23
+sample_q = [0.3, 0.8, -0.5, 0.2, 0.4, -0.1]
+fk_ceiling_fuzz = 1e-7
+platform_drift = false
+
+[arms.z1_ik.bench]
+ms_mean = 0.487
+ms_ci95 = 0.007
+max_fk = 3.0e-15
+sols_min = 4
+sols_max = 8
+
+[arms.z1_ik.known_gaps]
+xfail_reason = "three_parallel SP6 conditioning gap at q[4]=π/2 (Z1-specific; UR5 OK on same fuzz). Filed as #288."
+
+[arms.piper_ik]
+display_name = "AgileX PiPER"
+short_name = "PiPER"
+fixture = "piper.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "link6"
+dof = 6
+solver = "ikgeo.general_6r"
+tier = 2
+kinematic_class = "non-Pieper 6R (joints 4 & 6 tilted axis)"
+short_class = "non-Pieper 6R"
+class_tags = ["non-Pieper", "6R"]
+slow_build = false
+build_time_sec = 25
+artifact_size_kb = 88
+sample_q = [0.3, 0.7, -0.5, 0.2, 0.4, -0.1]
+fk_ceiling_fuzz = 1e-4
+platform_drift = true
+drift_markers = [
+    "_solve_algebraic",
+    "_build_pq_matrices",
+    'SOLVER_NAME = "ikgeo.general_6r"',
+]
+
+[arms.piper_ik.bench]
+ms_mean = 1.17
+ms_ci95 = 0.03
+max_fk = 9.0e-6
+sols_min = 1
+sols_max = 8
+
+[arms.piper_ik.known_gaps]
+xfail_reason = "RR coverage gap on q*=[0, 2.75, 0.29, 2.5, 2.75, 0] (returns 0 sols; q* + 0.01 returns 4). Filed as #286."
+
+[arms.rizon4_ik]
+display_name = "Flexiv Rizon 4"
+short_name = "Rizon 4"
+fixture = "rizon4.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "flange"
+dof = 7
+solver = "jointlock.seven_r"
+tier = 1
+kinematic_class = "non-SRS 7R"
+short_class = "non-SRS 7R"
+class_tags = ["non-SRS", "7R"]
+slow_build = true
+build_time_sec = 420
+artifact_size_kb = 270
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-4
+platform_drift = false
+
+[arms.rizon4_ik.bench]
+ms_mean = 30.58
+ms_ci95 = 8.58
+max_fk = 4.0e-9
+sols_min = 10
+sols_max = 60
+
+[arms.kassow_kr810_ik]
+display_name = "Kassow KR810"
+short_name = "Kassow KR810"
+fixture = "kassow_kr810.urdf"
+fixture_kind = "urdf"
+base_link = "base"
+ee_link = "end_effector"
+dof = 7
+solver = "jointlock.seven_r"
+tier = 1
+kinematic_class = "non-SRS 7R"
+short_class = "non-SRS 7R"
+class_tags = ["non-SRS", "7R"]
+slow_build = true
+build_time_sec = 1200
+artifact_size_kb = 530
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-4
+platform_drift = false
+
+[arms.kassow_kr810_ik.bench]
+ms_mean = 27.52
+ms_ci95 = 10.71
+max_fk = 7.0e-8
+sols_min = 10
+sols_max = 38
+
+[arms.rizon10_ik]
+display_name = "Flexiv Rizon 10"
+short_name = "Rizon 10"
+fixture = "rizon10.urdf"
+fixture_kind = "urdf"
+base_link = "base_link"
+ee_link = "flange"
+dof = 7
+solver = "jointlock.seven_r"
+tier = 1
+kinematic_class = "non-SRS 7R (~1.4 m reach)"
+short_class = "non-SRS 7R"
+class_tags = ["non-SRS", "7R"]
+slow_build = true
+build_time_sec = 420
+artifact_size_kb = 331
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-4
+platform_drift = false
+
+[arms.rizon10_ik.bench]
+ms_mean = 29.43
+ms_ci95 = 6.37
+max_fk = 6.1e-8
+sols_min = 10
+sols_max = 64

--- a/src/ssik/prebuilt/_manifest.py
+++ b/src/ssik/prebuilt/_manifest.py
@@ -1,0 +1,159 @@
+"""Loader for ``MANIFEST.toml`` — the prebuilt-arm metadata source of truth.
+
+Reads the sibling ``MANIFEST.toml`` and exposes per-arm metadata as a
+typed dataclass. All consumers (doc generators, test parametrisations,
+the build orchestration in ``scripts/regen_artifacts.py``, the
+``examples/04_compare_vs_eaik.py`` bench, the ``ssik add-arm`` CLI)
+read from this loader rather than hard-coding arm lists.
+
+See ``MANIFEST.toml`` itself for the schema reference.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal
+
+_MANIFEST_PATH = Path(__file__).resolve().parent / "MANIFEST.toml"
+
+__all__ = ["MANIFEST_PATH", "Arm", "ArmBench", "ArmKnownGap", "load_manifest"]
+
+MANIFEST_PATH = _MANIFEST_PATH
+
+
+@dataclass(frozen=True)
+class ArmBench:
+    """Latest bench measurements from ``examples/04_compare_vs_eaik.py``."""
+
+    ms_mean: float
+    ms_ci95: float
+    max_fk: float
+    sols_min: int
+    sols_max: int
+
+
+@dataclass(frozen=True)
+class ArmKnownGap:
+    """A known coverage gap that's xfailed in the uniform-fuzz test."""
+
+    xfail_reason: str
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One prebuilt-arm entry in ``MANIFEST.toml``.
+
+    Field semantics: see ``MANIFEST.toml``'s top-of-file schema comment.
+    """
+
+    name: str  # e.g. "rizon10_ik"
+    display_name: str
+    short_name: str
+    fixture: str
+    fixture_kind: Literal["urdf", "specs"]
+    base_link: str
+    ee_link: str
+    dof: int
+    solver: str
+    tier: int
+    kinematic_class: str
+    short_class: str
+    class_tags: tuple[str, ...]
+    slow_build: bool
+    build_time_sec: int
+    artifact_size_kb: int
+    sample_q: tuple[float, ...]
+    fk_ceiling_fuzz: float
+    platform_drift: bool
+    drift_markers: tuple[str, ...] = field(default=())
+    specs_fn: str | None = None
+    bench: ArmBench | None = None
+    known_gaps: ArmKnownGap | None = None
+
+
+def _coerce_arm(name: str, body: dict[str, object]) -> Arm:
+    """Build an :class:`Arm` from a TOML-loaded dict."""
+    bench_dict = body.get("bench")
+    bench = None
+    if isinstance(bench_dict, dict):
+        bench = ArmBench(
+            ms_mean=float(bench_dict["ms_mean"]),
+            ms_ci95=float(bench_dict["ms_ci95"]),
+            max_fk=float(bench_dict["max_fk"]),
+            sols_min=int(bench_dict["sols_min"]),
+            sols_max=int(bench_dict["sols_max"]),
+        )
+    gaps_dict = body.get("known_gaps")
+    known_gaps = None
+    if isinstance(gaps_dict, dict):
+        known_gaps = ArmKnownGap(xfail_reason=str(gaps_dict["xfail_reason"]))
+
+    fixture_kind = body["fixture_kind"]
+    if fixture_kind not in ("urdf", "specs"):
+        raise ValueError(
+            f"arm {name!r}: fixture_kind must be 'urdf' or 'specs', got {fixture_kind!r}"
+        )
+    # ``specs_fn`` is required when fixture_kind == "specs"; absent for urdf.
+    specs_fn = body.get("specs_fn")
+    if fixture_kind == "specs" and not specs_fn:
+        raise ValueError(f"arm {name!r}: fixture_kind='specs' requires specs_fn")
+    if fixture_kind == "urdf" and specs_fn:
+        raise ValueError(f"arm {name!r}: fixture_kind='urdf' but specs_fn is set; remove specs_fn")
+
+    return Arm(
+        name=name,
+        display_name=str(body["display_name"]),
+        short_name=str(body["short_name"]),
+        fixture=str(body["fixture"]),
+        fixture_kind=fixture_kind,  # type: ignore[arg-type]
+        specs_fn=str(specs_fn) if specs_fn else None,
+        base_link=str(body["base_link"]),
+        ee_link=str(body["ee_link"]),
+        dof=int(body["dof"]),
+        solver=str(body["solver"]),
+        tier=int(body["tier"]),
+        kinematic_class=str(body["kinematic_class"]),
+        short_class=str(body["short_class"]),
+        class_tags=tuple(str(t) for t in body["class_tags"]),  # type: ignore[arg-type]
+        slow_build=bool(body["slow_build"]),
+        build_time_sec=int(body["build_time_sec"]),
+        artifact_size_kb=int(body["artifact_size_kb"]),
+        sample_q=tuple(float(q) for q in body["sample_q"]),  # type: ignore[arg-type]
+        fk_ceiling_fuzz=float(body["fk_ceiling_fuzz"]),
+        platform_drift=bool(body["platform_drift"]),
+        drift_markers=tuple(str(m) for m in body.get("drift_markers", [])),  # type: ignore[arg-type]
+        bench=bench,
+        known_gaps=known_gaps,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_manifest(path: Path | None = None) -> dict[str, Arm]:
+    """Parse ``MANIFEST.toml`` and return ``{arm_name: Arm, ...}`` in
+    declaration order.
+
+    Order is preserved (Python dict iteration order matches TOML
+    file order), so downstream consumers that want a stable arm ordering
+    in tables / lists can just iterate the returned dict.
+
+    Result is cached: subsequent calls in the same process return the
+    same dict. Pass an explicit ``path`` for tests that need to load
+    an alternate manifest (which also bypasses the cache).
+    """
+    target = path if path is not None else _MANIFEST_PATH
+    if path is not None:
+        # Bypass the cache for explicit-path loads (test override).
+        return _load_uncached(target)
+    return _load_uncached(target)
+
+
+def _load_uncached(path: Path) -> dict[str, Arm]:
+    with path.open("rb") as fp:
+        data = tomllib.load(fp)
+    raw_arms = data.get("arms")
+    if not isinstance(raw_arms, dict):
+        raise ValueError(f"{path}: top-level 'arms' table is missing or malformed")
+    return {name: _coerce_arm(name, body) for name, body in raw_arms.items()}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -44,7 +44,9 @@ def test_every_shipped_prebuilt_has_a_manifest_entry(manifest: dict[str, Arm]) -
     parametrisations, and the bench. A manifest entry without a
     corresponding artifact would attempt to load nothing.
     """
-    prebuilt_dir = Path(importlib.import_module("ssik.prebuilt").__file__).parent
+    pkg = importlib.import_module("ssik.prebuilt")
+    assert pkg.__file__ is not None
+    prebuilt_dir = Path(pkg.__file__).parent
     on_disk = {
         p.stem
         for p in prebuilt_dir.glob("*_ik.py")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,131 @@
+"""Manifest cross-validation: every shipped prebuilt artifact has a
+manifest entry whose metadata matches the artifact's own bake-time
+constants.
+
+Adding a new arm: ``ssik add-arm`` (or its manual equivalent) populates
+the manifest. Editing an existing arm: bump the manifest, then re-emit
+the artifact so the bake-time constants stay in sync. This test fails
+loudly if those two ever drift.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from ssik.prebuilt._manifest import Arm, load_manifest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Arm]:
+    return load_manifest()
+
+
+def test_manifest_loads_cleanly(manifest: dict[str, Arm]) -> None:
+    """``MANIFEST.toml`` parses without errors and is non-empty."""
+    assert manifest, "manifest is empty"
+    # Stable iteration order matters: doc generators rely on it for
+    # table-row ordering. TOML preserves declaration order; this just
+    # documents the invariant.
+    names = list(manifest.keys())
+    assert len(set(names)) == len(names), "manifest has duplicate arm names"
+
+
+def test_every_shipped_prebuilt_has_a_manifest_entry(manifest: dict[str, Arm]) -> None:
+    """Every ``ssik.prebuilt.<arm>_ik`` module on disk must be in the
+    manifest, and vice versa.
+
+    The manifest is the single source of truth -- a prebuilt artifact
+    that's missing from it would silently drop out of doc tables, test
+    parametrisations, and the bench. A manifest entry without a
+    corresponding artifact would attempt to load nothing.
+    """
+    prebuilt_dir = Path(importlib.import_module("ssik.prebuilt").__file__).parent
+    on_disk = {
+        p.stem
+        for p in prebuilt_dir.glob("*_ik.py")
+        if not p.stem.startswith("_") and p.stem != "__init__"
+    }
+    in_manifest = set(manifest.keys())
+    missing_from_manifest = on_disk - in_manifest
+    missing_from_disk = in_manifest - on_disk
+    assert not missing_from_manifest, (
+        f"these prebuilt artifacts are on disk but absent from "
+        f"MANIFEST.toml: {sorted(missing_from_manifest)}"
+    )
+    assert not missing_from_disk, (
+        f"these manifest entries have no corresponding prebuilt artifact "
+        f"on disk: {sorted(missing_from_disk)} (regenerate with "
+        f"`uv run python scripts/regen_artifacts.py` and `--include-slow` "
+        f"if any are slow_build = true)"
+    )
+
+
+@pytest.mark.parametrize(
+    "arm_name",
+    [a for a in load_manifest()],
+    ids=list(load_manifest()),
+)
+def test_manifest_matches_artifact_constants(arm_name: str, manifest: dict[str, Arm]) -> None:
+    """Each manifest entry's ``solver`` / ``base_link`` / ``ee_link`` /
+    ``dof`` must equal the constants the artifact baked at emit time.
+
+    If they diverge, either the manifest is stale (bump it) or the
+    artifact was regenerated with different inputs (re-run ``ssik
+    build`` against the manifest's fixture).
+    """
+    arm = manifest[arm_name]
+    mod = importlib.import_module(f"ssik.prebuilt.{arm_name}")
+    assert arm.solver == mod.SOLVER_NAME, (
+        f"{arm_name}: manifest.solver={arm.solver!r}, artifact.SOLVER_NAME={mod.SOLVER_NAME!r}"
+    )
+    assert arm.base_link == mod.BASE_LINK, (
+        f"{arm_name}: manifest.base_link={arm.base_link!r}, artifact.BASE_LINK={mod.BASE_LINK!r}"
+    )
+    assert arm.ee_link == mod.EE_LINK, (
+        f"{arm_name}: manifest.ee_link={arm.ee_link!r}, artifact.EE_LINK={mod.EE_LINK!r}"
+    )
+    assert arm.dof == mod.DOF, f"{arm_name}: manifest.dof={arm.dof}, artifact.DOF={mod.DOF}"
+
+
+@pytest.mark.parametrize(
+    "arm_name",
+    [a for a in load_manifest()],
+    ids=list(load_manifest()),
+)
+def test_manifest_fixture_file_exists(arm_name: str, manifest: dict[str, Arm]) -> None:
+    """The fixture pointed at by each manifest entry must exist."""
+    arm = manifest[arm_name]
+    if arm.fixture_kind == "urdf":
+        path = FIXTURES_DIR / arm.fixture
+        assert path.exists(), f"{arm_name}: fixture {path} does not exist"
+    else:
+        # specs: a Python builder module under tests/fixtures
+        path = FIXTURES_DIR / f"{arm.fixture}.py"
+        assert path.exists(), f"{arm_name}: fixture {path} does not exist"
+
+
+@pytest.mark.parametrize(
+    "arm_name",
+    [a for a in load_manifest()],
+    ids=list(load_manifest()),
+)
+def test_manifest_sample_q_length_matches_dof(arm_name: str, manifest: dict[str, Arm]) -> None:
+    """``sample_q`` length must equal ``dof``."""
+    arm = manifest[arm_name]
+    assert len(arm.sample_q) == arm.dof, (
+        f"{arm_name}: sample_q has {len(arm.sample_q)} elements but dof = {arm.dof}"
+    )
+
+
+def test_drift_markers_present_when_platform_drift_true(manifest: dict[str, Arm]) -> None:
+    """Arms with ``platform_drift = true`` must declare ``drift_markers``
+    so the snapshot test can fall back to structural checks on non-macOS.
+    """
+    for name, arm in manifest.items():
+        if arm.platform_drift:
+            assert arm.drift_markers, f"{name}: platform_drift = true but drift_markers is empty"


### PR DESCRIPTION
First of six PRs implementing the turnkey arm onboarding from #290.

## Summary

Lands the single source of truth for prebuilt-arm metadata: each shipped arm gets one entry in \`src/ssik/prebuilt/MANIFEST.toml\`, covering data that's currently scattered across 18 files (README tables, \`docs/*\`, \`CITATION.cff\`, \`outreach/*\`, \`scripts/regen_artifacts.py\`, the three \`tests/test_prebuilt_*.py\` files, \`examples/04_compare_vs_eaik.py\` FIXTURES).

This PR is **pure data + loader** — no consumer is migrated yet. Keeps the diff minimal and reviewable. Subsequent PRs land:

- **PR 2**: \`test_prebuilt_*.py\` read from manifest
- **PR 3**: \`scripts/regen_docs.py\` regenerates README/docs/outreach tables from manifest, with named-anchor markers in source files
- **PR 4**: CI drift gate (\`regen_docs.py --check\`)
- **PR 5**: \`ssik add-arm\` CLI orchestration
- **PR 6**: \`CONTRIBUTING.md\` updates

## What's in this PR

- \`src/ssik/prebuilt/MANIFEST.toml\` — 13 entries (every currently-shipped prebuilt). Schema header documents every field. Bench numbers from the latest \`examples/04_compare_vs_eaik.py\` run; build_time / artifact_size from \`scripts/regen_artifacts.py\` output; sample_q from \`test_prebuilt_sanity.py\`; fk_ceiling_fuzz from \`test_prebuilt_uniform_fuzz.py\`; known_gaps from the existing xfail comments for piper_ik (#286) and z1_ik (#288).
- \`src/ssik/prebuilt/_manifest.py\` — typed loader exposing \`Arm\` / \`ArmBench\` / \`ArmKnownGap\` dataclasses + cached \`load_manifest()\`. Underscored — manifest format is package implementation detail, not public API.
- \`tests/test_manifest.py\` — cross-validation against the actual shipped prebuilt modules:
  1. Manifest loads cleanly + no duplicate names
  2. Every prebuilt artifact on disk has a manifest entry (+ vice versa)
  3. Manifest's \`solver\` / \`base_link\` / \`ee_link\` / \`dof\` match the artifact's baked \`SOLVER_NAME\` / \`BASE_LINK\` / \`EE_LINK\` / \`DOF\` constants (drift detection)
  4. Fixture files actually exist
  5. sample_q length matches dof
  6. drift_markers present whenever platform_drift = true

## Test plan

- [x] Local: \`uv run pytest tests/test_manifest.py\` → 42/42 passed
- [x] Local: \`uv build --wheel\` includes MANIFEST.toml in the published artifact
- [x] Local: ruff + format + mypy clean
- [ ] CI green