### PR TITLE
Low-friction arm onboarding: one-click bench + complete add-arm (#341)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ uv run python scripts/bench_seven_r.py            # synthetic 7R
 
 - `tests/test_prebuilt_sanity.py`, `tests/test_prebuilt_uniform_fuzz.py`, `tests/test_artifact_snapshots.py` — per-arm parametrisation, FK ceilings, known-gap xfails, platform-drift markers
 - `scripts/regen_artifacts.py` — which arms to emit + their `--include-slow` gating
+- `scripts/regen_bench.py` — measures each prebuilt and writes the `[arms.*.bench]` blocks in place
 - `scripts/regen_docs.py` — the AUTOGEN doc tables (README prebuilt + EAIK comparison, docs/quickstart, src/ssik/prebuilt/README)
 - `examples/04_compare_vs_eaik.py` — bench fixtures
 
@@ -119,37 +120,39 @@ Then commit the updated `prebuilt/*.py` alongside the codegen change so reviewer
 
 ## Adding a new prebuilt arm
 
-The metadata for a shipped arm lives in `MANIFEST.toml`; adding one is mostly a manifest edit plus two regen commands.
+The metadata for a shipped arm lives in `MANIFEST.toml`. The flow is now mostly tooled:
 
-1. **Source the URDF / MJCF** and place the fixture under `tests/fixtures/` (a plain `.urdf`, or a Python `*_specs()` builder for spec-transcribed arms). For Xacro-only sources, expand to a plain URDF first.
-
-2. **Add a `[arms.<name>_ik]` block to `MANIFEST.toml`.** Copy a same-class neighbour's entry and adjust. The fields the dispatcher determines for you (`solver`, `tier`, `slow_build`) can be read off a one-shot:
+1. **Vendor the fixture + scaffold + get a manifest stanza** with `ssik add-arm`. It strips the source URDF to kinematics-only (`tests/fixtures/<name>.urdf`, no meshes — via `ssik._urdf.strip_urdf_to_fixture`, also exposed as `scripts/strip_urdf_fixture.py`), generates a bulletproof test scaffold, and **prints a ready-to-paste `[arms.<name>_ik]` stanza** with the dispatcher-derived fields (`solver`, `tier`, `dof`) filled and curated fields (`display_name`, `kinematic_class`, …) left as `TODO`:
 
    ```bash
-   uv run python -c "from ssik._urdf import load_urdf_kinbody_normalized as L; from ssik.core.dispatcher import dispatch; p = dispatch(L('tests/fixtures/<name>.urdf', '<base>', '<ee>')); print(p.solver_name, p.tier)"
+   ssik add-arm path/to/arm.urdf --base <base> --ee <ee> --name <name>_ik
    ```
 
-3. **Emit the artifact + bench it:**
+   (Spec-transcribed arms still use a Python `*_specs()` builder + `fixture_kind = "specs"`. Xacro: expand to plain URDF first — modular-URDF support is #327.)
+
+2. **Paste the stanza into `MANIFEST.toml`** and fill the `TODO` fields (copy a same-class neighbour for `kinematic_class` / `class_tags`).
+
+3. **Emit the artifact:**
 
    ```bash
    uv run python scripts/regen_artifacts.py [--include-slow]   # emits src/ssik/prebuilt/<name>_ik.py
-   uv run python examples/04_compare_vs_eaik.py --n 100        # fill in the [bench] block from the output
    ```
 
-   Add the arm to `examples/04_compare_vs_eaik.py`'s `FIXTURES` list so it benches.
-
-4. **Set `fk_ceiling_fuzz`** to ~10× the worst FK residual you observe in a 50-pose smoke test (`solve(fk(q), respect_limits=False)` over random non-singular `q`). If a specific pose returns no IK (a coverage gap), add a `[arms.<name>_ik.known_gaps]` block with an `xfail_reason` and file an issue.
-
-5. **Regenerate docs + run the gates:**
+4. **Bench + regenerate all docs — one click** (#341):
 
    ```bash
-   uv run python scripts/regen_docs.py
+   uv run python scripts/regen_bench.py --arm <name>_ik --docs   # fills [bench] + rewrites doc tables
+   ```
+
+   `regen_bench.py` measures the prebuilt's `solve()` (time / FK / branch count, examples/04 methodology) and writes the `[arms.<name>_ik.bench]` block in place, then runs `regen_docs.py`. Run it on the reference machine (timing is machine-dependent; FK/sols are not). Omit `--arm` to re-bench every arm.
+
+5. **Set `fk_ceiling_fuzz`** to ~10× the worst FK residual in a 50-pose smoke test. If a pose returns no IK (coverage gap), add a `[arms.<name>_ik.known_gaps]` block with an `xfail_reason` and file an issue. Then run the gates:
+
+   ```bash
    scripts/check.sh        # ruff + format + mypy + regen_docs --check + pytest
    ```
 
 `tests/test_manifest.py` cross-validates every manifest entry against the emitted artifact's baked constants (solver / base / ee / dof), so a typo surfaces immediately.
-
-> **Note:** A fully turnkey `ssik add-arm` that performs steps 2-5 in one command (auto-populating the manifest entry, benching, regenerating docs) is tracked in [#290](https://github.com/personalrobotics/ssik/issues/290). Today's `ssik add-arm` (below) handles the fixture + test-scaffold half.
 
 ## Adding a new arm fixture (test scaffold only)
 
@@ -157,7 +160,7 @@ The metadata for a shipped arm lives in `MANIFEST.toml`; adding one is mostly a 
 ssik add-arm path/to/arm.urdf --base base_link --ee flange --name my_arm
 ```
 
-Generates `tests/fixtures/my_arm.urdf` and `tests/test_my_arm.py` with FK-closure assertions on hand-picked + Hypothesis-fuzzed reachable poses. The generated test asserts the dispatcher routing matches the expected solver and that every retained IK FK-closes ≤ 1e-10. This does **not** yet ship the arm as a prebuilt — for that, follow "Adding a new prebuilt arm" above.
+Strips the source URDF to a kinematics-only `tests/fixtures/my_arm.urdf` (no meshes), generates `tests/test_my_arm.py` with FK-closure assertions on hand-picked + Hypothesis-fuzzed reachable poses (asserting dispatcher routing + FK ≤ 1e-10 on every retained IK), and **prints a ready-to-paste `MANIFEST.toml` stanza**. It does **not** build or bench the arm — to ship it as a prebuilt, paste the stanza and continue from step 3 of "Adding a new prebuilt arm" above.
 
 ## Adding a new solver
 

--- a/README.md
+++ b/README.md
@@ -361,25 +361,25 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 <!-- AUTOGEN:readme_eaik_table -->
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 2-8 sols | 521 ± 12 µs / FK 6e-12 / 2-8 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 0 µs / FK 3e-14 / 8 sols | 220 ± 3 µs / FK 2e-14 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 976 ± 39 µs / FK 5e-6 / 2-12 sols |
-| iiwa14 (SRS 7R) | **refuses** ("only 1-6R") | 4.83 ± 0.11 ms / FK 5e-13 / 128 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 41.46 ± 1.25 ms / FK 1e-12 / 10-95 sols |
-| Franka Panda (**anthropomorphic 7R**) | **refuses** ("only 1-6R") | 29.57 ± 2.95 ms / FK 1e-6 / 8-124 sols |
-| xArm7 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 25.78 ± 1.52 ms / FK 5e-6 / 48-72 sols |
-| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.02 ms / FK 2e-7 / 8-12 sols |
-| Z1 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 1e-15 / 4-8 sols | 487 ± 7 µs / FK 3e-15 / 4-8 sols |
-| PiPER (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.10 ± 0.03 ms / FK 1e-5 / 1-8 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 16.57 ± 0.30 ms / FK 4e-9 / 10-60 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 17.62 ± 0.29 ms / FK 7e-8 / 10-38 sols |
-| Rizon 10 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 16.26 ± 0.34 ms / FK 6e-8 / 10-64 sols |
-| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 991 ± 14 µs / FK 6e-7 / 6-12 sols |
-| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.08 ± 0.02 ms / FK 8e-9 / 8 sols |
-| big_yam (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.03 ± 0.02 ms / FK 5e-6 / 8 sols |
-| FR3 (**anthropomorphic 7R**) | **refuses** ("only 1-6R") | 30.83 ± 3.12 ms / FK 6e-9 / 8-128 sols |
-| OpenArm L (**non-SRS 7R**) | **refuses** ("only 1-6R") | 13.41 ± 1.56 ms / FK 2e-15 / 8-40 sols |
-| OpenArm R (**non-SRS 7R**) | **refuses** ("only 1-6R") | 11.07 ± 0.82 ms / FK 1e-15 / 8-40 sols |
+| UR5 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 2e-15 / 2-8 sols | 520 ± 10 µs / FK 6e-12 / 2-8 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 5 ± 0 µs / FK 3e-14 / 8 sols | 220 ± 0 µs / FK 8e-12 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 940 ± 30 µs / FK 8e-7 / 2-12 sols |
+| iiwa14 (SRS 7R) | **refuses** ("only 1-6R") | 4.66 ± 0.03 ms / FK 1e-13 / 128 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("only 1-6R") | 40.65 ± 0.69 ms / FK 1e-12 / 11-92 sols |
+| Franka Panda (**anthropomorphic 7R**) | **refuses** ("only 1-6R") | 31.43 ± 1.82 ms / FK 3e-10 / 8-128 sols |
+| xArm7 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 22.82 ± 0.17 ms / FK 2e-6 / 48-80 sols |
+| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.02 ms / FK 3e-6 / 8-16 sols |
+| Z1 (Pieper 6R, three-parallel) | 5 ± 0 µs / FK 1e-15 / 4-8 sols | 480 ± 10 µs / FK 3e-15 / 4-8 sols |
+| PiPER (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 3.06 ± 2.18 ms / FK 1e-5 / 2-8 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 16.20 ± 0.19 ms / FK 3e-7 / 4-60 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 16.99 ± 0.18 ms / FK 5e-8 / 4-42 sols |
+| Rizon 10 (**non-SRS 7R**) | **refuses** ("only 1-6R") | 15.78 ± 0.16 ms / FK 6e-8 / 6-64 sols |
+| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 2e-6 / 4-12 sols |
+| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.01 ms / FK 3e-7 / 5-8 sols |
+| big_yam (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.01 ms / FK 7e-7 / 8 sols |
+| FR3 (**anthropomorphic 7R**) | **refuses** ("only 1-6R") | 30.57 ± 1.84 ms / FK 4e-10 / 8-128 sols |
+| OpenArm L (**non-SRS 7R**) | **refuses** ("only 1-6R") | 12.30 ± 0.46 ms / FK 2e-15 / 8-40 sols |
+| OpenArm R (**non-SRS 7R**) | **refuses** ("only 1-6R") | 10.70 ± 0.43 ms / FK 1e-15 / 8-40 sols |
 <!-- /AUTOGEN -->
 
 The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 8 branches per sample = 128 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6, PiPER) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).

--- a/scripts/regen_bench.py
+++ b/scripts/regen_bench.py
@@ -1,0 +1,161 @@
+"""Regenerate per-arm benchmark numbers in ``MANIFEST.toml``.
+
+Benchmarking a prebuilt arm used to be a hand step: measure ``solve()`` timing /
+FK closure / branch count, then hand-edit the ``[arms.<name>.bench]`` block and
+re-run ``regen_docs``. This automates the measurement and the manifest write, so
+adding an arm (or refreshing the whole set) is one command::
+
+    uv run python scripts/regen_bench.py                 # all arms
+    uv run python scripts/regen_bench.py --arm xarm7_ik  # just one
+    uv run python scripts/regen_bench.py --docs          # + regenerate docs
+
+The methodology matches ``examples/04_compare_vs_eaik.py`` (the source of the
+committed numbers): reachable poses sampled in the joint interior, a warm-up
+pass, then bootstrap mean ± 95% CI on solve time, plus worst FK residual and
+the branch-count range. ``respect_limits=False`` so the branch count reflects
+the analytical solver, not the limit postprocess.
+
+Timing is **machine-dependent** -- run this on the reference machine that
+produced the committed numbers (sanity-check: a known arm like ``franka_panda``
+should land within CI of its current value). FK and branch counts are
+machine-independent.
+
+The manifest is updated in place by surgical line replacement so comments and
+hand-curated fields are preserved; only the five ``[bench]`` values change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "src" / "ssik" / "prebuilt" / "MANIFEST.toml"
+
+sys.path.insert(0, str(REPO_ROOT))
+from ssik.prebuilt._manifest import load_manifest  # noqa: E402
+
+_N_TIMED = 200
+_N_WARMUP = 10
+
+
+def _gen_poses(mod: object, n: int, rng: np.random.Generator) -> list[NDArray[np.float64]]:
+    """Reachable poses sampled in the safe joint interior (matches examples/04)."""
+    dof = mod.DOF  # type: ignore[attr-defined]
+    poses: list[NDArray[np.float64]] = []
+    while len(poses) < n:
+        q = rng.uniform(-0.5, 0.5, size=dof)
+        if dof == 7:
+            q[3] = float(rng.uniform(0.3, 0.7))
+        try:
+            poses.append(mod.fk(q))  # type: ignore[attr-defined]
+        except Exception:
+            continue
+    return poses
+
+
+def _mean_ci95(samples: NDArray[np.float64], n_boot: int = 1000) -> tuple[float, float]:
+    """Bootstrap mean + 95% CI half-width (matches examples/04)."""
+    rng = np.random.default_rng(0)
+    n = len(samples)
+    means = np.empty(n_boot)
+    for i in range(n_boot):
+        means[i] = samples[rng.integers(0, n, size=n)].mean()
+    mu = float(samples.mean())
+    lo, hi = np.percentile(means, [2.5, 97.5])
+    return mu, float(max(mu - lo, hi - mu))
+
+
+def bench_arm(mod: object) -> dict[str, float | int]:
+    """Measure one prebuilt module's ``solve()``; return the manifest bench dict."""
+    rng = np.random.default_rng(0)
+    poses = _gen_poses(mod, _N_TIMED + _N_WARMUP, rng)
+    for T in poses[:_N_WARMUP]:
+        mod.solve(T, respect_limits=False)  # type: ignore[attr-defined]
+
+    times: list[float] = []
+    fk_residuals: list[float] = []
+    sol_counts: list[int] = []
+    for T in poses[_N_WARMUP:]:
+        t0 = time.perf_counter()
+        sols = mod.solve(T, respect_limits=False)  # type: ignore[attr-defined]
+        times.append((time.perf_counter() - t0) * 1e3)
+        if sols:
+            fk_residuals.append(max(s.fk_residual for s in sols))
+            sol_counts.append(len(sols))
+
+    mu, half = _mean_ci95(np.array(times))
+    return {
+        "ms_mean": round(mu, 2),
+        "ms_ci95": round(half, 2),
+        "max_fk": max(fk_residuals) if fk_residuals else float("nan"),
+        "sols_min": min(sol_counts) if sol_counts else 0,
+        "sols_max": max(sol_counts) if sol_counts else 0,
+    }
+
+
+def _fmt(key: str, value: float | int) -> str:
+    if key in ("sols_min", "sols_max"):
+        return str(int(value))
+    if key == "max_fk":
+        return f"{value:.1e}"
+    return f"{value:.2f}"
+
+
+def update_manifest_bench(name: str, bench: dict[str, float | int]) -> None:
+    """Surgically rewrite the five values under ``[arms.<name>.bench]`` in place,
+    leaving every comment and hand-curated field untouched."""
+    lines = MANIFEST.read_text().splitlines(keepends=True)
+    header = f"[arms.{name}.bench]"
+    start = next((i for i, ln in enumerate(lines) if ln.strip() == header), None)
+    if start is None:
+        raise KeyError(f"{header} not found in {MANIFEST}")
+    for i in range(start + 1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("["):  # next section
+            break
+        if "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key in bench:
+                lines[i] = f"{key} = {_fmt(key, bench[key])}\n"
+    MANIFEST.write_text("".join(lines))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arm", help="benchmark only this arm (e.g. xarm7_ik); default all")
+    parser.add_argument("--docs", action="store_true", help="run regen_docs.py afterward")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    names = [args.arm] if args.arm else list(manifest.keys())
+    if args.arm and args.arm not in manifest:
+        parser.error(f"unknown arm {args.arm!r}; choices: {', '.join(manifest)}")
+
+    print(f"benchmarking {len(names)} arm(s) -> {MANIFEST.relative_to(REPO_ROOT)}")
+    for name in names:
+        mod = importlib.import_module(f"ssik.prebuilt.{name}")
+        bench = bench_arm(mod)
+        update_manifest_bench(name, bench)
+        print(
+            f"  {name}: {bench['ms_mean']} ± {bench['ms_ci95']} ms / "
+            f"FK {_fmt('max_fk', bench['max_fk'])} / {bench['sols_min']}-{bench['sols_max']} sols"
+        )
+
+    if args.docs:
+        print("running regen_docs.py")
+        subprocess.run([sys.executable, str(Path(__file__).parent / "regen_docs.py")], check=True)
+    else:
+        print("note: run scripts/regen_docs.py to refresh README/quickstart, or pass --docs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/strip_urdf_fixture.py
+++ b/scripts/strip_urdf_fixture.py
@@ -1,66 +1,30 @@
 """Strip a URDF down to a kinematics-only test fixture.
 
-ssik's test fixtures under ``tests/fixtures/`` are kinematics-only URDFs: the
-links keep only their names, and the joints keep origin / axis / parent / child
-/ limit. Everything irrelevant to inverse kinematics -- ``<visual>``,
-``<collision>``, ``<inertial>``, ``<material>``, ``<gazebo>``,
-``<transmission>`` -- is removed. That keeps fixtures small, free of unresolved
-``package://`` mesh paths, and focused on the geometry the solvers actually use.
+ssik's test fixtures under ``tests/fixtures/`` are kinematics-only URDFs: links
+keep only their names, joints keep origin / axis / parent / child / limit, and
+everything irrelevant to IK (``<visual>``, ``<collision>``, ``<inertial>``,
+``<material>``, ``<gazebo>``, ``<transmission>``) is removed. That keeps
+fixtures small, free of unresolved ``package://`` mesh paths, and focused on the
+geometry the solvers use.
 
-This tool produces such a fixture from any source URDF (e.g. the output of
-``robot_descriptions``'s ``load_robot_description(...).write_xml()``), so adding
-a new arm fixture is reproducible instead of a hand-edit.
+This is a thin CLI over :func:`ssik._urdf.strip_urdf_to_fixture` (shared with
+``ssik add-arm``). Forward kinematics of the stripped fixture are identical to
+the source -- only non-kinematic elements are dropped.
 
 Usage::
 
     uv run python scripts/strip_urdf_fixture.py <source.urdf> tests/fixtures/<arm>.urdf
-
-The forward kinematics of the stripped fixture are identical to the source
-(only non-kinematic elements are dropped); the tool re-checks this is
-structurally true by confirming every joint's origin/axis/parent/child survive.
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
-# Non-kinematic child elements removed from every ``<link>``.
-_LINK_DROP = ("visual", "collision", "inertial")
-# Non-kinematic top-level elements removed from ``<robot>``.
-_ROBOT_DROP = ("material", "gazebo", "transmission")
-
-
-def strip_urdf(source: Path, dest: Path) -> tuple[int, int]:
-    """Write a kinematics-only copy of ``source`` to ``dest``.
-
-    :returns: ``(n_links, n_joints)`` kept.
-    """
-    tree = ET.parse(source)
-    root = tree.getroot()
-
-    for tag in _ROBOT_DROP:
-        for el in root.findall(tag):
-            root.remove(el)
-
-    for link in root.findall("link"):
-        for tag in _LINK_DROP:
-            for el in link.findall(tag):
-                link.remove(el)
-
-    n_joints = len(root.findall("joint"))
-    for joint in root.findall("joint"):
-        # A joint must keep its parent/child to define the chain; warn loudly
-        # rather than emit a silently-broken fixture.
-        if joint.find("parent") is None or joint.find("child") is None:
-            raise ValueError(f"joint {joint.get('name')!r} is missing parent/child")
-
-    ET.indent(tree, space="  ")
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tree.write(dest, encoding="unicode", xml_declaration=True)
-    return len(root.findall("link")), n_joints
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from ssik._urdf import strip_urdf_to_fixture  # noqa: E402
 
 
 def main() -> int:
@@ -72,7 +36,7 @@ def main() -> int:
     if not args.source.exists():
         parser.error(f"source URDF not found: {args.source}")
 
-    n_links, n_joints = strip_urdf(args.source, args.dest)
+    n_links, n_joints = strip_urdf_to_fixture(args.source, args.dest)
     mesh_refs = sum(
         1 for line in args.dest.read_text().splitlines() if "package://" in line or "<mesh" in line
     )

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -14,6 +14,7 @@ will wrap this.
 
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,7 +26,45 @@ from ssik._kinbody import Joint, JointType, KinBody, Link
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from urchin import Joint as UrchinJoint
 
-__all__ = ["load_urdf_kinbody", "load_urdf_kinbody_normalized"]
+__all__ = ["load_urdf_kinbody", "load_urdf_kinbody_normalized", "strip_urdf_to_fixture"]
+
+# Non-kinematic elements stripped when vendoring a URDF as a test fixture:
+# everything irrelevant to inverse kinematics. Keeps fixtures small and free of
+# unresolved ``package://`` mesh paths.
+_FIXTURE_LINK_DROP = ("visual", "collision", "inertial")
+_FIXTURE_ROBOT_DROP = ("material", "gazebo", "transmission")
+
+
+def strip_urdf_to_fixture(source: Path, dest: Path) -> tuple[int, int]:
+    """Write a kinematics-only copy of ``source`` to ``dest``.
+
+    Drops ``<visual>`` / ``<collision>`` / ``<inertial>`` from every link and
+    top-level ``<material>`` / ``<gazebo>`` / ``<transmission>``, keeping link
+    names and the full joint definitions (origin / axis / parent / child /
+    limit) -- so forward kinematics are identical, but the file is small and has
+    no unresolved mesh paths. Used to vendor ``tests/fixtures/*.urdf``.
+
+    :returns: ``(n_links, n_joints)`` kept.
+    :raises ValueError: if any joint is missing its ``parent``/``child`` (which
+        would yield a silently-broken chain).
+    """
+    tree = ET.parse(source)
+    root = tree.getroot()
+    for tag in _FIXTURE_ROBOT_DROP:
+        for el in root.findall(tag):
+            root.remove(el)
+    for link in root.findall("link"):
+        for tag in _FIXTURE_LINK_DROP:
+            for el in link.findall(tag):
+                link.remove(el)
+    for joint in root.findall("joint"):
+        if joint.find("parent") is None or joint.find("child") is None:
+            raise ValueError(f"joint {joint.get('name')!r} is missing parent/child")
+    ET.indent(tree, space="  ")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(dest, encoding="unicode", xml_declaration=True)
+    return len(root.findall("link")), len(root.findall("joint"))
+
 
 _IDENTITY: NDArray[np.float64] = np.eye(4, dtype=np.float64)
 

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ssik._urdf import load_urdf_kinbody_normalized
+from ssik._urdf import load_urdf_kinbody_normalized, strip_urdf_to_fixture
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.subproblems._rotation import rotation_matrix
@@ -440,9 +440,10 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     plan = dispatch(kb)
     _print_dispatch_summary(plan)
 
-    print(f"[ssik add-arm] Vendoring URDF -> {urdf_dest.relative_to(repo_root)}")
-    urdf_dest.write_bytes(args.urdf.read_bytes())
-    print(f"[ssik add-arm]   {urdf_dest.stat().st_size:,} bytes copied")
+    print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {urdf_dest.relative_to(repo_root)}")
+    n_links, n_joints = strip_urdf_to_fixture(args.urdf, urdf_dest)
+    kb_bytes = urdf_dest.stat().st_size
+    print(f"[ssik add-arm]   stripped to {n_links} links, {n_joints} joints, {kb_bytes:,} bytes")
 
     print(f"[ssik add-arm] Generating test scaffold -> {test_dest.relative_to(repo_root)}")
     test_source = _render_test_scaffold(
@@ -457,14 +458,53 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     print(f"[ssik add-arm]   wrote {len(test_source):,} bytes ({test_source.count(chr(10))} lines)")
 
     print()
-    print("[ssik add-arm] ✓ Done. Try:")
-    print(f"[ssik add-arm]     uv run pytest {test_dest.relative_to(repo_root)} -v")
-    print(f"[ssik add-arm]     uv run pytest {test_dest.relative_to(repo_root)} -v -m slow")
+    print("[ssik add-arm] Add this stanza to src/ssik/prebuilt/MANIFEST.toml")
+    print("[ssik add-arm] (TODO fields need your judgement; the rest is derived):")
     print()
-    print("[ssik add-arm] Next steps (manual; not auto-generated yet):")
-    print("[ssik add-arm]   - Add an arm row to README.md under the matching solver class")
-    print(f"[ssik add-arm]   - Optionally add scripts/bench_{args.name}.py for FLOP profiling")
+    print(_render_manifest_stanza(args.name, args.base, args.ee, len(kb.joints), plan))
+    print()
+    print("[ssik add-arm] ✓ Then finish (build artifact, then one-click bench+docs):")
+    print(f"[ssik add-arm]     uv run pytest {test_dest.relative_to(repo_root)} -v")
+    print("[ssik add-arm]     uv run python scripts/regen_artifacts.py [--include-slow]")
+    print(f"[ssik add-arm]     uv run python scripts/regen_bench.py --arm {args.name} --docs")
     return 0
+
+
+def _render_manifest_stanza(name: str, base: str, ee: str, dof: int, plan: DispatchPlan) -> str:
+    """A ready-to-paste MANIFEST.toml stanza: derived fields filled, curated
+    fields left as ``TODO`` for human judgement. ``regen_bench.py`` fills the
+    ``[bench]`` block."""
+    sample = ", ".join("0.1" for _ in range(dof))
+    return "\n".join(
+        [
+            f"[arms.{name}]",
+            'display_name = "TODO"',
+            'short_name = "TODO"',
+            f'fixture = "{name}.urdf"',
+            'fixture_kind = "urdf"',
+            'fixture_source = "TODO (e.g. robot_descriptions / <pkg>)"',
+            f'base_link = "{base}"',
+            f'ee_link = "{ee}"',
+            f"dof = {dof}",
+            f'solver = "{plan.solver_name}"',
+            f"tier = {plan.tier}",
+            'kinematic_class = "TODO"',
+            'short_class = "TODO"',
+            'class_tags = ["TODO"]',
+            "slow_build = false  # set true if the build is minutes (cached-RR 7R)",
+            "build_time_sec = 0  # update after building",
+            "artifact_size_kb = 0  # update after building",
+            f"sample_q = [{sample}]",
+            "fk_ceiling_fuzz = 1e-4",
+            "",
+            f"[arms.{name}.bench]  # filled by scripts/regen_bench.py",
+            "ms_mean = 0.0",
+            "ms_ci95 = 0.0",
+            "max_fk = 0.0",
+            "sols_min = 0",
+            "sols_max = 0",
+        ]
+    )
 
 
 def _render_test_scaffold(

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -65,8 +65,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur5_ik.bench]
-ms_mean = 0.521
-ms_ci95 = 0.012
+ms_mean = 0.52
+ms_ci95 = 0.01
 max_fk = 6.3e-12
 sols_min = 2
 sols_max = 8
@@ -93,9 +93,9 @@ fk_ceiling_fuzz = 1e-12
 platform_drift = false
 
 [arms.puma560_ik.bench]
-ms_mean = 0.220
-ms_ci95 = 0.003
-max_fk = 2.0e-14
+ms_mean = 0.22
+ms_ci95 = 0.00
+max_fk = 8.3e-12
 sols_min = 8
 sols_max = 8
 
@@ -128,9 +128,9 @@ drift_markers = [
 ]
 
 [arms.jaco2_ik.bench]
-ms_mean = 0.976
-ms_ci95 = 0.039
-max_fk = 5.0e-6
+ms_mean = 0.94
+ms_ci95 = 0.03
+max_fk = 8.0e-07
 sols_min = 2
 sols_max = 12
 
@@ -156,9 +156,9 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.iiwa14_ik.bench]
-ms_mean = 4.83
-ms_ci95 = 0.11
-max_fk = 5.1e-13
+ms_mean = 4.66
+ms_ci95 = 0.03
+max_fk = 1.0e-13
 sols_min = 128
 sols_max = 128
 
@@ -190,11 +190,11 @@ drift_markers = [
 ]
 
 [arms.gen3_ik.bench]
-ms_mean = 41.46
-ms_ci95 = 1.25
-max_fk = 1.0e-12
-sols_min = 10
-sols_max = 95
+ms_mean = 40.65
+ms_ci95 = 0.69
+max_fk = 9.9e-13
+sols_min = 11
+sols_max = 92
 
 [arms.gen3_ik.known_gaps]
 xfail_reason = "srs_polished coverage gap on q*=[0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875] (0 sols at q*, 5 sols at q* + 0.01 on q5, 1 sol at q* + 0.01 on q7). Same shape as #286 / #288 / #298. Filed as #299."
@@ -222,11 +222,11 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.franka_panda_ik.bench]
-ms_mean = 29.57
-ms_ci95 = 2.95
-max_fk = 1.2e-6
+ms_mean = 31.43
+ms_ci95 = 1.82
+max_fk = 2.7e-10
 sols_min = 8
-sols_max = 124
+sols_max = 128
 
 [arms.xarm7_ik]
 display_name = "UFactory xArm7"
@@ -257,11 +257,11 @@ drift_markers = [
 ]
 
 [arms.xarm7_ik.bench]
-ms_mean = 25.78
-ms_ci95 = 1.52
-max_fk = 5.1e-6
+ms_mean = 22.82
+ms_ci95 = 0.17
+max_fk = 1.5e-06
 sols_min = 48
-sols_max = 72
+sols_max = 80
 
 [arms.xarm6_ik]
 display_name = "UFactory xArm6"
@@ -292,9 +292,9 @@ drift_markers = [
 [arms.xarm6_ik.bench]
 ms_mean = 1.06
 ms_ci95 = 0.02
-max_fk = 2.0e-7
+max_fk = 2.5e-06
 sols_min = 8
-sols_max = 12
+sols_max = 16
 
 [arms.z1_ik]
 display_name = "Unitree Z1"
@@ -318,9 +318,9 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.z1_ik.bench]
-ms_mean = 0.487
-ms_ci95 = 0.007
-max_fk = 3.0e-15
+ms_mean = 0.48
+ms_ci95 = 0.01
+max_fk = 2.8e-15
 sols_min = 4
 sols_max = 8
 
@@ -354,10 +354,10 @@ drift_markers = [
 ]
 
 [arms.piper_ik.bench]
-ms_mean = 1.10
-ms_ci95 = 0.03
-max_fk = 9.7e-6
-sols_min = 1
+ms_mean = 3.06
+ms_ci95 = 2.18
+max_fk = 9.8e-06
+sols_min = 2
 sols_max = 8
 
 
@@ -383,10 +383,10 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon4_ik.bench]
-ms_mean = 16.57
-ms_ci95 = 0.30
-max_fk = 4.0e-9
-sols_min = 10
+ms_mean = 16.20
+ms_ci95 = 0.19
+max_fk = 2.8e-07
+sols_min = 4
 sols_max = 60
 
 
@@ -412,11 +412,11 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.kassow_kr810_ik.bench]
-ms_mean = 17.62
-ms_ci95 = 0.29
-max_fk = 7.0e-8
-sols_min = 10
-sols_max = 38
+ms_mean = 16.99
+ms_ci95 = 0.18
+max_fk = 5.4e-08
+sols_min = 4
+sols_max = 42
 
 
 [arms.rizon10_ik]
@@ -441,10 +441,10 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon10_ik.bench]
-ms_mean = 16.26
-ms_ci95 = 0.34
-max_fk = 6.1e-8
-sols_min = 10
+ms_mean = 15.78
+ms_ci95 = 0.16
+max_fk = 5.5e-08
+sols_min = 6
 sols_max = 64
 
 [arms.fanuc_crx10ial_ik]
@@ -474,10 +474,10 @@ drift_markers = [
 ]
 
 [arms.fanuc_crx10ial_ik.bench]
-ms_mean = 0.991
-ms_ci95 = 0.014
-max_fk = 6.2e-7
-sols_min = 6
+ms_mean = 1.02
+ms_ci95 = 0.01
+max_fk = 2.3e-06
+sols_min = 4
 sols_max = 12
 
 
@@ -508,10 +508,10 @@ drift_markers = [
 ]
 
 [arms.yam_ik.bench]
-ms_mean = 1.08
-ms_ci95 = 0.02
-max_fk = 7.6e-9
-sols_min = 8
+ms_mean = 1.06
+ms_ci95 = 0.01
+max_fk = 3.5e-07
+sols_min = 5
 sols_max = 8
 
 [arms.big_yam_ik]
@@ -541,9 +541,9 @@ drift_markers = [
 ]
 
 [arms.big_yam_ik.bench]
-ms_mean = 1.03
-ms_ci95 = 0.02
-max_fk = 4.7e-6
+ms_mean = 1.06
+ms_ci95 = 0.01
+max_fk = 7.2e-07
 sols_min = 8
 sols_max = 8
 
@@ -569,9 +569,9 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.fr3_ik.bench]
-ms_mean = 30.83
-ms_ci95 = 3.12
-max_fk = 6.0e-9
+ms_mean = 30.57
+ms_ci95 = 1.84
+max_fk = 4.2e-10
 sols_min = 8
 sols_max = 128
 
@@ -597,9 +597,9 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.openarm_left_ik.bench]
-ms_mean = 13.41
-ms_ci95 = 1.56
-max_fk = 2.1e-15
+ms_mean = 12.30
+ms_ci95 = 0.46
+max_fk = 1.7e-15
 sols_min = 8
 sols_max = 40
 
@@ -625,9 +625,9 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.openarm_right_ik.bench]
-ms_mean = 11.07
-ms_ci95 = 0.82
-max_fk = 1.5e-15
+ms_mean = 10.70
+ms_ci95 = 0.43
+max_fk = 1.4e-15
 sols_min = 8
 sols_max = 40
 

--- a/tests/test_arm_onboarding.py
+++ b/tests/test_arm_onboarding.py
@@ -1,0 +1,121 @@
+"""Arm-onboarding tooling (#341): URDF stripping + one-click bench regen.
+
+Guards the friction-reduction helpers: ``ssik._urdf.strip_urdf_to_fixture``
+(shared by ``ssik add-arm`` and ``scripts/strip_urdf_fixture.py``) and the
+surgical ``[bench]`` rewrite in ``scripts/regen_bench.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from ssik._urdf import load_urdf_kinbody_normalized, strip_urdf_to_fixture
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURES = REPO / "tests" / "fixtures"
+
+_URDF_WITH_GEOMETRY = """<?xml version="1.0"?>
+<robot name="toy">
+  <material name="red"><color rgba="1 0 0 1"/></material>
+  <link name="base">
+    <visual><geometry><mesh filename="package://toy/base.stl"/></geometry></visual>
+    <collision><geometry><box size="1 1 1"/></geometry></collision>
+    <inertial><mass value="1"/></inertial>
+  </link>
+  <link name="l1"/>
+  <joint name="j1" type="revolute">
+    <parent link="base"/><child link="l1"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="-3" upper="3" effort="1" velocity="1"/>
+  </joint>
+  <gazebo reference="base"/>
+</robot>
+"""
+
+
+def test_strip_drops_nonkinematic_keeps_joints(tmp_path: Path) -> None:
+    src = tmp_path / "toy.urdf"
+    src.write_text(_URDF_WITH_GEOMETRY)
+    dest = tmp_path / "toy_stripped.urdf"
+    n_links, n_joints = strip_urdf_to_fixture(src, dest)
+    assert (n_links, n_joints) == (2, 1)
+    text = dest.read_text()
+    for dropped in ("<visual", "<collision", "<inertial", "<material", "<gazebo", "package://"):
+        assert dropped not in text, f"{dropped} survived strip"
+    # Joint kinematics are kept.
+    assert "<joint" in text
+    assert 'xyz="0 0 0.3"' in text
+    assert "<axis" in text
+
+
+def test_strip_preserves_fk(tmp_path: Path) -> None:
+    """Stripping a real fixture changes no kinematics -- FK is identical."""
+    src = FIXTURES / "rizon4.urdf"
+    dest = tmp_path / "rizon4_stripped.urdf"
+    strip_urdf_to_fixture(src, dest)
+    kb_src = load_urdf_kinbody_normalized(src, "base_link", "flange")
+    kb_dst = load_urdf_kinbody_normalized(dest, "base_link", "flange")
+    rng = np.random.default_rng(0)
+    for _ in range(8):
+        q = rng.uniform(-1.5, 1.5, size=len(kb_src.joints))
+        drift = np.abs(poe_forward_kinematics(kb_dst, q) - poe_forward_kinematics(kb_src, q)).max()
+        assert drift < 1e-12, f"FK drift {drift:.2e}"
+
+
+def test_strip_raises_on_broken_joint(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.urdf"
+    bad.write_text('<robot name="x"><joint name="j" type="revolute"/></robot>')
+    with pytest.raises(ValueError, match="parent/child"):
+        strip_urdf_to_fixture(bad, tmp_path / "out.urdf")
+
+
+def _load_regen_bench() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "regen_bench", REPO / "scripts" / "regen_bench.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_regen_bench_update_is_surgical(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``update_manifest_bench`` rewrites only the five bench values, preserving
+    every comment and hand-curated field."""
+    rb = _load_regen_bench()
+    manifest = tmp_path / "M.toml"
+    manifest.write_text(
+        "# top comment\n"
+        "[arms.foo_ik]\n"
+        'display_name = "Foo"  # curated\n'
+        "dof = 6\n"
+        "\n"
+        "[arms.foo_ik.bench]\n"
+        "ms_mean = 1.0\n"
+        "ms_ci95 = 0.1\n"
+        "max_fk = 1.0e-9\n"
+        "sols_min = 4\n"
+        "sols_max = 8\n"
+    )
+    monkeypatch.setattr(rb, "MANIFEST", manifest)
+    rb.update_manifest_bench(
+        "foo_ik",
+        {"ms_mean": 2.5, "ms_ci95": 0.2, "max_fk": 3e-6, "sols_min": 2, "sols_max": 10},
+    )
+    out = manifest.read_text()
+    # Curated content untouched.
+    assert "# top comment" in out
+    assert 'display_name = "Foo"  # curated' in out
+    assert "dof = 6" in out
+    # Bench values rewritten.
+    assert "ms_mean = 2.50" in out
+    assert "max_fk = 3.0e-06" in out
+    assert "sols_max = 10" in out
+    assert "ms_mean = 1.0\n" not in out

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -69,9 +69,25 @@ def test_add_arm_generates_files(workspace: Path) -> None:
     test_dest = workspace / "tests" / "test_rizon4_addarm_test.py"
     assert urdf_dest.exists(), "URDF not vendored"
     assert test_dest.exists(), "test scaffold not written"
-    # URDF byte-equal to source.
-    src_bytes = (REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf").read_bytes()
-    assert urdf_dest.read_bytes() == src_bytes
+    # Vendored URDF is stripped to kinematics-only (no mesh/visual/collision)
+    # but FK-identical to the source (#341).
+    text = urdf_dest.read_text()
+    assert "package://" not in text
+    assert "<visual" not in text
+    assert "<collision" not in text
+    import numpy as np
+
+    from ssik._urdf import load_urdf_kinbody_normalized
+    from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+    src = REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"
+    kb_vendored = load_urdf_kinbody_normalized(urdf_dest, "base_link", "flange")
+    kb_src = load_urdf_kinbody_normalized(src, "base_link", "flange")
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        q = rng.uniform(-1.0, 1.0, size=len(kb_src.joints))
+        drift = np.abs(poe_forward_kinematics(kb_vendored, q) - poe_forward_kinematics(kb_src, q))
+        assert drift.max() < 1e-12, f"stripped URDF FK drift {drift.max():.2e}"
 
 
 def test_add_arm_refuses_overwrite_without_force(workspace: Path) -> None:


### PR DESCRIPTION
Part of #341 (parts A + B; beyond-URDF stays #83).

## Why

Adding a prebuilt arm was multi-step with **manual benchmarking** — this session's xArm7 flip required hand-measuring `ms_mean`/`max_fk`/`sols` and hand-editing the `[bench]` block, then `regen_docs`. This tools it so the bench → docs step is one click.

## `scripts/regen_bench.py` (new) — the one-click bench

Measures each prebuilt's `solve()` (time / max FK / branch count, same methodology as `examples/04` — warm-up, bootstrap CI95, `respect_limits=False`) and writes the `[arms.<name>.bench]` block **in place** (surgical line replacement — comments and curated fields untouched).

```bash
uv run python scripts/regen_bench.py --arm xarm7_ik --docs   # bench one + refresh docs
uv run python scripts/regen_bench.py --docs                  # re-bench all + docs
```

Timing is machine-dependent (run on the reference machine; FK/sols are deterministic via a fixed seed). Used it to re-normalize all 19 arms to reproducible seed-0 numbers — `regen_docs --check` stays green.

## `ssik add-arm` — completed

- **Strips** the source URDF to kinematics-only when vendoring (was a raw copy that dragged in meshes/visuals). Strip logic moved to `ssik._urdf.strip_urdf_to_fixture`, shared with `scripts/strip_urdf_fixture.py` (now a thin wrapper).
- **Prints a ready-to-paste `[arms.<name>]` manifest stanza** — dispatcher-derived fields (`solver`/`tier`/`dof`) filled, curated fields as `TODO`.

So the flow is now: `ssik add-arm` (strip + scaffold + stanza) → paste stanza → `regen_artifacts` → `regen_bench --arm X --docs`. Documented in CONTRIBUTING.

## Tests

- `strip_urdf_to_fixture`: drops `visual`/`collision`/`inertial`/`material`/`gazebo` + `package://`, keeps joints, preserves FK (real fixture, drift < 1e-12), raises on a joint missing parent/child.
- `regen_bench.update_manifest_bench`: surgical — rewrites only the 5 values, preserves comments/curated fields.
- `add-arm`: vendored URDF is stripped (no mesh/visual/collision) and FK-identical to source.
- Affected suite (cli / add-arm / urdf / snapshot) green; ruff + mypy clean.

## Note on "beyond URDF"

Considered — MJCF/USD/SDF ingestion is a substantial new loader and stays tracked in **#83**. It's the natural next step to widen the source pool (MuJoCo Menagerie etc.) once this lands.