### PR TITLE
sp5: reject spurious near-double-root candidates via tighter post-verify (#337)

### DIFF
--- a/src/ssik/core/tolerances.py
+++ b/src/ssik/core/tolerances.py
@@ -54,6 +54,15 @@ class TolerancePolicy:
             produced by quartic / ellipse root-finding inside SP5 and SP6.
             Unit-circle closure is checked to this tolerance; returned
             solutions that fail are dropped.
+        subproblem_postverify: tighter closure gate for SP5's *refined*
+            candidates. Gauss-Newton refinement drives every genuine SP5
+            solution to machine precision (measured <= 6e-16 over ~3e5 calls),
+            so a refined candidate still above this threshold is a spurious
+            near-double-quartic-root least-squares point (a non-zero local
+            minimum, FK ~1e-6), not an IK solution -- it is dropped (#337 /
+            #159). Far above genuine residuals yet well below
+            ``subproblem_numerical`` (the artifact's FK-closure gate, which
+            this must not loosen); default ``1e-9``.
         subproblem_degeneracy: rank / collinearity threshold. A QR leading
             coefficient or sin-of-angle-between-axes below this value
             marks the input as degenerate and SP6/aux return
@@ -71,6 +80,7 @@ class TolerancePolicy:
     axis_intersect: float = 1e-8
     subproblem_feasibility: float = 1e-9
     subproblem_numerical: float = 1e-5
+    subproblem_postverify: float = 1e-9
     subproblem_degeneracy: float = 1e-12
     subproblem_dedup: float = 1e-3
 

--- a/src/ssik/subproblems/sp5.py
+++ b/src/ssik/subproblems/sp5.py
@@ -24,7 +24,7 @@ of a 2x2 quadratic-circle system, and ``theta2`` via :func:`sp1.solve`.
    the single correctness gate; no valid solution can be dropped by a
    heuristic filter.
 3. *Post-verification against the original equation*. Every candidate
-   residual is checked; candidates above ``subproblem_numerical`` are
+   residual is checked; candidates above ``subproblem_postverify`` are
    dropped.
 4. *Empty return on infeasibility* (issue #324). If no candidate satisfies
    the defining equation, return ``([], True)``. The equation is genuinely
@@ -150,7 +150,7 @@ def solve(
         which stage.
     :returns: ``(solutions, is_ls)``. On exact feasibility, ``solutions``
         has 1 to 4 deduplicated triples that satisfy the defining equation
-        within ``subproblem_numerical`` and ``is_ls`` is ``False``. On
+        within ``subproblem_postverify`` and ``is_ls`` is ``False``. On
         infeasibility or degeneracy, ``solutions`` is empty and ``is_ls`` is
         ``True`` -- every returned triple is guaranteed to satisfy the
         equation (issue #324).
@@ -166,7 +166,6 @@ def solve(
     ):
         validate_vec3(v, name)
 
-    num_tol = policy.subproblem_numerical
     deg_tol = policy.subproblem_degeneracy
 
     if _degenerate(p1, p3, k1, k2, k3, deg_tol):
@@ -273,8 +272,12 @@ def solve(
         t1, t2, t3 = _refine_sp5(cand[0], cand[1], cand[2], p0, p1, p2, p3, k1, k2, k3)
         refined.append((t1, t2, t3))
 
-    # Post-verify against the SP5 equation.
-    exact = [cand for cand in refined if residual(cand) < num_tol]
+    # Post-verify against the SP5 equation. The gate is the *tight*
+    # subproblem_postverify (not subproblem_numerical): Gauss-Newton refinement
+    # drives every genuine solution to machine precision, so a candidate still
+    # above this is a spurious near-double-quartic-root least-squares point
+    # (FK ~1e-6, e.g. #337 / #159), not an IK solution -- drop it.
+    exact = [cand for cand in refined if residual(cand) < policy.subproblem_postverify]
 
     if exact:
         solutions = _dedup(exact, policy.subproblem_dedup)

--- a/tests/test_ikgeo_spherical.py
+++ b/tests/test_ikgeo_spherical.py
@@ -300,3 +300,20 @@ def test_wrong_topology_raises_no_spherical_wrist() -> None:
     bad_kb = KinBody(links=links, joints=joints)
     with pytest.raises(ValueError, match=r"\(3, 4, 5\)"):
         spherical.solve(bad_kb, np.eye(4))
+
+
+def test_spherical_rejects_spurious_near_double_root_branch(synth_a: KinBody) -> None:
+    """#337: at this pose the SP5 sub-solve's quartic has a near-double root
+    (gap ~9e-10) that produced a spurious branch -- a non-zero least-squares
+    point (FK ~5.7e-6) that slipped through SP5's loose post-verify. SP5 now
+    gates refined candidates at ``subproblem_postverify`` (1e-9), so every
+    returned spherical branch FK-closes at machine precision.
+    """
+    q_star = np.array([0.0, -0.61412196, -0.61412196, 1.0, 1.0, 0.0])
+    T_star = _fk(synth_a, q_star)
+    solutions, is_ls = spherical.solve(synth_a, T_star)
+    assert not is_ls
+    assert solutions
+    for s in solutions:
+        err = float(np.abs(_fk(synth_a, s.q) - T_star).max())
+        assert err < 1e-9, f"spurious branch survived: FK {err:.2e}"


### PR DESCRIPTION
Closes #337.

## Root cause (not what the issue guessed)

#337 hypothesized "better quartic root-splitting." I traced it and the root value isn't the problem — **Newton-polishing the quartic roots didn't help**. The real cause:

- At the repro pose the SP5 quartic has a **near-double root** (gap ~9e-10).
- Its sign-branch backsolve produces a **spurious candidate**: a non-zero least-squares point (LM stalls at ~2.6e-6 despite a *well-conditioned* `cond(J)~960`, so it's genuinely not a solution), sitting **3 rad** from any real branch.
- It slips through SP5's post-verify because that gate was the loose `subproblem_numerical` (1e-5) and the spurious residual (~5.6e-6) is just under it → surfaces as a spherical-6R branch with FK ~5.7e-6.

## The clean separation

Genuine SP5 solutions reach machine precision via Gauss-Newton refinement — **measured ≤ 6.2e-16 across 293,814 returned triples** (spherical + two_intersecting, random poses); **not one** lands in [1e-15, 1e-5]. So an 11-order gap separates genuine from spurious.

## Fix

Gate SP5's *refined* candidates at a new, tight **`subproblem_postverify`** (1e-9) instead of `subproblem_numerical`. Critically, `subproblem_numerical` is *also* the artifact's FK-closure `fk_atol` (codegen) — tightening it globally would reject valid orchestrator solutions — so this is a **separate policy field**.

Result at the repro pose: spherical **6 → 4 sols** (2 spurious dropped), worst FK **5.7e-6 → 3.5e-16**, q* still recovered. Zero risk to genuine solutions (all 11 orders below the gate).

## Tests

- Deterministic regression: the repro pose yields only machine-precision branches.
- No regression across sp5 / sp56-adversarial / spherical / two_intersecting / puma cross-validation (53 passed); the previously-failing `test_ikgeo_spherical::test_random_q_roundtrip_fk` now passes.

## Note on #159 (not fixed here)

I bundled #337+#159 expecting one root cause; they're **different**. xArm7's #159 floor is *not* a spurious SP5 candidate — it's genuine solutions at ~2.7e-7 that pass the artifact's `fk_atol` (1e-5) *without* refinement (`refinement_used=none`), so they're accepted as-is. It fails no current test (xArm7 fuzz ceiling is 1e-4; it's a documented floor). Closing it would need full-solution refinement below `fk_atol` — a separate, lower-priority change. #159 stays open.