### PR TITLE
seed_tolerance: hard per-joint deviation bound for q_seed (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,24 @@ q_current = np.array([0.0, -0.5, 0.0, 0.7, 0.0, 1.2, 0.0])
 # Target pose updates every control tick (VR controller, planner, etc.).
 T_target = ...
 
-# max_solutions=1 + q_seed: solver visits lock-samples in nearest-to-seed
-# order and short-circuits on the first in-limits branch (~5-6× faster
-# than the full sweep on 7R jointlock arms; sub-ms on 6R / SRS arms).
+# max_solutions=1 + q_seed: returns the single solution nearest q_current.
+# On 7R jointlock arms the seed drives the lock-outward fast path (~20×
+# faster than the full sweep); sub-ms on 6R / SRS arms.
 sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
 q_command = sols[0].q if sols else q_current
+```
+
+When a seed is given, two knobs control what "nearest" means:
+
+- **`seed_metric`** (default `"wrap_linf"`) ranks by the *largest* single-joint move, so the arm holds its branch instead of flipping mid-trajectory; `"wrap_l2"` ranks by summed distance.
+- **`seed_tolerance`** (radians) is a *hard* bound — only solutions whose every joint is within the tolerance of the seed are returned. The result may be **empty**, which is the signal that smooth continuation isn't possible at this pose (replan / accept a jump). Omitted ⇒ best-effort (always returns the nearest if any IK exists).
+
+```python
+# "no joint jumps more than 6° from where I am, or tell me it can't":
+sols = franka_panda_ik.solve(
+    T_target, q_seed=q_current, max_solutions=1, seed_tolerance=np.deg2rad(6)
+)
+q_command = sols[0].q if sols else replan()   # empty ⇒ discontinuity
 ```
 
 ### Build an artifact for your own arm
@@ -320,21 +333,22 @@ Per-arm worst-case behaviour under both policies is documented in [`docs/arm_cov
 
 ### `ssik.postprocess` — composable filters
 
-`solve()` returns the geometric IK set. For application-specific filtering, four helpers in `ssik.postprocess` compose into the typical "robot-aware IK" pipeline:
+`solve()` returns the geometric IK set. For application-specific filtering, five helpers in `ssik.postprocess` compose into the typical "robot-aware IK" pipeline:
 
 ```python
 from ssik.postprocess import (
-    respect_limits, wrap_to_limits, nearest_to_seed, take_first,
+    respect_limits, wrap_to_limits, nearest_to_seed, within_seed_tolerance, take_first,
 )
 
-sols = my_arm_ik.solve(T_target, respect_limits=False)  # raw geometric set
-sols = wrap_to_limits(sols, my_arm_ik._KB)              # try q ± 2π to bring in
-sols = respect_limits(sols, my_arm_ik._KB)              # drop anything still outside
-sols = nearest_to_seed(sols, q_current)                 # sort by wrap-to-pi distance
-sols = take_first(sols, k=4)                            # top-k after ranking
+sols = my_arm_ik.solve(T_target, respect_limits=False)       # raw geometric set
+sols = wrap_to_limits(sols, my_arm_ik._KB)                   # try q ± 2π to bring in
+sols = respect_limits(sols, my_arm_ik._KB)                   # drop anything still outside
+sols = within_seed_tolerance(sols, q_current, np.deg2rad(6)) # drop big-jump branches (may empty)
+sols = nearest_to_seed(sols, q_current, metric="wrap_linf")  # rank by max-joint-move
+sols = take_first(sols, k=4)                                 # top-k after ranking
 ```
 
-By default `solve()` already runs `wrap_to_limits` + `respect_limits`; the standalone helpers exist for callers who want a different order, a different metric, or to add their own filters (collision-aware filtering, dexterity scoring, custom seed metrics) between the layers.
+By default `solve()` already runs `wrap_to_limits` + `respect_limits` (and, when `q_seed`/`seed_tolerance`/`seed_metric` are passed, the seed filter + ranking); the standalone helpers exist for callers who want a different order, a different metric, or to add their own filters (collision-aware filtering, dexterity scoring) between the layers.
 
 Out of scope: collision filtering (use FCL or similar at the application layer) and continuous-trajectory smoothness (typically a separate planner concern).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,11 @@ The `solve()` pipeline already applies these by default (when `respect_limits=Tr
       show_root_heading: false
       show_root_full_path: false
 
+::: ssik.postprocess.within_seed_tolerance
+    options:
+      show_root_heading: false
+      show_root_full_path: false
+
 ::: ssik.postprocess.take_first
     options:
       show_root_heading: false

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,10 +65,30 @@ For real-time control / teleop, "give me the IK closest to where I am now":
 ```python
 q_current = np.array([0.0, -0.5, 0.0, 0.7, 0.0, 1.2, 0.0])
 
-# max_solutions=1 + q_seed: visit lock-samples nearest q_current first,
-# short-circuit on the first in-limits branch. ~5-6x faster than full sweep.
+# max_solutions=1 + q_seed: returns the single solution nearest q_current.
+# On 7R jointlock arms the seed also drives the lock-outward fast path
+# (~20x faster than the full sweep).
 sols = franka_panda_ik.solve(T_target, max_solutions=1, q_seed=q_current)
 q_command = sols[0].q if sols else q_current
+```
+
+Two knobs refine what "nearest" means when a seed is given:
+
+```python
+# seed_metric (default "wrap_linf"): rank by the LARGEST single-joint move,
+# so the arm holds its branch instead of flipping. Use "wrap_l2" for
+# summed-distance ranking.
+sols = franka_panda_ik.solve(T_target, q_seed=q_current, seed_metric="wrap_linf")
+
+# seed_tolerance (radians): a HARD bound -- only return solutions where every
+# joint is within the tolerance of the seed. The list may come back EMPTY,
+# which is the signal that smooth continuation isn't possible at this pose
+# (replan / accept a larger jump). Best-effort behaviour when omitted.
+sols = franka_panda_ik.solve(
+    T_target, q_seed=q_current, max_solutions=1, seed_tolerance=np.deg2rad(6)
+)
+if not sols:
+    ...  # no config within 6 deg of q_current -- handle the discontinuity
 ```
 
 ## When `solve()` returns an empty list

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -166,6 +166,7 @@ def _render_thin_wrapper(
     buf.write("from ssik.postprocess import (\n")
     buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
     buf.write("    respect_limits as _ps_respect_limits,\n")
+    buf.write("    within_seed_tolerance as _ps_within_seed_tolerance,\n")
     buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
     buf.write(")\n")
     buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
@@ -239,6 +240,7 @@ def _render_specialised(
     buf.write("from ssik.postprocess import (\n")
     buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
     buf.write("    respect_limits as _ps_respect_limits,\n")
+    buf.write("    within_seed_tolerance as _ps_within_seed_tolerance,\n")
     buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
     buf.write(")\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
@@ -500,6 +502,7 @@ def _render_specialised_solve_orchestrator() -> str:
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
             seed_metric: str = "wrap_linf",
+            seed_tolerance: float | None = None,
         ):
             """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -519,6 +522,12 @@ def _render_specialised_solve_orchestrator() -> str:
                 ``"wrap_l2"`` minimises the summed move (can favour a flip
                 "paid for" by smaller moves elsewhere). Ignored when
                 ``q_seed`` is ``None``.
+            :param seed_tolerance: optional max per-joint deviation from
+                ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+                *every* joint within ``seed_tolerance`` are returned -- a hard
+                tracking guarantee that may return an empty list when no branch
+                qualifies. ``None`` (default) keeps the best-effort behaviour.
+                Requires ``q_seed``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. Pass ``False`` for
                 the raw geometric set (e.g. analysis / debugging).
@@ -547,6 +556,8 @@ def _render_specialised_solve_orchestrator() -> str:
                 closed within ``policy.subproblem_numerical`` (or all
                 IKs were filtered by ``respect_limits=True``).
             """
+            if seed_tolerance is not None and q_seed is None:
+                raise ValueError("seed_tolerance requires q_seed")
             T = np.asarray(T_target, dtype=np.float64)
             candidates = _solve_algebraic(T)
 
@@ -643,6 +654,8 @@ def _render_specialised_solve_orchestrator() -> str:
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
             if max_solutions is not None and len(solutions) > max_solutions:
                 solutions = solutions[:max_solutions]
@@ -874,6 +887,7 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
             seed_metric: str = "wrap_linf",
+            seed_tolerance: float | None = None,
         ):
             """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -895,6 +909,12 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                 wrap-to-pi move, holding the branch during tracking;
                 ``"wrap_l2"`` minimises the summed move. Ignored when
                 ``q_seed`` is ``None``.
+            :param seed_tolerance: optional max per-joint deviation from
+                ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+                *every* joint within ``seed_tolerance`` are returned -- a hard
+                tracking guarantee that may return an empty list when no branch
+                qualifies. ``None`` (default) keeps the best-effort behaviour.
+                Requires ``q_seed``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. Pass ``False``
                 for the raw geometric set.
@@ -926,6 +946,8 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                     T_target, q_seed=q_current, max_solutions=1,
                 )
             """
+            if seed_tolerance is not None and q_seed is None:
+                raise ValueError("seed_tolerance requires q_seed")
             T = np.asarray(T_target, dtype=np.float64)
             # Lock-sweep filters limits in-flight (#238 review): the
             # short-circuit fires on the first in-limits valid IK, not
@@ -1022,6 +1044,10 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                         solutions = _ps_wrap_to_limits(solutions, _KB)
                         solutions = _ps_respect_limits(solutions, _KB)
                     if q_seed is not None:
+                        if seed_tolerance is not None:
+                            solutions = _ps_within_seed_tolerance(
+                                solutions, q_seed, seed_tolerance
+                            )
                         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
             # No orchestrator-level respect_limits pass on the analytical
@@ -1037,6 +1063,8 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             # cap. Without this the cap would keep the nearest *lock samples*,
             # not the nearest *configs*.
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
             if max_solutions is not None and len(solutions) > max_solutions:
                 solutions = solutions[:max_solutions]
@@ -1301,6 +1329,7 @@ def _render_solve_function(solver_short: str) -> str:
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
             seed_metric: str = "wrap_linf",
+            seed_tolerance: float | None = None,
         ):
             \"\"\"Inverse kinematics. Returns ``list[Solution]``.
 
@@ -1315,6 +1344,12 @@ def _render_solve_function(solver_short: str) -> str:
                 ``"wrap_linf"`` (default, largest single-joint move) holds
                 the branch during tracking; ``"wrap_l2"`` uses the summed
                 move. Ignored when ``q_seed`` is ``None``.
+            :param seed_tolerance: optional max per-joint deviation from
+                ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+                *every* joint within ``seed_tolerance`` are returned -- a hard
+                tracking guarantee that may return an empty list when no branch
+                qualifies. ``None`` (default) keeps the best-effort behaviour.
+                Requires ``q_seed``.
             :param respect_limits: when ``True`` (default), solutions
                 outside URDF joint limits are dropped. ``False`` returns
                 the raw geometric set.
@@ -1330,6 +1365,8 @@ def _render_solve_function(solver_short: str) -> str:
 
             Solver: {solver_short}.
             \"\"\"
+            if seed_tolerance is not None and q_seed is None:
+                raise ValueError("seed_tolerance requires q_seed")
             sols, _is_ls = _solver_solve(
                 _KB,
                 T_target,
@@ -1341,6 +1378,8 @@ def _render_solve_function(solver_short: str) -> str:
                 sols = _ps_wrap_to_limits(sols, _KB)
                 sols = _ps_respect_limits(sols, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
                 sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
             if max_solutions is not None and len(sols) > max_solutions:
                 sols = sols[:max_solutions]

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -229,6 +229,7 @@ class Manipulator:
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
+        seed_tolerance: float | None = None,
         **solver_kwargs: Any,
     ) -> list[Solution]: ...
 
@@ -245,6 +246,7 @@ class Manipulator:
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
+        seed_tolerance: float | None = None,
         **solver_kwargs: Any,
     ) -> tuple[list[Solution], Diagnostic]: ...
 
@@ -260,6 +262,7 @@ class Manipulator:
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
+        seed_tolerance: float | None = None,
         **solver_kwargs: Any,
     ) -> list[Solution] | tuple[list[Solution], Diagnostic]:
         """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
@@ -283,6 +286,11 @@ class Manipulator:
             ``"wrap_linf"`` (default) minimises the largest single-joint
             wrap-to-pi move (holds the branch during tracking); ``"wrap_l2"``
             minimises the summed move. Ignored when ``q_seed`` is ``None``.
+        :param seed_tolerance: optional max per-joint deviation from ``q_seed``
+            (radians, wrap-to-pi). When set, only solutions with every joint
+            within ``seed_tolerance`` are returned -- a hard tracking guarantee
+            that may return an empty list. ``None`` (default) keeps the
+            best-effort behaviour. Requires ``q_seed``.
         :param respect_limits: when ``True`` (default), solutions outside
             URDF joint limits are dropped. Pass ``False`` for the raw
             geometric set (analysis / debugging).
@@ -312,11 +320,14 @@ class Manipulator:
         """
         from ssik.postprocess import nearest_to_seed as _ps_nearest_to_seed
         from ssik.postprocess import respect_limits as _ps_respect_limits
+        from ssik.postprocess import within_seed_tolerance as _ps_within_seed_tolerance
         from ssik.postprocess import wrap_to_limits as _ps_wrap_to_limits
 
         T = np.asarray(T_target, dtype=np.float64)
         if T.shape != (4, 4):
             raise ValueError(f"solve expected T_target of shape (4, 4), got {T.shape}")
+        if seed_tolerance is not None and q_seed is None:
+            raise ValueError("seed_tolerance requires q_seed")
         if q_seed is not None:
             q_seed_arr: NDArray[np.float64] | None = np.asarray(q_seed, dtype=np.float64)
             assert q_seed_arr is not None
@@ -370,6 +381,8 @@ class Manipulator:
         else:
             dropped_by_limits = 0
         if q_seed_arr is not None:
+            if seed_tolerance is not None:
+                sols = _ps_within_seed_tolerance(sols, q_seed_arr, seed_tolerance)
             sols = _ps_nearest_to_seed(sols, q_seed_arr, metric=seed_metric)
         if max_solutions is not None and len(sols) > max_solutions:
             dropped_by_max_solutions = len(sols) - max_solutions

--- a/src/ssik/postprocess.py
+++ b/src/ssik/postprocess.py
@@ -12,11 +12,13 @@ seed / collision logic on the Python side).
 
 Each function takes ``list[Solution]`` (and any extra args) and returns
 ``list[Solution]`` -- pure transforms, easy to test, easy to compose.
-The four shipping with v0.1 cover ~95% of real-world post-processing:
+These cover ~95% of real-world post-processing:
 
   * :func:`respect_limits` -- drop solutions outside any joint's range
   * :func:`wrap_to_limits` -- try ``q ± 2*pi`` per joint to bring solutions in
   * :func:`nearest_to_seed` -- sort by wrap-to-pi distance to a reference q
+  * :func:`within_seed_tolerance` -- drop solutions beyond a per-joint
+    deviation from a reference q (hard tracking bound; may return empty)
   * :func:`take_first` -- truncate to the first ``k``
 
 Production pipeline pattern::
@@ -38,7 +40,7 @@ Out of scope for v0.1 (separate issues / future work):
   * Trajectory-context filters (continuous q-trajectory with smoothness).
   * Reachability / dexterity scoring.
 
-These can be follow-ups; the four above cover the common case and form a
+These can be follow-ups; the filters above cover the common case and form a
 self-contained module that compiles cleanly to a single shared ``.so``
 in Phase 4 (no per-arm specialisation, no symbolic precompute).
 """
@@ -57,6 +59,7 @@ __all__ = [
     "nearest_to_seed",
     "respect_limits",
     "take_first",
+    "within_seed_tolerance",
     "wrap_to_limits",
 ]
 
@@ -188,6 +191,39 @@ def nearest_to_seed(
 
     # Python's sort is stable, so ties preserve input order.
     return sorted(sols, key=distance)
+
+
+def within_seed_tolerance(
+    sols: list[Solution],
+    q_seed: NDArray[np.float64],
+    tolerance: float,
+) -> list[Solution]:
+    """Keep only solutions within a per-joint deviation of a reference config.
+
+    A solution passes when *every* joint is within ``tolerance`` of the seed in
+    wrap-to-pi distance -- ``max_i |wrap(q_i - seed_i)| <= tolerance``, the
+    L-infinity (max-joint-move) bound. This is the hard guarantee for
+    trajectory tracking ("no joint jumps more than ``tolerance``"), as opposed
+    to :func:`nearest_to_seed`, which only ranks. The result may be empty when
+    no in-tolerance branch exists -- itself the useful signal that smooth
+    continuation is not possible at this pose. Compose with
+    :func:`nearest_to_seed` + :func:`take_first` to rank and cap the survivors.
+
+    :param sols: candidate solutions.
+    :param q_seed: reference joint configuration (length matches the chain's
+        DOF).
+    :param tolerance: maximum allowed per-joint wrap-to-pi deviation, radians.
+    :returns: the subset of ``sols`` within ``tolerance`` of ``q_seed``, in
+        input order.
+    """
+    seed = np.asarray(q_seed, dtype=np.float64)
+
+    def within(sol: Solution) -> bool:
+        return all(
+            abs(_wrap_to_pi(float(sol.q[i] - seed[i]))) <= tolerance for i in range(len(seed))
+        )
+
+    return [s for s in sols if within(s)]
 
 
 def take_first(sols: list[Solution], k: int) -> list[Solution]:

--- a/src/ssik/prebuilt/big_yam_ik.py
+++ b/src/ssik/prebuilt/big_yam_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -959,6 +960,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -978,6 +980,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1006,6 +1014,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1102,6 +1112,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/fanuc_crx10ial_ik.py
+++ b/src/ssik/prebuilt/fanuc_crx10ial_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -916,6 +917,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -935,6 +937,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -963,6 +971,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1059,6 +1069,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/fr3_ik.py
+++ b/src/ssik/prebuilt/fr3_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -434,6 +435,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -455,6 +457,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -486,6 +494,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -582,6 +592,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -597,6 +611,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/franka_panda_ik.py
+++ b/src/ssik/prebuilt/franka_panda_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -434,6 +435,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -455,6 +457,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -486,6 +494,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -582,6 +592,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -597,6 +611,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/gen3_ik.py
+++ b/src/ssik/prebuilt/gen3_ik.py
@@ -46,6 +46,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.solvers.seven_r.srs_polished import solve as _solver_solve
@@ -160,6 +161,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -174,6 +176,12 @@ def solve(
         ``"wrap_linf"`` (default, largest single-joint move) holds
         the branch during tracking; ``"wrap_l2"`` uses the summed
         move. Ignored when ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. ``False`` returns
         the raw geometric set.
@@ -189,6 +197,8 @@ def solve(
 
     Solver: srs_polished.
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -200,6 +210,8 @@ def solve(
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
         sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
     if max_solutions is not None and len(sols) > max_solutions:
         sols = sols[:max_solutions]

--- a/src/ssik/prebuilt/iiwa14_ik.py
+++ b/src/ssik/prebuilt/iiwa14_ik.py
@@ -46,6 +46,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.solvers.seven_r.srs import solve as _solver_solve
@@ -160,6 +161,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -174,6 +176,12 @@ def solve(
         ``"wrap_linf"`` (default, largest single-joint move) holds
         the branch during tracking; ``"wrap_l2"`` uses the summed
         move. Ignored when ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. ``False`` returns
         the raw geometric set.
@@ -189,6 +197,8 @@ def solve(
 
     Solver: srs.
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -200,6 +210,8 @@ def solve(
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
         sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
     if max_solutions is not None and len(sols) > max_solutions:
         sols = sols[:max_solutions]

--- a/src/ssik/prebuilt/jaco2_ik.py
+++ b/src/ssik/prebuilt/jaco2_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -884,6 +885,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -903,6 +905,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -931,6 +939,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1027,6 +1037,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/kassow_kr810_ik.py
+++ b/src/ssik/prebuilt/kassow_kr810_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -807,6 +808,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -828,6 +830,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -859,6 +867,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -955,6 +965,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -970,6 +984,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/openarm_left_ik.py
+++ b/src/ssik/prebuilt/openarm_left_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -434,6 +435,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -455,6 +457,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -486,6 +494,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -582,6 +592,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -597,6 +611,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/openarm_right_ik.py
+++ b/src/ssik/prebuilt/openarm_right_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -434,6 +435,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -455,6 +457,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -486,6 +494,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -582,6 +592,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -597,6 +611,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/piper_ik.py
+++ b/src/ssik/prebuilt/piper_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -933,6 +934,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -952,6 +954,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -980,6 +988,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1076,6 +1086,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/puma560_ik.py
+++ b/src/ssik/prebuilt/puma560_ik.py
@@ -55,6 +55,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -539,6 +540,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -558,6 +560,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -586,6 +594,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -682,6 +692,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/rizon10_ik.py
+++ b/src/ssik/prebuilt/rizon10_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -807,6 +808,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -828,6 +830,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -859,6 +867,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -955,6 +965,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -970,6 +984,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/rizon4_ik.py
+++ b/src/ssik/prebuilt/rizon4_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -807,6 +808,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -828,6 +830,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -859,6 +867,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -955,6 +965,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -970,6 +984,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -56,6 +56,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -476,6 +477,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -495,6 +497,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -523,6 +531,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -619,6 +629,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/xarm6_ik.py
+++ b/src/ssik/prebuilt/xarm6_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -928,6 +929,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -947,6 +949,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -975,6 +983,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1071,6 +1081,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/xarm7_ik.py
+++ b/src/ssik/prebuilt/xarm7_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -434,6 +435,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -455,6 +457,12 @@ def solve(
         wrap-to-pi move, holding the branch during tracking;
         ``"wrap_l2"`` minimises the summed move. Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False``
         for the raw geometric set.
@@ -486,6 +494,8 @@ def solve(
             T_target, q_seed=q_current, max_solutions=1,
         )
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     # Lock-sweep filters limits in-flight (#238 review): the
     # short-circuit fires on the first in-limits valid IK, not
@@ -582,6 +592,10 @@ def solve(
                 solutions = _ps_wrap_to_limits(solutions, _KB)
                 solutions = _ps_respect_limits(solutions, _KB)
             if q_seed is not None:
+                if seed_tolerance is not None:
+                    solutions = _ps_within_seed_tolerance(
+                        solutions, q_seed, seed_tolerance
+                    )
                 solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
 
     # No orchestrator-level respect_limits pass on the analytical
@@ -597,6 +611,8 @@ def solve(
     # cap. Without this the cap would keep the nearest *lock samples*,
     # not the nearest *configs*.
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/yam_ik.py
+++ b/src/ssik/prebuilt/yam_ik.py
@@ -60,6 +60,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -1016,6 +1017,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -1035,6 +1037,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -1063,6 +1071,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -1159,6 +1169,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/src/ssik/prebuilt/z1_ik.py
+++ b/src/ssik/prebuilt/z1_ik.py
@@ -56,6 +56,7 @@ from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_pe
 from ssik.postprocess import (
     nearest_to_seed as _ps_nearest_to_seed,
     respect_limits as _ps_respect_limits,
+    within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
@@ -466,6 +467,7 @@ def solve(
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -485,6 +487,12 @@ def solve(
         ``"wrap_l2"`` minimises the summed move (can favour a flip
         "paid for" by smaller moves elsewhere). Ignored when
         ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
     :param respect_limits: when ``True`` (default), solutions
         outside URDF joint limits are dropped. Pass ``False`` for
         the raw geometric set (e.g. analysis / debugging).
@@ -513,6 +521,8 @@ def solve(
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
@@ -609,6 +619,8 @@ def solve(
         solutions = _ps_wrap_to_limits(solutions, _KB)
         solutions = _ps_respect_limits(solutions, _KB)
     if q_seed is not None:
+        if seed_tolerance is not None:
+            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
         solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
     if max_solutions is not None and len(solutions) > max_solutions:
         solutions = solutions[:max_solutions]

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -25,6 +25,7 @@ from ssik.postprocess import (
     nearest_to_seed,
     respect_limits,
     take_first,
+    within_seed_tolerance,
     wrap_to_limits,
 )
 
@@ -233,6 +234,43 @@ def test_nearest_to_seed_unknown_metric_raises() -> None:
     seed = np.array([0.0])
     with pytest.raises(ValueError, match="unknown metric"):
         nearest_to_seed(sols, seed, metric="manhattan")
+
+
+def test_within_seed_tolerance_keeps_in_bound() -> None:
+    sols = [_sol([0.05, -0.05]), _sol([0.2, 0.0]), _sol([0.0, 0.0])]
+    seed = np.array([0.0, 0.0])
+    out = within_seed_tolerance(sols, seed, 0.1)
+    # [0.05,-0.05] (max 0.05) and [0,0] pass; [0.2,0] (max 0.2) is dropped.
+    assert [s.q.tolist() for s in out] == [[0.05, -0.05], [0.0, 0.0]]
+
+
+def test_within_seed_tolerance_is_per_joint_linf() -> None:
+    """A small summed move can still exceed the per-joint cap on one joint."""
+    sols = [_sol([0.09, 0.09]), _sol([0.15, 0.0])]
+    seed = np.array([0.0, 0.0])
+    out = within_seed_tolerance(sols, seed, 0.1)
+    # [0.09,0.09] passes (each joint <= 0.1); [0.15,0] fails (joint 0 = 0.15).
+    assert [s.q.tolist() for s in out] == [[0.09, 0.09]]
+
+
+def test_within_seed_tolerance_uses_wrap() -> None:
+    """q=3.1 vs seed=-3.1 is a ~0.08 wrap move, well within tolerance."""
+    sols = [_sol([3.1]), _sol([0.2])]
+    seed = np.array([-3.1])
+    out = within_seed_tolerance(sols, seed, 0.1)
+    assert [s.q.tolist() for s in out] == [[3.1]]
+
+
+def test_within_seed_tolerance_just_inside_and_outside() -> None:
+    seed = np.array([0.0])
+    assert len(within_seed_tolerance([_sol([0.099])], seed, 0.1)) == 1
+    assert len(within_seed_tolerance([_sol([0.101])], seed, 0.1)) == 0
+
+
+def test_within_seed_tolerance_can_return_empty() -> None:
+    sols = [_sol([0.5]), _sol([-0.5])]
+    seed = np.array([0.0])
+    assert within_seed_tolerance(sols, seed, 0.1) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_seeded_nearest_tracking.py
+++ b/tests/test_seeded_nearest_tracking.py
@@ -184,3 +184,89 @@ def test_jointlock_seeded_dispatches_fewer_than_exhaustive(franka_kb: KinBody) -
     assert seeded_dispatches < exhaustive_dispatches, (
         f"seeded {seeded_dispatches} not < exhaustive {exhaustive_dispatches}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #333 -- seed_tolerance: hard per-joint deviation bound (postprocess filter).
+# ---------------------------------------------------------------------------
+
+_TRACK_SEED = np.array([0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5])
+
+
+def test_seed_tolerance_requires_q_seed() -> None:
+    from ssik.prebuilt import franka_panda_ik
+
+    T = franka_panda_ik.fk(np.zeros(7))
+    with pytest.raises(ValueError, match="seed_tolerance requires q_seed"):
+        franka_panda_ik.solve(T, seed_tolerance=0.1)
+
+
+def test_seed_tolerance_manipulator_requires_q_seed() -> None:
+    arm = ssik.Manipulator.from_urdf(
+        FIXTURES / "franka_panda.urdf", base="panda_link0", ee="panda_link8"
+    )
+    with pytest.raises(ValueError, match="seed_tolerance requires q_seed"):
+        arm.solve(arm.fk(np.zeros(7)), seed_tolerance=0.1)
+
+
+def test_seed_tolerance_returned_solutions_respect_bound() -> None:
+    """The guarantee: every returned solution is within the per-joint bound.
+
+    Seeding at an actual solution (deviation 0 from itself) keeps the set
+    non-empty, so the bound check is never vacuous.
+    """
+    from ssik.prebuilt import franka_panda_ik
+
+    rng = np.random.default_rng(0)
+    tol = np.deg2rad(6)
+    checked = 0
+    for _ in range(100):
+        q = rng.uniform(-1.5, 1.5, size=7)
+        T = franka_panda_ik.fk(q)
+        any_sols = franka_panda_ik.solve(T, respect_limits=False)
+        if not any_sols:
+            continue
+        seed = np.asarray(any_sols[0].q)
+        sols = franka_panda_ik.solve(T, q_seed=seed, seed_tolerance=tol, respect_limits=False)
+        assert sols, "seeding at an actual solution must keep at least itself"
+        for s in sols:
+            assert np.abs(_wrap(np.asarray(s.q) - seed)).max() <= tol + 1e-9
+            checked += 1
+    assert checked > 0
+
+
+def test_seed_tolerance_large_keeps_all_zero_keeps_none() -> None:
+    from ssik.prebuilt import franka_panda_ik
+
+    T = franka_panda_ik.fk(_TRACK_SEED)
+    base = franka_panda_ik.solve(T, q_seed=_TRACK_SEED, respect_limits=False)
+    huge = franka_panda_ik.solve(T, q_seed=_TRACK_SEED, seed_tolerance=10.0, respect_limits=False)
+    assert {tuple(np.round(s.q, 9)) for s in huge} == {tuple(np.round(s.q, 9)) for s in base}
+    # max wrap-to-pi deviation is always <= pi, so 10 rad keeps everything.
+    zero = franka_panda_ik.solve(T, q_seed=_TRACK_SEED, seed_tolerance=0.0, respect_limits=False)
+    assert zero == []
+
+
+def test_seed_tolerance_none_matches_no_tolerance() -> None:
+    from ssik.prebuilt import franka_panda_ik
+
+    T = franka_panda_ik.fk(_TRACK_SEED)
+    a = franka_panda_ik.solve(T, q_seed=_TRACK_SEED, max_solutions=1, respect_limits=False)
+    b = franka_panda_ik.solve(
+        T, q_seed=_TRACK_SEED, max_solutions=1, seed_tolerance=None, respect_limits=False
+    )
+    assert [tuple(np.round(s.q, 12)) for s in a] == [tuple(np.round(s.q, 12)) for s in b]
+
+
+def test_seed_tolerance_manipulator_honors_bound() -> None:
+    arm = ssik.Manipulator.from_urdf(
+        FIXTURES / "franka_panda.urdf", base="panda_link0", ee="panda_link8"
+    )
+    T = arm.fk(_TRACK_SEED)
+    any_sols = arm.solve(T, respect_limits=False)
+    seed = np.asarray(any_sols[0].q)
+    tol = np.deg2rad(6)
+    sols = arm.solve(T, q_seed=seed, seed_tolerance=tol, respect_limits=False)
+    assert sols
+    for s in sols:
+        assert np.abs(_wrap(np.asarray(s.q) - seed)).max() <= tol + 1e-9


### PR DESCRIPTION
Closes #333.

## What

Adds a **hard tracking guarantee** on top of `q_seed`: `solve(T, q_seed=q, seed_tolerance=tau)` returns only solutions whose *every* joint is within `tau` of the seed (per-joint wrap-to-pi L∞), and the list may come back **empty** — the signal that smooth continuation isn't possible at this pose (replan / accept a jump).

```python
sols = arm.solve(T, q_seed=q_current, max_solutions=1, seed_tolerance=np.deg2rad(6))
q_cmd = sols[0].q if sols else replan()   # empty ⇒ discontinuity
```

- `seed_tolerance=None` (default) ⇒ **exactly today's best-effort behaviour** (no filtering).
- `seed_tolerance` without `q_seed` ⇒ `ValueError`.
- Plumbed through the artifact `solve()` (6R/7R/thin orchestrators) and `Manipulator.solve`, like `seed_metric`.

## Implementation — postprocess filter only (the #333 scope)

New `ssik.postprocess.within_seed_tolerance(sols, q_seed, tol)`, applied **filter → rank → cap**:

```
solve → (limits) → within_seed_tolerance(tol) → nearest_to_seed(metric) → take max_solutions
```

No online/in-search pruning. That was considered and explicitly deferred: pruning the search by tolerance could early-exit before gathering enough in-tolerance solutions and **break the `max_solutions` guarantee**. The cap runs *last*, so truncation only ever discards in-tolerance solutions beyond what was asked for.

**7R composition.** The filter sits cleanly on top of the #331 lock-outward path: the nearest lock slice is collected in full before any cap, and at tracking tolerances (≤ half the ~22° lock-grid spacing) *all* in-tolerance solutions live in that single slice — so the filter sees the complete set and returns `min(#in-tolerance, max_solutions)`. Under-return happens only when that many genuinely don't exist, never from pruning.

## Measured (steady tracking @ 6°)

| arm | in-tolerance | median step |
|---|---|---|
| Franka | 299/300 | 0.3° |
| Kassow | 300/300 | 0.3° |

So the existing 16-sample lock grid is plenty for the common case; a denser grid / continuous-redundancy "exact-tolerance" mode stays an out-of-scope follow-up (noted in #333), to be revisited only if a workload shows a high empty-rate.

## Docs

- `quickstart.md` + `README.md` trajectory-tracking sections now document both `seed_metric` (default `wrap_linf`) and `seed_tolerance`.
- `api.md` lists `within_seed_tolerance` in the postprocess reference.

## Tests

- `within_seed_tolerance` unit tests (per-joint L∞, wrap-to-pi, just-inside/outside, can-return-empty).
- Plumb-through on the franka artifact + `Manipulator`: the bound holds on every returned solution; large tolerance keeps all / zero keeps none; `seed_tolerance=None` matches no-tolerance; `ValueError` without `q_seed`.
- Regenerated all 19 prebuilt artifacts; `test_artifact_snapshots` byte-parity holds.

## Validation

Full suite green (1474 passed) except 3 pre-existing flakes unrelated to this change (verified on clean tree: SP5 #324, ikgeo-spherical, EAIK-cross-check); the one perf-gate blip (`test_ik_overhead_under_300us`) was load-induced during the 12-min run and passes 3/3 in isolation. ruff + mypy clean.