### PR TITLE
Seeded nearest-to-seed tracking: seed_metric + 7R lock-outward fast path (#330, #331)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -499,6 +499,7 @@ def _render_specialised_solve_orchestrator() -> str:
             allow_rescue: bool = True,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
+            seed_metric: str = "wrap_linf",
         ):
             """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -508,9 +509,16 @@ def _render_specialised_solve_orchestrator() -> str:
                 Combine with ``q_seed`` for the "give me the IK closest to
                 where I am now" trajectory-tracking idiom.
             :param q_seed: optional joint configuration. When provided,
-                returned solutions are sorted by wrap-to-pi distance from
-                ``q_seed`` (closest first). Has no effect on which solutions
-                are returned, only their order.
+                returned solutions are sorted by distance from ``q_seed``
+                (closest first, via ``seed_metric``); with ``max_solutions``
+                this returns the nearest ``max_solutions`` to the seed -- the
+                trajectory-tracking idiom.
+            :param seed_metric: distance used to rank against ``q_seed``.
+                ``"wrap_linf"`` (default) minimises the *largest* single-joint
+                wrap-to-pi move, which holds the branch during tracking;
+                ``"wrap_l2"`` minimises the summed move (can favour a flip
+                "paid for" by smaller moves elsewhere). Ignored when
+                ``q_seed`` is ``None``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. Pass ``False`` for
                 the raw geometric set (e.g. analysis / debugging).
@@ -635,7 +643,7 @@ def _render_specialised_solve_orchestrator() -> str:
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
             if max_solutions is not None and len(solutions) > max_solutions:
                 solutions = solutions[:max_solutions]
             return solutions
@@ -865,6 +873,7 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             allow_rescue: bool = True,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
+            seed_metric: str = "wrap_linf",
         ):
             """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -874,10 +883,18 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 search. ``max_solutions=1`` short-circuits as soon as
                 one valid IK is found (~17x faster on this 7R).
             :param q_seed: optional length-7 seed configuration. When
-                provided, the lock-joint samples are visited in order
-                of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-                combined with ``max_solutions=1`` this is the
-                trajectory-tracking fast path.
+                provided, the lock-joint samples are visited outward from
+                ``q_seed[lock_idx]`` and the first yielding slice's full
+                branch set is L-infinity-ranked against the seed (see
+                ``seed_metric``); with ``max_solutions`` this returns the
+                nearest configs to the seed in ~1 sub-solve -- the
+                trajectory-tracking fast path (#331), branch-continuous and
+                ~20x faster than the exhaustive sweep.
+            :param seed_metric: distance used to rank against ``q_seed``.
+                ``"wrap_linf"`` (default) minimises the *largest* single-joint
+                wrap-to-pi move, holding the branch during tracking;
+                ``"wrap_l2"`` minimises the summed move. Ignored when
+                ``q_seed`` is ``None``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. Pass ``False``
                 for the raw geometric set.
@@ -1005,12 +1022,22 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                         solutions = _ps_wrap_to_limits(solutions, _KB)
                         solutions = _ps_respect_limits(solutions, _KB)
                     if q_seed is not None:
-                        solutions = _ps_nearest_to_seed(solutions, q_seed)
+                        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
             # No orchestrator-level respect_limits pass on the analytical
             # result: the inner ``_solve_algebraic`` already filtered in-flight
             # when respect_limits=True, so candidates here are guaranteed
-            # in-limits. The cap on max_solutions also ran inside.
+            # in-limits.
+            #
+            # Seeded ranking (#331): the lock-sweep returns candidates from the
+            # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+            # order), but the genuinely-nearest config -- and the
+            # branch-continuous one for tracking -- needs an explicit rank by
+            # ``seed_metric`` (default L-infinity) over that window before the
+            # cap. Without this the cap would keep the nearest *lock samples*,
+            # not the nearest *configs*.
+            if q_seed is not None:
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
             if max_solutions is not None and len(solutions) > max_solutions:
                 solutions = solutions[:max_solutions]
             return solutions
@@ -1273,6 +1300,7 @@ def _render_solve_function(solver_short: str) -> str:
             allow_refinement: bool = False,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
+            seed_metric: str = "wrap_linf",
         ):
             \"\"\"Inverse kinematics. Returns ``list[Solution]``.
 
@@ -1280,9 +1308,13 @@ def _render_solve_function(solver_short: str) -> str:
             :param max_solutions: optional cap on returned IKs (post-dedup,
                 post-limits filter). ``None`` = full enumeration.
             :param q_seed: optional joint config. When provided, solutions
-                are sorted by wrap-to-pi distance from ``q_seed`` (closest
-                first). Combine with ``max_solutions=1`` for the
+                are sorted by distance from ``q_seed`` (closest first, via
+                ``seed_metric``). Combine with ``max_solutions=1`` for the
                 trajectory-tracking idiom.
+            :param seed_metric: distance used to rank against ``q_seed``.
+                ``"wrap_linf"`` (default, largest single-joint move) holds
+                the branch during tracking; ``"wrap_l2"`` uses the summed
+                move. Ignored when ``q_seed`` is ``None``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. ``False`` returns
                 the raw geometric set.
@@ -1309,7 +1341,7 @@ def _render_solve_function(solver_short: str) -> str:
                 sols = _ps_wrap_to_limits(sols, _KB)
                 sols = _ps_respect_limits(sols, _KB)
             if q_seed is not None:
-                sols = _ps_nearest_to_seed(sols, q_seed)
+                sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
             if max_solutions is not None and len(sols) > max_solutions:
                 sols = sols[:max_solutions]
             return sols

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -228,6 +228,7 @@ class Manipulator:
         allow_refinement: bool = False,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
+        seed_metric: str = "wrap_linf",
         **solver_kwargs: Any,
     ) -> list[Solution]: ...
 
@@ -243,6 +244,7 @@ class Manipulator:
         allow_refinement: bool = False,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
+        seed_metric: str = "wrap_linf",
         **solver_kwargs: Any,
     ) -> tuple[list[Solution], Diagnostic]: ...
 
@@ -257,6 +259,7 @@ class Manipulator:
         allow_refinement: bool = False,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
+        seed_metric: str = "wrap_linf",
         **solver_kwargs: Any,
     ) -> list[Solution] | tuple[list[Solution], Diagnostic]:
         """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
@@ -272,9 +275,14 @@ class Manipulator:
             On 7R jointlock arms the cap also short-circuits the lock-sweep
             internally for a 10-15x speedup.
         :param q_seed: optional length-:attr:`dof` seed. When provided,
-            returned solutions are sorted by wrap-to-pi distance from
-            ``q_seed`` (closest first). On jointlock-7R arms it also
-            reorders the internal lock-sample sweep.
+            returned solutions are sorted by distance from ``q_seed``
+            (closest first, via ``seed_metric``); with ``max_solutions``
+            this returns the nearest configs to the seed. On jointlock-7R
+            arms it also drives the lock-outward-from-seed fast path (#331).
+        :param seed_metric: distance used to rank against ``q_seed``.
+            ``"wrap_linf"`` (default) minimises the largest single-joint
+            wrap-to-pi move (holds the branch during tracking); ``"wrap_l2"``
+            minimises the summed move. Ignored when ``q_seed`` is ``None``.
         :param respect_limits: when ``True`` (default), solutions outside
             URDF joint limits are dropped. Pass ``False`` for the raw
             geometric set (analysis / debugging).
@@ -362,7 +370,7 @@ class Manipulator:
         else:
             dropped_by_limits = 0
         if q_seed_arr is not None:
-            sols = _ps_nearest_to_seed(sols, q_seed_arr)
+            sols = _ps_nearest_to_seed(sols, q_seed_arr, metric=seed_metric)
         if max_solutions is not None and len(sols) > max_solutions:
             dropped_by_max_solutions = len(sols) - max_solutions
             sols = sols[:max_solutions]

--- a/src/ssik/prebuilt/big_yam_ik.py
+++ b/src/ssik/prebuilt/big_yam_ik.py
@@ -958,6 +958,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -967,9 +968,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1094,7 +1102,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/fanuc_crx10ial_ik.py
+++ b/src/ssik/prebuilt/fanuc_crx10ial_ik.py
@@ -915,6 +915,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -924,9 +925,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1051,7 +1059,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/fr3_ik.py
+++ b/src/ssik/prebuilt/fr3_ik.py
@@ -433,6 +433,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -442,10 +443,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -573,12 +582,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/franka_panda_ik.py
+++ b/src/ssik/prebuilt/franka_panda_ik.py
@@ -433,6 +433,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -442,10 +443,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -573,12 +582,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/gen3_ik.py
+++ b/src/ssik/prebuilt/gen3_ik.py
@@ -159,6 +159,7 @@ def solve(
     allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -166,9 +167,13 @@ def solve(
     :param max_solutions: optional cap on returned IKs (post-dedup,
         post-limits filter). ``None`` = full enumeration.
     :param q_seed: optional joint config. When provided, solutions
-        are sorted by wrap-to-pi distance from ``q_seed`` (closest
-        first). Combine with ``max_solutions=1`` for the
+        are sorted by distance from ``q_seed`` (closest first, via
+        ``seed_metric``). Combine with ``max_solutions=1`` for the
         trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default, largest single-joint move) holds
+        the branch during tracking; ``"wrap_l2"`` uses the summed
+        move. Ignored when ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. ``False`` returns
         the raw geometric set.
@@ -195,7 +200,7 @@ def solve(
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)
     if q_seed is not None:
-        sols = _ps_nearest_to_seed(sols, q_seed)
+        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
     if max_solutions is not None and len(sols) > max_solutions:
         sols = sols[:max_solutions]
     return sols

--- a/src/ssik/prebuilt/iiwa14_ik.py
+++ b/src/ssik/prebuilt/iiwa14_ik.py
@@ -159,6 +159,7 @@ def solve(
     allow_refinement: bool = False,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -166,9 +167,13 @@ def solve(
     :param max_solutions: optional cap on returned IKs (post-dedup,
         post-limits filter). ``None`` = full enumeration.
     :param q_seed: optional joint config. When provided, solutions
-        are sorted by wrap-to-pi distance from ``q_seed`` (closest
-        first). Combine with ``max_solutions=1`` for the
+        are sorted by distance from ``q_seed`` (closest first, via
+        ``seed_metric``). Combine with ``max_solutions=1`` for the
         trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default, largest single-joint move) holds
+        the branch during tracking; ``"wrap_l2"`` uses the summed
+        move. Ignored when ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. ``False`` returns
         the raw geometric set.
@@ -195,7 +200,7 @@ def solve(
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)
     if q_seed is not None:
-        sols = _ps_nearest_to_seed(sols, q_seed)
+        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
     if max_solutions is not None and len(sols) > max_solutions:
         sols = sols[:max_solutions]
     return sols

--- a/src/ssik/prebuilt/jaco2_ik.py
+++ b/src/ssik/prebuilt/jaco2_ik.py
@@ -883,6 +883,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -892,9 +893,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1019,7 +1027,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/kassow_kr810_ik.py
+++ b/src/ssik/prebuilt/kassow_kr810_ik.py
@@ -806,6 +806,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -815,10 +816,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -946,12 +955,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/openarm_left_ik.py
+++ b/src/ssik/prebuilt/openarm_left_ik.py
@@ -433,6 +433,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -442,10 +443,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -573,12 +582,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/openarm_right_ik.py
+++ b/src/ssik/prebuilt/openarm_right_ik.py
@@ -433,6 +433,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -442,10 +443,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -573,12 +582,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/piper_ik.py
+++ b/src/ssik/prebuilt/piper_ik.py
@@ -932,6 +932,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -941,9 +942,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1068,7 +1076,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/puma560_ik.py
+++ b/src/ssik/prebuilt/puma560_ik.py
@@ -538,6 +538,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -547,9 +548,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -674,7 +682,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/rizon10_ik.py
+++ b/src/ssik/prebuilt/rizon10_ik.py
@@ -806,6 +806,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -815,10 +816,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -946,12 +955,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/rizon4_ik.py
+++ b/src/ssik/prebuilt/rizon4_ik.py
@@ -806,6 +806,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -815,10 +816,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -946,12 +955,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -475,6 +475,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -484,9 +485,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -611,7 +619,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/xarm6_ik.py
+++ b/src/ssik/prebuilt/xarm6_ik.py
@@ -927,6 +927,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -936,9 +937,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1063,7 +1071,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/xarm7_ik.py
+++ b/src/ssik/prebuilt/xarm7_ik.py
@@ -433,6 +433,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -442,10 +443,18 @@ def solve(
         search. ``max_solutions=1`` short-circuits as soon as
         one valid IK is found (~17x faster on this 7R).
     :param q_seed: optional length-7 seed configuration. When
-        provided, the lock-joint samples are visited in order
-        of wrap-to-pi distance to ``q_seed[lock_idx]`` --
-        combined with ``max_solutions=1`` this is the
-        trajectory-tracking fast path.
+        provided, the lock-joint samples are visited outward from
+        ``q_seed[lock_idx]`` and the first yielding slice's full
+        branch set is L-infinity-ranked against the seed (see
+        ``seed_metric``); with ``max_solutions`` this returns the
+        nearest configs to the seed in ~1 sub-solve -- the
+        trajectory-tracking fast path (#331), branch-continuous and
+        ~20x faster than the exhaustive sweep.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, holding the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move. Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -573,12 +582,22 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
-                solutions = _ps_nearest_to_seed(solutions, q_seed)
+                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
     # result: the inner ``_solve_algebraic`` already filtered in-flight
     # when respect_limits=True, so candidates here are guaranteed
-    # in-limits. The cap on max_solutions also ran inside.
+    # in-limits.
+    #
+    # Seeded ranking (#331): the lock-sweep returns candidates from the
+    # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
+    # order), but the genuinely-nearest config -- and the
+    # branch-continuous one for tracking -- needs an explicit rank by
+    # ``seed_metric`` (default L-infinity) over that window before the
+    # cap. Without this the cap would keep the nearest *lock samples*,
+    # not the nearest *configs*.
+    if q_seed is not None:
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/yam_ik.py
+++ b/src/ssik/prebuilt/yam_ik.py
@@ -1015,6 +1015,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -1024,9 +1025,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1151,7 +1159,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/prebuilt/z1_ik.py
+++ b/src/ssik/prebuilt/z1_ik.py
@@ -465,6 +465,7 @@ def solve(
     allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -474,9 +475,16 @@ def solve(
         Combine with ``q_seed`` for the "give me the IK closest to
         where I am now" trajectory-tracking idiom.
     :param q_seed: optional joint configuration. When provided,
-        returned solutions are sorted by wrap-to-pi distance from
-        ``q_seed`` (closest first). Has no effect on which solutions
-        are returned, only their order.
+        returned solutions are sorted by distance from ``q_seed``
+        (closest first, via ``seed_metric``); with ``max_solutions``
+        this returns the nearest ``max_solutions`` to the seed -- the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default) minimises the *largest* single-joint
+        wrap-to-pi move, which holds the branch during tracking;
+        ``"wrap_l2"`` minimises the summed move (can favour a flip
+        "paid for" by smaller moves elsewhere). Ignored when
+        ``q_seed`` is ``None``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -601,7 +609,7 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
-        solutions = _ps_nearest_to_seed(solutions, q_seed)
+        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]
     return solutions

--- a/src/ssik/solvers/jointlock/seven_r.py
+++ b/src/ssik/solvers/jointlock/seven_r.py
@@ -638,11 +638,12 @@ def solve(
 
     if q_seed_arr is not None:
         # Reorder samples by wrap-to-pi distance to seed[lock_idx], nearest
-        # first. Combined with max_solutions=1, this is the trajectory-
-        # tracking fast path: usually one or two dispatches before the
-        # match emerges. The unstable sort + numerical tiebreak below keeps
-        # ordering deterministic even when two samples land at equal
-        # distance.
+        # first -- the "outward from the seed's redundancy value" walk that
+        # makes the trajectory-tracking fast path work (#331): the nearest IK
+        # lives in the first slice(s) to yield, so the seed-ordered early-exit
+        # stops after usually one or two dispatches. The unstable sort +
+        # numerical tiebreak below keeps ordering deterministic even when two
+        # samples land at equal distance.
         seed_lock = float(q_seed_arr[lock_idx])
         diffs = np.abs((samples - seed_lock + np.pi) % (2 * np.pi) - np.pi)
         order = np.lexsort((samples, diffs))
@@ -653,6 +654,18 @@ def solve(
             cache_arr = [cache_arr[i] for i in order]
 
     dedup_tol = policy.subproblem_dedup
+
+    # Seeded "lock-outward-from-seed" tracking (#331). The lock samples are
+    # already ordered outward from ``seed[lock_idx]`` (above), so the nearest IK
+    # lives in the first slice(s) that yield. To return the branch-continuous
+    # one we need that slice's *full* branch set, not a single capped branch --
+    # so per-slice we ask the inner solver for ALL branches (max_solutions=None)
+    # and let the seed-ordered early-exit stop after the first slice provides
+    # enough. The orchestrator then L-infinity-ranks those branches against the
+    # seed (postprocess) and takes ``max_solutions``. Net: ~1 sub-solve in the
+    # tracking case (fast) AND no elbow/wrist branch flips (smooth).
+    seeded = q_seed_arr is not None
+    inner_max_solutions = None if seeded else max_solutions
 
     def _sweep(cached_rr_only: bool) -> tuple[list[Solution], int]:
         """Run the lock-sweep once. With ``cached_rr_only`` (the primary
@@ -681,7 +694,7 @@ def solve(
                     policy,
                     allow_refinement=allow_refinement,
                     refinement_max_iters=refinement_max_iters,
-                    max_solutions=max_solutions,
+                    max_solutions=inner_max_solutions,
                     cached_rr_only=cached_rr_only,
                 )
             except ValueError:
@@ -741,13 +754,18 @@ def solve(
         candidates, samples_evaluated = _sweep(cached_rr_only=False)
 
     solutions = dedup_by_wrap_close(candidates, dedup_tol)
-    if max_solutions is not None and len(solutions) > max_solutions:
+    if not seeded and max_solutions is not None and len(solutions) > max_solutions:
         # Trim to exactly max_solutions. The incremental check above
         # exits the *outer* loop on the first sample that pushes the
         # deduped count past the cap, so the final dedup may yield
         # slightly more than the cap (the last sample contributed
-        # multiple new unique solutions). Trimming preserves the
-        # nearest-first order under q_seed.
+        # multiple new unique solutions).
+        #
+        # Skipped when seeded (#331): the candidates here are the first
+        # yielding lock slice's *full* branch set in branch order, NOT
+        # nearest-to-seed order. Trimming now would keep an arbitrary
+        # branch; the caller (orchestrator / Manipulator) L-infinity-ranks
+        # against the seed and *then* trims, so we hand back every branch.
         solutions = solutions[:max_solutions]
     _LOG.info(
         "%s: lock_idx=%d, %d/%d samples -> %d candidates -> %d unique solutions (is_ls=%s)",

--- a/tests/test_jointlock_seven_r.py
+++ b/tests/test_jointlock_seven_r.py
@@ -24,6 +24,7 @@ import pytest
 from numpy.typing import NDArray
 
 from ssik._kinbody import Joint, KinBody, Link
+from ssik.postprocess import nearest_to_seed
 from ssik.solvers.jointlock import seven_r
 
 
@@ -279,14 +280,17 @@ def test_max_solutions_subset_of_full_sweep(srs_kb: KinBody) -> None:
 
 
 def test_q_seed_returns_nearest_first(srs_kb: KinBody) -> None:
-    """With ``q_seed=q*`` and ``max_solutions=1``, the returned solution
-    should be the one closest to ``q*`` (in wrap-to-pi joint distance) --
-    that's the trajectory-tracking promise."""
+    """With ``q_seed=q*``, the nearest-ranked solution should be the one
+    closest to ``q*`` (in wrap-to-pi joint distance) -- the trajectory-tracking
+    promise. Since #331, jointlock hands back the first yielding lock slice's
+    *full* branch set when seeded (so the caller can rank by ``seed_metric``);
+    the caller's ``nearest_to_seed`` -- applied here as the orchestrator and
+    Manipulator do -- delivers the nearest config."""
     q_star = np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2, 0.4])
     T_star = _fk(srs_kb, q_star)
     sols_seeded, _ = seven_r.solve(srs_kb, T_star, q_seed=q_star, max_solutions=1)
-    assert len(sols_seeded) == 1
-    sol_seeded = sols_seeded[0]
+    assert len(sols_seeded) >= 1
+    sol_seeded = nearest_to_seed(sols_seeded, q_star, metric="wrap_linf")[0]
     # Compare against the full sweep to confirm we picked the nearest one
     # to the seed (or one of them, modulo 2pi wrap on non-locked joints).
     full, _ = seven_r.solve(srs_kb, T_star)
@@ -473,7 +477,10 @@ def test_dispatch_cache_with_q_seed_reordering(srs_kb: KinBody) -> None:
         q_seed=q_star,
         max_solutions=1,
     )
-    assert len(sols_seeded) == 1
-    # FK-closes at machine precision.
-    T_check = _fk(srs_kb, sols_seeded[0].q)
-    assert np.allclose(T_check, T_star, atol=1e-10)
+    # Seeded returns the first yielding slice's full branch set (#331); every
+    # branch must FK-close at machine precision -- a mis-permuted cache would
+    # dispatch the wrong inner solver and yield garbage / non-closing branches.
+    assert len(sols_seeded) >= 1
+    for sol in sols_seeded:
+        T_check = _fk(srs_kb, sol.q)
+        assert np.allclose(T_check, T_star, atol=1e-10)

--- a/tests/test_seeded_nearest_tracking.py
+++ b/tests/test_seeded_nearest_tracking.py
@@ -1,0 +1,186 @@
+"""Seeded nearest-to-seed tracking: ``seed_metric`` (#330) + the 7R
+lock-outward-from-seed fast path (#331).
+
+Two coupled guarantees on the ``q_seed`` contract:
+
+* **#330** -- ``solve(T, q_seed=q, max_solutions=k)`` returns the ``k``
+  solutions nearest ``q_seed`` ranked by ``seed_metric``. The default is
+  ``"wrap_linf"`` (minimise the *largest* single-joint move), which holds the
+  branch during trajectory tracking where the summed-distance ``"wrap_l2"``
+  would let a big single-joint flip hide behind smaller moves elsewhere.
+* **#331** -- on jointlock-7R arms the seeded path walks lock samples outward
+  from ``q_seed[lock_idx]`` and L-infinity-ranks the first yielding slice's
+  *full* branch set, so it returns the same nearest config as the exhaustive
+  sweep in ~1 sub-solve instead of ~16.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import ssik
+from ssik._kinbody import KinBody
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.postprocess import nearest_to_seed
+from ssik.solvers.jointlock import seven_r as jointlock_seven_r
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# A franka pose + seed where the L2-nearest and L-infinity-nearest branches
+# differ (found by enumeration; see #330). The L-infinity pick has a strictly
+# smaller worst-single-joint move -- the anti-flip property.
+_DIVERGENT_QTRUE = np.array([-0.5455, 0.0149, 0.819, -0.2425, -0.2675, -1.247, 0.1981])
+_DIVERGENT_QSEED = np.array([-1.1469, 0.4888, 1.9194, -0.2181, -1.391, 1.9702, -0.4396])
+
+
+def _wrap(d: np.ndarray) -> np.ndarray:
+    return (d + np.pi) % (2 * np.pi) - np.pi
+
+
+def _linf(q_seed: np.ndarray, sol: object) -> float:
+    return float(np.abs(_wrap(np.asarray(sol.q) - q_seed)).max())  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="module")
+def franka_kb() -> KinBody:
+    return load_urdf_kinbody_normalized(
+        FIXTURES / "franka_panda.urdf", "panda_link0", "panda_link8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #330 -- seed_metric plumbs through the baked artifact solve().
+# ---------------------------------------------------------------------------
+
+
+def test_seed_metric_plumbs_through_artifact_solve() -> None:
+    """``seed_metric`` selects the ranking on the public artifact ``solve()``;
+    ``wrap_linf`` (the default) yields a strictly smaller worst-joint move than
+    ``wrap_l2`` on a divergent pose."""
+    from ssik.prebuilt import franka_panda_ik
+
+    T = franka_panda_ik._fk(_DIVERGENT_QTRUE)
+
+    l2 = franka_panda_ik.solve(
+        T, q_seed=_DIVERGENT_QSEED, max_solutions=1, respect_limits=False, seed_metric="wrap_l2"
+    )
+    linf = franka_panda_ik.solve(
+        T, q_seed=_DIVERGENT_QSEED, max_solutions=1, respect_limits=False, seed_metric="wrap_linf"
+    )
+    default = franka_panda_ik.solve(
+        T, q_seed=_DIVERGENT_QSEED, max_solutions=1, respect_limits=False
+    )
+    assert l2
+    assert linf
+    assert default
+
+    # The two metrics genuinely disagree, and wrap_linf wins on worst-joint move.
+    assert not np.allclose(l2[0].q, linf[0].q), "metrics should pick different branches here"
+    assert _linf(_DIVERGENT_QSEED, linf[0]) < _linf(_DIVERGENT_QSEED, l2[0])
+
+    # Default is wrap_linf.
+    assert np.allclose(default[0].q, linf[0].q)
+
+    # Both are real IK solutions.
+    for sols in (l2, linf):
+        err = float(np.max(np.abs(franka_panda_ik._fk(sols[0].q) - T)))
+        assert err < 1e-9, f"FK closure {err:.2e}"
+
+
+def test_bad_seed_metric_raises() -> None:
+    from ssik.prebuilt import franka_panda_ik
+
+    T = franka_panda_ik._fk(_DIVERGENT_QTRUE)
+    with pytest.raises(ValueError, match="unknown metric"):
+        franka_panda_ik.solve(T, q_seed=_DIVERGENT_QSEED, seed_metric="bogus")
+
+
+def test_seed_metric_plumbs_through_manipulator() -> None:
+    """``Manipulator.solve`` forwards ``seed_metric`` to the ranking pass."""
+    arm = ssik.Manipulator.from_urdf(
+        FIXTURES / "franka_panda.urdf", base="panda_link0", ee="panda_link8"
+    )
+    T = arm.fk(_DIVERGENT_QTRUE)
+    l2 = arm.solve(
+        T, q_seed=_DIVERGENT_QSEED, max_solutions=1, respect_limits=False, seed_metric="wrap_l2"
+    )
+    linf = arm.solve(
+        T, q_seed=_DIVERGENT_QSEED, max_solutions=1, respect_limits=False, seed_metric="wrap_linf"
+    )
+    assert l2
+    assert linf
+    assert not np.allclose(l2[0].q, linf[0].q)
+    assert _linf(_DIVERGENT_QSEED, linf[0]) < _linf(_DIVERGENT_QSEED, l2[0])
+
+
+# ---------------------------------------------------------------------------
+# #331 -- 7R seeded fast path matches the exhaustive nearest, cheaply.
+# ---------------------------------------------------------------------------
+
+
+def test_jointlock_seeded_matches_exhaustive_nearest(franka_kb: KinBody) -> None:
+    """Across a smooth trajectory, the seeded fast path's nearest solution is
+    exactly as close to the seed as the exhaustive sweep's nearest -- it never
+    settles for a farther branch."""
+    rng = np.random.default_rng(2)
+    q_prev = np.array([0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5])
+    worst_gap = 0.0
+    for _ in range(15):
+        q_true = q_prev + rng.normal(scale=0.02, size=7)
+        T = poe_forward_kinematics(franka_kb, q_true)
+
+        seeded, _ = jointlock_seven_r.solve(
+            franka_kb, T, q_seed=q_prev, max_solutions=1, respect_limits=False
+        )
+        seeded = nearest_to_seed(seeded, q_prev, metric="wrap_linf")
+        exhaustive, _ = jointlock_seven_r.solve(franka_kb, T, respect_limits=False)
+        assert seeded
+        assert exhaustive
+
+        seeded_best = _linf(q_prev, seeded[0])
+        exhaustive_best = min(_linf(q_prev, s) for s in exhaustive)
+        worst_gap = max(worst_gap, seeded_best - exhaustive_best)
+        q_prev = np.asarray(seeded[0].q)
+    assert worst_gap < 1e-9, f"seeded path missed the nearest branch by {worst_gap:.2e} rad"
+
+
+def test_jointlock_seeded_returns_full_branch_set(franka_kb: KinBody) -> None:
+    """When seeded, jointlock hands back the first yielding slice's *full*
+    branch set (not a single branch) so the caller can rank by ``seed_metric``.
+    This guards the "skip the in-solver trim when seeded" change in #331."""
+    q_seed = np.array([0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5])
+    T = poe_forward_kinematics(franka_kb, q_seed)
+    seeded, _ = jointlock_seven_r.solve(
+        franka_kb, T, q_seed=q_seed, max_solutions=1, respect_limits=False
+    )
+    assert len(seeded) > 1, "seeded solve must return the full branch set for ranking, not 1"
+
+
+def test_jointlock_seeded_dispatches_fewer_than_exhaustive(franka_kb: KinBody) -> None:
+    """The lock-outward early-exit (#331) evaluates far fewer inner sub-solves
+    than the exhaustive sweep -- the speed win, asserted structurally (no
+    wall-clock)."""
+    q_seed = np.array([0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5])
+    T = poe_forward_kinematics(franka_kb, q_seed)
+    real_dispatch = jointlock_seven_r._dispatch  # type: ignore[attr-defined]
+
+    def _count(*args: object, **kwargs: object) -> object:
+        _count.n += 1  # type: ignore[attr-defined]
+        return real_dispatch(*args, **kwargs)  # type: ignore[arg-type]
+
+    def _run(**solve_kwargs: object) -> int:
+        _count.n = 0  # type: ignore[attr-defined]
+        jointlock_seven_r._dispatch = _count  # type: ignore[attr-defined,assignment]
+        try:
+            jointlock_seven_r.solve(franka_kb, T, respect_limits=False, **solve_kwargs)  # type: ignore[arg-type]
+        finally:
+            jointlock_seven_r._dispatch = real_dispatch  # type: ignore[attr-defined]
+        return _count.n  # type: ignore[attr-defined,no-any-return]
+
+    seeded_dispatches = _run(q_seed=q_seed, max_solutions=1)
+    exhaustive_dispatches = _run()
+    assert seeded_dispatches < exhaustive_dispatches, (
+        f"seeded {seeded_dispatches} not < exhaustive {exhaustive_dispatches}"
+    )


### PR DESCRIPTION
## Why

Strengthens the `q_seed` contract so `solve(T, q_seed=q, max_solutions=k)` returns the `k` solutions **genuinely nearest the seed** — branch-continuously and cheaply. This is the trajectory-tracking idiom (stream a moving target → smooth single-solution tracking), surfaced while building the IHMC Alex V2 dual-arm viz.

Closes #330. Closes #331.

## What

**#330 — `seed_metric`.** New kwarg on `solve()` (all artifacts) and `Manipulator.solve`, threaded into the nearest-to-seed ranking.
- `"wrap_linf"` (**new default**) minimises the *largest* single-joint wrap-to-pi move → holds the branch during tracking.
- `"wrap_l2"` (previous behaviour) minimises summed distance → can let a big single-joint flip hide behind smaller moves elsewhere.
- Ignored when `q_seed is None`. `postprocess.nearest_to_seed` already supported both metrics; this exposes the choice through the public API.

**#331 — 7R jointlock lock-outward-from-seed.** Lock samples are already visited outward from `q_seed[lock_idx]`, so the nearest IK lives in the first slice(s) to yield. The seeded path now:
- requests the inner solver's **full branch set** per slice (instead of a single capped branch), and
- **skips the in-solver branch-order trim** when seeded, so the caller L∞-ranks the slice's branches and takes `max_solutions`.

Net: returns the **same nearest config as the exhaustive sweep** (verified gap = 0 across a trajectory) in **~1 sub-solve** instead of ~16. 6R is free — the algebraic solvers already return all branches; ranking + truncation alone delivers nearest-k.

## Measured (Franka, true jointlock-7R)

| | exhaustive + L∞ | seeded fast path |
|---|---|---|
| latency | 46–57 ms | **0.8–1.9 ms (24–64×)** |
| nearest-branch gap vs exhaustive | — | **0.00 rad** (every step) |

Worst per-step jump is dominated by the lock joint snapping to the sample grid (joints 1–6 track smoothly); that floor is inherent to analytical jointlock — exhaustive can't beat it either.

## ⚠️ Behaviour change

Under `q_seed`, the default ranking metric is now `wrap_linf` (was `wrap_l2`), so the **order** — and, with `max_solutions`, the **selection** — of returned solutions can differ for existing seeded callers. Opt back in with `seed_metric="wrap_l2"`.

## Artifacts

Regenerated all 20 prebuilt artifacts (orchestrator template changed); `test_artifact_snapshots.py` byte-parity holds.

## Test plan

- `tests/test_seeded_nearest_tracking.py` (new): metric plumbing through artifact `solve()` + `Manipulator`; the divergent `wrap_l2` vs `wrap_linf` pick (L∞ worst-joint 1.74 < L2's 2.97); seeded-matches-exhaustive (gap < 1e-9 over a trajectory); full-branch-set return; fewer-dispatches speed win.
- Updated 2 jointlock tests to the new seeded contract (full branch set returned; caller ranks).
- Full suite green except 3 **pre-existing** failures (verified identical on a clean tree via `git stash`): `test_sp5_returned_solutions_always_satisfy_equation`, `test_ikgeo_spherical::test_random_q_roundtrip_fk`, `test_oracle2_eaik_cross_check_ur5` — Hypothesis edge cases in subproblem/ikgeo/EAIK code untouched by this PR.
- ruff + mypy clean on all changed files.