### PR TITLE
sp5: return [] on infeasibility instead of a non-satisfying best-LS (#324)

### DIFF
--- a/src/ssik/subproblems/sp5.py
+++ b/src/ssik/subproblems/sp5.py
@@ -26,9 +26,11 @@ of a 2x2 quadratic-circle system, and ``theta2`` via :func:`sp1.solve`.
 3. *Post-verification against the original equation*. Every candidate
    residual is checked; candidates above ``subproblem_numerical`` are
    dropped.
-4. *Best-LS return on infeasibility*. If no candidate passes post-verify
-   but the algorithm produced candidates, return the minimum-residual one
-   with ``is_ls=True`` (consistent with SP1-SP4's LS semantics).
+4. *Empty return on infeasibility* (issue #324). If no candidate satisfies
+   the defining equation, return ``([], True)``. The equation is genuinely
+   infeasible for some inputs (cone ranges that don't overlap), so unlike
+   SP1-SP4 -- where the closest rotation always exists -- there is no useful
+   "nearest" triple to hand back; post-verification is the only gate.
 5. *Deduplication*. Near-duplicate solutions (angle-wise within
    ``subproblem_numerical``) are collapsed.
 
@@ -149,9 +151,9 @@ def solve(
     :returns: ``(solutions, is_ls)``. On exact feasibility, ``solutions``
         has 1 to 4 deduplicated triples that satisfy the defining equation
         within ``subproblem_numerical`` and ``is_ls`` is ``False``. On
-        infeasibility or degeneracy, ``solutions`` has at most 1 best-LS
-        triple (or is empty if no candidate was even generated) and
-        ``is_ls`` is ``True``.
+        infeasibility or degeneracy, ``solutions`` is empty and ``is_ls`` is
+        ``True`` -- every returned triple is guaranteed to satisfy the
+        equation (issue #324).
     """
     for name, v in (
         ("p0", p0),
@@ -278,13 +280,18 @@ def solve(
         solutions = _dedup(exact, policy.subproblem_dedup)
         return solutions, False
 
-    # No exact solution survived. Return best-LS if we have any candidate
-    # at all; otherwise signal total infeasibility.
-    if not refined:
-        return [], True
-
-    best = min(refined, key=residual)
-    return [best], True
+    # No candidate satisfies the defining equation. Post-verification is the
+    # single correctness gate (issue #324): return no solution with
+    # ``is_ls=True`` rather than a best-LS triple that fails the equation.
+    # SP5's defining equation is genuinely infeasible for some inputs (e.g.
+    # ``|p0 + Rot(k1,t1)p1| = |p1|`` can never equal ``|p2 + Rot(k3,t3)p3|``
+    # when their ranges don't overlap), and a far-off "nearest" triple is not
+    # a usable partial IK -- both callers fill non-existent branches with inf /
+    # drop them, and the outer FK-closure gate would discard it anyway. Valid
+    # solutions reach machine precision via the Gauss-Newton refinement above,
+    # so this branch no longer drops near-valid solutions (the original #55
+    # completeness concern that motivated the best-LS fallback).
+    return [], True
 
 
 @cython.ccall

--- a/tests/test_sp56_adversarial.py
+++ b/tests/test_sp56_adversarial.py
@@ -61,6 +61,31 @@ def _sp5_adversarial(draw: st.DrawFn) -> tuple[np.ndarray, ...]:
     return p0, p1, p2, p3, k1, k2, k3
 
 
+def test_sp5_infeasible_returns_empty_not_best_ls() -> None:
+    """Regression for #324: a norm-infeasible SP5 returns ``([], True)``, not a
+    far-off best-LS triple.
+
+    Here ``|p0 + Rot(k1,t1)p1| = |p1| = 1`` always, but
+    ``|p2 + Rot(k3,t3)p3| in [1.5, 2.5]``, so the equation can never hold. SP5
+    used to hand back the minimum-residual triple (residual ~0.5) which failed
+    the defining equation; post-verify is now the single gate. (The Hypothesis
+    example that found this had a near-parallel k2, but the cause is
+    infeasibility, not degeneracy -- the degeneracy guard correctly does not
+    fire.)
+    """
+    p0 = np.array([0.0, 0.0, 0.0])
+    p1 = np.array([0.0, 1.0, 0.0])
+    p2 = np.array([2.0, 0.0, 0.0])
+    p3 = np.array([0.0, 0.5, 0.0])
+    k1 = np.array([0.0, 0.0, 1.0])
+    k2 = np.array([0.0, 6.10e-05, 0.99999998])
+    k2 = k2 / np.linalg.norm(k2)
+    k3 = np.array([0.0, 0.0, 1.0])
+    solutions, is_ls = sp5.solve(p0, p1, p2, p3, k1, k2, k3)
+    assert solutions == []
+    assert is_ls is True
+
+
 @given(_sp5_adversarial())
 @settings(
     max_examples=300,


### PR DESCRIPTION
Closes #324.

## Root cause (it's infeasibility, not degeneracy)

The Hypothesis falsifying example has SP5 returning a triple that fails the defining equation by ~0.5. The issue framed it as a near-parallel-`k2` **degeneracy**, but that's incidental — the degeneracy guard correctly does *not* fire (`k1×k2² = 3.7e-9 > 1e-12`). The real cause is that the input is **genuinely infeasible**:

- `|p0 + Rot(k1,t1)·p1| = |p1| = 1` for all `t1`
- `|p2 + Rot(k3,t3)·p3| ∈ [1.5, 2.5]` for all `t3`

The two sides are rotations of vectors with non-overlapping norm ranges, so the equation can never hold. SP5 was returning the minimum-residual triple as a best-LS (`is_ls=True`, residual 0.5 = the true geometric gap). A non-degenerate orthogonal-axis case with the same norm mismatch reproduces it too — confirming infeasibility, not conditioning.

## Fix

Post-verification is now the **single** correctness gate. When no candidate satisfies the equation within `subproblem_numerical`, SP5 returns `([], True)` instead of a best-LS triple that fails it. Unlike SP1–SP4 (where the closest rotation always exists), SP5's equation is genuinely infeasible for some inputs, so there's no useful "nearest" triple to hand back.

### Why this is safe (no completeness regression)

- **Callers** (`spherical`, `two_intersecting`) already ignore `is_ls` and consume the list; both handle an empty list correctly — `two_intersecting` fills non-existent branches with `inf` and the 1-D search skips them, so returning `[]` *removes* spurious candidates rather than dropping valid ones. The outer FK-closure gate would have discarded the bad triple anyway.
- The Gauss-Newton refinement added for #55 drives valid solutions to machine precision, so the best-LS fallback no longer protects any completeness.
- **Verified**: no regression across SP5 unit tests, Puma 500-pose cross-validation, and the full prebuilt fuzz (the only fuzz xfails are the pre-existing z1 #288 / gen3 #299 gaps).

## Tests

- New deterministic regression `test_sp5_infeasible_returns_empty_not_best_ls` (the #324 case → `([], True)`).
- The Hypothesis `test_sp5_returned_solutions_always_satisfy_equation` now passes (empty list ⇒ nothing to violate).

ruff + mypy clean. `sp5.c` is a gitignored build artifact regenerated from `sp5.py` at wheel-build time, so no committed codegen to update.

## Note

This is subproblem-internal (private per the semver policy); no public API change. There's a separate, pre-existing `test_ikgeo_spherical::test_random_q_roundtrip_fk` Hypothesis failure (same `q*` on clean `main`) that is **unrelated** to this fix — I'll file/triage it separately.