### PR TITLE
Manipulator: rescue + cold-coverage warning for from_urdf 7R (#328)

### DIFF
--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -77,7 +78,7 @@ class Manipulator:
         loader). Most users should use :meth:`from_urdf` instead.
     """
 
-    __slots__ = ("_kb", "_plan", "_solver_module")
+    __slots__ = ("_kb", "_plan", "_solver_module", "_warned_cold_coverage")
 
     def __init__(
         self,
@@ -97,6 +98,8 @@ class Manipulator:
         self._solver_module: ModuleType = importlib.import_module(
             _SOLVER_MODULE_PATHS[self._plan.solver_name]
         )
+        # Guards the one-time cold-coverage warning (#328).
+        self._warned_cold_coverage: bool = False
 
     # ------------------------------------------------------------------
     # Factories
@@ -230,6 +233,7 @@ class Manipulator:
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
         seed_tolerance: float | None = None,
+        allow_rescue: bool = True,
         **solver_kwargs: Any,
     ) -> list[Solution]: ...
 
@@ -247,6 +251,7 @@ class Manipulator:
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
         seed_tolerance: float | None = None,
+        allow_rescue: bool = True,
         **solver_kwargs: Any,
     ) -> tuple[list[Solution], Diagnostic]: ...
 
@@ -263,6 +268,7 @@ class Manipulator:
         refinement_max_iters: int = 15,
         seed_metric: str = "wrap_linf",
         seed_tolerance: float | None = None,
+        allow_rescue: bool = True,
         **solver_kwargs: Any,
     ) -> list[Solution] | tuple[list[Solution], Diagnostic]:
         """Inverse kinematics: find every ``q`` such that ``fk(q) ≈ T_target``.
@@ -299,6 +305,13 @@ class Manipulator:
             path is already at machine precision on tier-0 / SRS arms.
             Set ``True`` on tier-2 RR arms to recover edge-case
             candidates whose algebraic FK drifts above ``fk_atol``.
+        :param allow_rescue: when ``True`` (default), if the analytical
+            path returns no solutions for a target within the arm's reach
+            (a measure-zero rank-deficient ridge), recover the IK via the
+            T-perturbation rescue (#319) -- matching the baked ``ssik build``
+            artifact's coverage so ``from_urdf`` isn't a worse "try before
+            you build" path (#328). Set ``False`` for a guaranteed
+            analytical-only result.
         :param policy: tolerance policy. Rarely customised. Defaults to
             :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
         :param refinement_max_iters: cap on Newton iterations per candidate
@@ -360,10 +373,53 @@ class Manipulator:
         # Power-user kwargs override our defaults.
         kwargs.update(solver_kwargs)
 
+        # One-time coverage warning (#328): the cold jointlock-7R path (no
+        # build-time cached-RR prime) dispatches non-tier-0 inner sub-chains to
+        # the universal Husty-Pfurner solver, which has coverage gaps the baked
+        # ``ssik build`` artifact's cached-RR derivations don't. The
+        # T-perturbation rescue below recovers many such poses, but for arms
+        # whose cold path is broadly gappy it can't fully match the prebuilt --
+        # so surface the difference rather than let it be silent.
+        if self._plan.solver_name == "jointlock.seven_r" and not self._warned_cold_coverage:
+            self._warned_cold_coverage = True
+            warnings.warn(
+                f"{self._plan.solver_name}: solving this 7R arm from a URDF uses the "
+                "universal Husty-Pfurner inner solver, which can have reduced coverage "
+                "(and is slower) vs the cached-RR artifact from `ssik build`. For full "
+                "coverage and speed, build the per-arm artifact once.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Internal solver functions still return (sols, is_ls); unwrap the
         # tuple at the public-API boundary. `is_ls` is redundant with
         # `len(sols) == 0` in every shipped solver -- ssik #238 item 1.
         sols, _is_ls = self._solver_module.solve(self._kb, T, **kwargs)
+
+        # Bulletproof rescue (#319 / #328): when the analytical path returns
+        # nothing for a target within the arm's reach, recover the IK via the
+        # T-perturbation rescue -- the same runtime layer the baked ``ssik
+        # build`` artifacts apply. Without this, ``from_urdf(...).solve(T)``
+        # silently has worse coverage than the prebuilt at measure-zero
+        # rank-deficient ridges. Gated by the reach-sphere (triangle-inequality
+        # upper bound on ``|T_pos|``) so far-field unreachable targets stay
+        # cheap. ``allow_rescue=False`` is the guaranteed-analytical escape.
+        if not sols and allow_rescue:
+            reach_radius = sum(
+                float(np.linalg.norm(j.T_left[:3, 3])) + float(np.linalg.norm(j.T_right[:3, 3]))
+                for j in self._kb.joints
+            )
+            if float(np.linalg.norm(T[:3, 3])) <= reach_radius:
+                from ssik.refinement.rescue import rescue_via_T_perturbation
+
+                def _analytic(T_pert: NDArray[np.float64], **rescue_kwargs: Any) -> list[Solution]:
+                    inner: dict[str, Any] = {"policy": policy}
+                    inner.update({k: v for k, v in rescue_kwargs.items() if k in params})
+                    inner_sols, _ = self._solver_module.solve(self._kb, T_pert, **inner)
+                    return list(inner_sols)
+
+                sols = rescue_via_T_perturbation(self.fk, _analytic, T, jacobian_fn=None)
+
         raw_candidate_count = len(sols)
 
         # Cross-arm postprocess pass: solvers that didn't honour kwargs

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -358,3 +358,44 @@ def test_ik_overhead_under_300us() -> None:
         f"Manipulator.solve overhead {overhead:.1f} us > 300 us regression gate "
         f"(manip={manip_per * 1e6:.1f} us, raw={raw_per * 1e6:.1f} us)"
     )
+
+
+# ---------------------------------------------------------------------------
+# #328: from_urdf cold-path coverage parity (rescue) + discoverability (warn).
+# ---------------------------------------------------------------------------
+
+
+def test_from_urdf_jointlock_solves_ridge_via_rescue() -> None:
+    """A rank-deficient ridge pose that the analytical path misses is recovered
+    by the T-perturbation rescue, so ``from_urdf`` matches the baked artifact's
+    coverage instead of silently returning [] (#328)."""
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
+    q = np.array([0.0, 1.0, -2.0, 0.375, -2.0, 1.0, 0.0])  # rizon4 #304 ridge
+    T = arm.fk(q)
+    rescued = arm.solve(T, respect_limits=False)
+    assert rescued, "ridge pose should be recovered via rescue"
+    for s in rescued:
+        T_fk = poe_forward_kinematics(arm.kinbody, np.asarray(s.q))
+        assert np.allclose(T_fk, T, atol=1e-6), (
+            f"rescued solution FK off by {np.abs(T_fk - T).max():.1e}"
+        )
+    # Rescue never reduces the analytical result.
+    analytic = arm.solve(T, respect_limits=False, allow_rescue=False)
+    assert len(rescued) >= len(analytic)
+
+
+def test_from_urdf_jointlock_warns_once_about_cold_coverage() -> None:
+    """The cold jointlock-7R path warns once that coverage/speed differ from the
+    baked artifact, so the difference is discoverable rather than silent (#328)."""
+    import warnings
+
+    arm = ssik.Manipulator.from_urdf(FIXTURES / "rizon4.urdf", base="base_link", ee="flange")
+    T = arm.fk(np.zeros(7))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        arm.solve(T)
+        arm.solve(T)  # second call must NOT repeat the warning
+    cold = [
+        w for w in caught if issubclass(w.category, UserWarning) and "ssik build" in str(w.message)
+    ]
+    assert len(cold) == 1, f"expected exactly one cold-coverage warning, got {len(cold)}"


### PR DESCRIPTION
Closes #328.

## The trap

`Manipulator.from_urdf(...).solve(T)` could return `[]` (or far fewer branches) for poses the baked `ssik build` artifact solves perfectly — a silent "try before you build" coverage trap. The cached-RR fast path is only primed at build time; the cold URDF path falls back to the universal Husty-Pfurner inner solver, which has coverage gaps.

## What I found (the gap is arm-dependent)

Importing a prebuilt primes the RR cache process-globally, which masks the gap — so I measured in clean processes:

| arm | cold @ ridge | cold @ random | rescue |
|---|---|---|---|
| **rizon4** | 0 (gap only at ridge) | 0/10 empty | **recovers 24, FK 2.6e-9** ✓ |
| **kassow** | 0 | 2/10 empty (HP gappy *everywhere*) | can't escape the gap ✗ |

The headline gap is the **missing rescue**: the baked artifact's orchestrator bakes the #319 T-perturbation rescue; `Manipulator.solve` called the solver module directly and skipped it.

## Fix (the design agreed on #328)

**1. Wire the rescue into `Manipulator.solve`** — the same runtime layer the baked artifact uses. When the analytical path returns `[]` for a target within the **reach-sphere** (triangle-inequality bound on `|T_pos|`, from the chain's joint transforms), recover via perturbation + LM polish. New `allow_rescue: bool = True` kwarg (matches the artifact API); `allow_rescue=False` is the analytical-only escape. Far-field unreachable stays fast via the gate.

**2. One-time cold-coverage warning** — for arms whose cold inner is broadly gappy (Kassow's HP fails ~20% of *random* poses, so its gap covers the ridge neighbourhood and the rescue's small perturbations can't escape it), nothing short of priming the cached-RR matches the baked artifact. So emit a one-time `UserWarning` on the cold jointlock-7R path pointing to `ssik build` — making the difference **discoverable** rather than silent.

## Tests

- `test_from_urdf_jointlock_solves_ridge_via_rescue`: the rizon4 #304 ridge is recovered, every solution FK-closes (1e-6), and rescue never reduces the analytical count.
- `test_from_urdf_jointlock_warns_once_about_cold_coverage`: the warning fires exactly once per Manipulator.

No `filterwarnings = error` in CI, so the (intended) warning on existing 7R `from_urdf` tests is output-only, not a failure. ruff + mypy clean.

## Note

This is the runtime/`from_urdf` path only — no artifact regen. The rescue uses a numerical Jacobian (`jacobian_fn=None`), ~2.5 s when it fires (the rare cold-ridge case in the non-production "try before build" path); a POE spatial Jacobian for `KinBody` would speed it up and is a reasonable follow-up if profiled.