### PR TITLE
PR 4/6 (#290): CI drift gate -- regen_docs.py --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,13 @@ jobs:
       - name: mypy
         run: uv run mypy
 
+      - name: regen_docs --check
+        # Fail if MANIFEST.toml and the AUTOGEN doc-table regions are
+        # out of sync. The script regenerates anchored tables from
+        # the manifest; this gate enforces "edit MANIFEST.toml + run
+        # scripts/regen_docs.py" as the only correct workflow for
+        # arm metadata changes.
+        run: uv run python scripts/regen_docs.py --check
+
       - name: pytest
         run: uv run pytest -q

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -33,6 +33,9 @@ uv run ruff format --check
 echo "[check] mypy"
 uv run mypy
 
+echo "[check] regen_docs --check"
+uv run python scripts/regen_docs.py --check
+
 if [[ $run_tests -eq 1 ]]; then
     echo "[check] pytest"
     # Deselects: pre-existing stale xfails / known flakes that gate on


### PR DESCRIPTION
Fourth of six PRs implementing the turnkey arm onboarding from #290.

## Summary

Wires \`scripts/regen_docs.py --check\` into both the CI workflow and the local pre-push gate. The check fails non-zero with a diff if MANIFEST.toml and the AUTOGEN doc-table regions are out of sync.

## What it catches

The anti-pattern: editing a doc table by hand inside an \`<!-- AUTOGEN --> ... <!-- /AUTOGEN -->\` region. CI fails; reviewer is pointed at the manifest as the source of truth.

The workflow it enforces: edit MANIFEST.toml → run \`scripts/regen_docs.py\` → commit both.

## Files touched

- \`.github/workflows/ci.yml\` — new step between mypy and pytest
- \`scripts/check.sh\` — same check in the local pre-push hook

## Test plan

- [x] Local: \`scripts/regen_docs.py --check\` passes on the current main (zero drift)
- [x] Local: \`scripts/check.sh\` passes end-to-end
- [ ] CI green