### PR TITLE
MJCF loader: load_mjcf_kinbody_normalized via mujoco MjModel (#343)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ demo = [
     "robot-descriptions>=2.0.0",
     "imageio>=2.34",
 ]
+mjcf = [
+    "mujoco>=3.10.0",
+]
 
 [project.urls]
 Repository = "https://github.com/personalrobotics/ssik"
@@ -82,6 +85,7 @@ dev = [
     "robot-descriptions>=2.0.0",
     "yourdfpy>=0.0.60",
     "xacrodoc>=2.0.1",
+    "mujoco>=3.0", # exercised by the MJCF-adapter tests (also the [mjcf] extra)
 ]
 docs = [
     "mkdocs-material>=9.5",
@@ -209,6 +213,10 @@ ignore_missing_imports = true
 # urchin (URDF parser) ships no type stubs.
 [[tool.mypy.overrides]]
 module = "urchin.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "mujoco.*"
 ignore_missing_imports = true
 
 # cython runtime ships ``py.typed`` from 3.1+ but the marker is missing

--- a/src/ssik/_kinbody.py
+++ b/src/ssik/_kinbody.py
@@ -33,7 +33,7 @@ from typing import Literal, overload
 import numpy as np
 from numpy.typing import NDArray
 
-__all__ = ["Joint", "JointSpec", "KinBody", "Link", "build_kinbody"]
+__all__ = ["Joint", "JointSpec", "KinBody", "Link", "build_kinbody", "build_poe_kinbody"]
 
 JointType = Literal["revolute", "prismatic"]
 
@@ -336,4 +336,50 @@ def build_kinbody(
         )
         prev_origin = joint_origin
 
+    return KinBody(links=links, joints=joints)
+
+
+# POE record: (joint name, joint type, axis in base frame, translation offset
+# from the previous joint's frame, optional (lo, hi) limits).
+PoeRecord = tuple[
+    str, "JointType", NDArray[np.float64], NDArray[np.float64], "tuple[float, float] | None"
+]
+
+
+def build_poe_kinbody(
+    records: list[PoeRecord],
+    final_t_right: NDArray[np.float64],
+    base_link: str,
+    ee_link: str,
+) -> KinBody:
+    """Construct a POE-normalized :class:`KinBody` from per-joint records.
+
+    Each record's ``T_left`` is the pure translation ``p_offset`` and its axis
+    is already in the base frame at ``q=0`` (the POE encoding). ``final_t_right``
+    absorbs the trailing offset + home orientation on the last joint so
+    ``FK(q=0)`` matches the source. Shared by the URDF and MJCF loaders so the
+    construction (and synthesized intermediate link names) lives in one place.
+    """
+    n = len(records)
+    if n == 0:
+        raise ValueError(f"chain from {base_link!r} to {ee_link!r} has no active joints")
+    link_names = [base_link, *[f"_poe_link_{i}" for i in range(1, n)], ee_link]
+    links = [Link(name=name) for name in link_names]
+    joints: list[Joint] = []
+    for i, (name, joint_type, axis_base, p_offset, limits) in enumerate(records):
+        t_left = np.eye(4, dtype=np.float64)
+        t_left[:3, 3] = p_offset
+        t_right = final_t_right if i == n - 1 else np.eye(4, dtype=np.float64)
+        joints.append(
+            Joint(
+                name=name,
+                dof_index=i,
+                parent_link=links[i],
+                T_left=t_left,
+                T_right=t_right,
+                axis=axis_base,
+                joint_type=joint_type,
+                limits=limits,
+            )
+        )
     return KinBody(links=links, joints=joints)

--- a/src/ssik/_mjcf.py
+++ b/src/ssik/_mjcf.py
@@ -1,0 +1,128 @@
+"""MJCF → KinBody adapter (#343, sub-task of #83).
+
+Loads a MuJoCo MJCF via the optional ``mujoco`` package and builds a
+**POE-normalized** :class:`ssik._kinbody.KinBody` for the chain between two
+bodies. ``mujoco`` compiles the MJCF -- resolving ``<default>`` classes,
+``<compiler>`` angle/coordinate settings, ``<include>``, keyframes -- so we
+never hand-parse the XML. Its ``mj_forward`` pass at the reference configuration
+(``qpos0``) exposes world-frame joint axes/anchors and body poses, which *is*
+the POE form, so the normalized chain reads straight off the compiled model.
+
+``mujoco`` is an optional dependency (the ``mjcf`` extra), mirroring ``urchin``
+for URDF; importing this module is fine without it, only the loader needs it.
+
+The produced KinBody is identical in form to :func:`ssik._urdf.load_urdf_kinbody_normalized`:
+solvers and the dispatcher are format-agnostic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik._kinbody import JointType, KinBody, build_poe_kinbody
+
+__all__ = ["load_mjcf_kinbody_normalized"]
+
+
+def _import_mujoco() -> object:
+    try:
+        import mujoco
+    except ImportError as err:
+        raise ImportError(
+            "MJCF loading requires the optional 'mjcf' extra: "
+            "`pip install ssik[mjcf]` (or `uv add mujoco`)."
+        ) from err
+    return mujoco
+
+
+def load_mjcf_kinbody_normalized(
+    mjcf_path: str | Path,
+    base_body: str,
+    ee_body: str,
+) -> KinBody:
+    """Load an MJCF and build a POE-normalized :class:`KinBody` for the chain
+    from ``base_body`` to ``ee_body``.
+
+    Only single-DOF joints (``hinge`` → revolute, ``slide`` → prismatic) are
+    supported; bodies with no joint are fused into the next active joint's
+    transform (the MJCF analogue of URDF fixed-joint fusion). ``ball`` / ``free``
+    joints raise. ``q=0`` corresponds to MuJoCo's reference ``qpos0``.
+
+    :raises ValueError: if a body name is absent or ``ee_body`` is not a
+        descendant of ``base_body``.
+    :raises NotImplementedError: on ball/free joints.
+    """
+    mujoco = _import_mujoco()
+    model = mujoco.MjModel.from_xml_path(str(mjcf_path))  # type: ignore[attr-defined]
+    data = mujoco.MjData(model)  # type: ignore[attr-defined]
+    mujoco.mj_forward(model, data)  # type: ignore[attr-defined]  # qpos defaults to qpos0
+
+    def _body_id(name: str) -> int:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)  # type: ignore[attr-defined]
+        if bid < 0:
+            raise ValueError(f"MJCF has no body named {name!r}")
+        return int(bid)
+
+    base_id = _body_id(base_body)
+    ee_id = _body_id(ee_body)
+
+    # Walk ee → base via the body tree; the base body is the reference frame.
+    chain: list[int] = []
+    b = ee_id
+    while b != base_id:
+        chain.append(b)
+        parent = int(model.body_parentid[b])
+        if parent == b:  # reached the world root without hitting base
+            raise ValueError(f"body {ee_body!r} is not a descendant of {base_body!r}")
+        b = parent
+    chain.reverse()  # base-child … ee
+
+    r_base = np.asarray(data.xmat[base_id], dtype=np.float64).reshape(3, 3)
+    p_base = np.asarray(data.xpos[base_id], dtype=np.float64)
+
+    hinge = mujoco.mjtJoint.mjJNT_HINGE  # type: ignore[attr-defined]
+    slide = mujoco.mjtJoint.mjJNT_SLIDE  # type: ignore[attr-defined]
+
+    records: list[
+        tuple[str, JointType, NDArray[np.float64], NDArray[np.float64], tuple[float, float] | None]
+    ] = []
+    prev_pos = np.zeros(3, dtype=np.float64)  # base origin in base frame
+    for body_id in chain:
+        j0 = int(model.body_jntadr[body_id])
+        njnt = int(model.body_jntnum[body_id])
+        for jid in range(j0, j0 + njnt):
+            jtype = int(model.jnt_type[jid])
+            jname = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, jid) or f"joint{jid}"  # type: ignore[attr-defined]
+            if jtype not in (hinge, slide):
+                raise NotImplementedError(
+                    f"joint {jname!r}: only hinge/slide (single-DOF) joints are "
+                    "supported by the MJCF adapter (got ball/free)."
+                )
+            # World-frame axis/anchor at qpos0 expressed in the base frame = POE.
+            axis_base = r_base.T @ np.asarray(data.xaxis[jid], dtype=np.float64)
+            anchor_base = r_base.T @ (np.asarray(data.xanchor[jid], dtype=np.float64) - p_base)
+            joint_type: JointType = "revolute" if jtype == hinge else "prismatic"
+            if bool(model.jnt_limited[jid]):
+                lo, hi = (float(x) for x in model.jnt_range[jid])
+                limits: tuple[float, float] | None = (lo, hi)
+            else:
+                limits = None
+            records.append((jname, joint_type, axis_base, anchor_base - prev_pos, limits))
+            prev_pos = anchor_base
+
+    if not records:
+        raise ValueError(f"chain from {base_body!r} to {ee_body!r} has no joints")
+
+    # Trailing offset + home orientation on the last joint's T_right.
+    r_ee = np.asarray(data.xmat[ee_id], dtype=np.float64).reshape(3, 3)
+    p_ee = np.asarray(data.xpos[ee_id], dtype=np.float64)
+    final_t_right = np.eye(4, dtype=np.float64)
+    final_t_right[:3, 3] = r_base.T @ (p_ee - p_base) - prev_pos
+    rot4 = np.eye(4, dtype=np.float64)
+    rot4[:3, :3] = r_base.T @ r_ee
+    final_t_right = final_t_right @ rot4
+
+    return build_poe_kinbody(records, final_t_right, base_body, ee_body)

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
-from ssik._kinbody import Joint, JointType, KinBody, Link
+from ssik._kinbody import Joint, JointType, KinBody, Link, build_poe_kinbody
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from urchin import Joint as UrchinJoint
@@ -326,26 +326,4 @@ def load_urdf_kinbody_normalized(
     final_rotation[:3, :3] = r_ee_home
     final_t_right = final_t_right @ final_rotation
 
-    # Build the KinBody with synthesized intermediate link names.
-    n = len(records)
-    link_names = [base_link, *[f"_poe_link_{i}" for i in range(1, n)], ee_link]
-    links = [Link(name=name) for name in link_names]
-    joints: list[Joint] = []
-    for i, (name, joint_type, axis_base, p_offset, limits) in enumerate(records):
-        t_left = np.eye(4, dtype=np.float64)
-        t_left[:3, 3] = p_offset
-        t_right = final_t_right if i == n - 1 else _IDENTITY.copy()
-        joints.append(
-            Joint(
-                name=name,
-                dof_index=i,
-                parent_link=links[i],
-                T_left=t_left,
-                T_right=t_right,
-                axis=axis_base,
-                joint_type=joint_type,
-                limits=limits,
-            )
-        )
-
-    return KinBody(links=links, joints=joints)
+    return build_poe_kinbody(records, final_t_right, base_link, ee_link)

--- a/tests/fixtures/toy3r.xml
+++ b/tests/fixtures/toy3r.xml
@@ -1,0 +1,23 @@
+<mujoco model="toy3r">
+  <compiler angle="radian"/>
+  <!-- Minimal 3R serial arm for MJCF-adapter tests (#343): varied joint axes
+       (z, y, x), a non-trivial body orientation (quat on link2), and one
+       limited joint (j2). Inertials are required by the MuJoCo compiler but
+       irrelevant to the kinematics the adapter reads. -->
+  <worldbody>
+    <body name="base">
+      <body name="link1" pos="0 0 0.2">
+        <joint name="j1" type="hinge" axis="0 0 1"/>
+        <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+        <body name="link2" pos="0.3 0 0" quat="0.92388 0 0.38268 0">
+          <joint name="j2" type="hinge" axis="0 1 0" range="-2.0 2.0"/>
+          <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+          <body name="link3" pos="0.25 0 0.1">
+            <joint name="j3" type="hinge" axis="1 0 0"/>
+            <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>

--- a/tests/test_mjcf.py
+++ b/tests/test_mjcf.py
@@ -1,0 +1,80 @@
+"""MJCF → KinBody adapter (#343): FK parity vs mujoco + edge cases.
+
+Gated on the optional ``mujoco`` dependency (the ``mjcf`` extra; also in the dev
+group so CI runs these). The gold-standard oracle is mujoco's own ``mj_forward``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from ssik._mjcf import load_mjcf_kinbody_normalized  # noqa: E402
+from ssik.kinematics.poe_fk import poe_forward_kinematics  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
+TOY = FIXTURES / "toy3r.xml"
+
+
+def _mujoco_base_ee_fk(path: Path, base: str, ee: str, q: np.ndarray) -> np.ndarray:
+    """Reference base→ee transform from mujoco at joint config ``q``."""
+    m = mujoco.MjModel.from_xml_path(str(path))
+    d = mujoco.MjData(m)
+    d.qpos[:] = 0.0
+    for jid in range(m.njnt):
+        d.qpos[int(m.jnt_qposadr[jid])] = q[jid]
+    mujoco.mj_forward(m, d)
+    bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, base)
+    eid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, ee)
+    t_base = np.eye(4)
+    t_base[:3, :3] = d.xmat[bid].reshape(3, 3)
+    t_base[:3, 3] = d.xpos[bid]
+    t_ee = np.eye(4)
+    t_ee[:3, :3] = d.xmat[eid].reshape(3, 3)
+    t_ee[:3, 3] = d.xpos[eid]
+    return np.linalg.inv(t_base) @ t_ee
+
+
+def test_mjcf_fk_matches_mujoco() -> None:
+    """The POE-normalized KinBody's FK matches mujoco's mj_forward at random q."""
+    kb = load_mjcf_kinbody_normalized(TOY, "base", "link3")
+    assert len(kb.joints) == 3
+    rng = np.random.default_rng(0)
+    worst = 0.0
+    for _ in range(50):
+        q = rng.uniform(-2.0, 2.0, size=3)
+        ref = _mujoco_base_ee_fk(TOY, "base", "link3", q)
+        got = poe_forward_kinematics(kb, q)
+        worst = max(worst, float(np.abs(got - ref).max()))
+    assert worst < 1e-12, f"MJCF KinBody FK off from mujoco by {worst:.2e}"
+
+
+def test_mjcf_limits_are_read() -> None:
+    kb = load_mjcf_kinbody_normalized(TOY, "base", "link3")
+    limits = [j.limits for j in kb.joints]
+    assert limits[0] is None  # j1 unlimited
+    assert limits[1] == pytest.approx((-2.0, 2.0))  # j2 range
+    assert limits[2] is None  # j3 unlimited
+
+
+def test_mjcf_missing_body_raises() -> None:
+    with pytest.raises(ValueError, match="no body named"):
+        load_mjcf_kinbody_normalized(TOY, "base", "nonexistent")
+
+
+def test_mjcf_rejects_ball_joint(tmp_path: Path) -> None:
+    """Ball/free joints are multi-DOF and unsupported -- raise, don't mis-parse."""
+    ball = tmp_path / "ball.xml"
+    ball.write_text(
+        "<mujoco model='b'><worldbody><body name='base'>"
+        "<body name='ee' pos='0 0 0.2'>"
+        "<joint name='jb' type='ball'/>"
+        "<inertial pos='0 0 0' mass='1' diaginertia='0.01 0.01 0.01'/>"
+        "</body></body></worldbody></mujoco>"
+    )
+    with pytest.raises(NotImplementedError, match="hinge/slide"):
+        load_mjcf_kinbody_normalized(ball, "base", "ee")

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -276,6 +285,22 @@ wheels = [
 ]
 
 [[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
+]
+
+[[package]]
 name = "freetype-py"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -287,6 +312,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/93/6f/fcc1789e42b8c6617c3112196d68e87bfe7d957d80812d3c24d639782dcb/freetype_py-2.5.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:cd3bfdbb7e1a84818cfbc8025fca3096f4f2afcd5d4641184bf0a3a2e6f97bbf", size = 1108180, upload-time = "2024-08-29T18:32:21.871Z" },
     { url = "https://files.pythonhosted.org/packages/2a/1b/161d3a6244b8a820aef188e4397a750d4a8196316809576d015f26594296/freetype_py-2.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3c1aefc4f0d5b7425f014daccc5fdc7c6f914fb7d6a695cc684f1c09cd8c1660", size = 1106792, upload-time = "2024-08-29T18:32:23.134Z" },
     { url = "https://files.pythonhosted.org/packages/93/6e/bd7fbfacca077bc6f34f1a1109800a2c41ab50f4704d3a0507ba41009915/freetype_py-2.5.1-py3-none-win_amd64.whl", hash = "sha256:0b7f8e0342779f65ca13ef8bc103938366fecade23e6bb37cb671c2b8ad7f124", size = 814608, upload-time = "2024-08-29T18:32:24.648Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -323,6 +357,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
+name = "glfw"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/72/642d4f12f61816ac96777f7360d413e3977a7dd08237d196f02da681b186/glfw-2.10.0.tar.gz", hash = "sha256:801e55d8581b34df9aa2cfea43feb06ff617576e2a8cc5dac23ee75b26d10abe", size = 31475, upload-time = "2025-09-12T08:54:38.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/1f/a9ce08b1173b0ab625ee92f0c47a5278b3e76fd367699880d8ee7d56c338/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_10_6_intel.whl", hash = "sha256:5f365a8c94bcea71ec91327e7c16e7cf739128479a18b8c1241b004b40acc412", size = 105329, upload-time = "2025-09-12T08:54:27.938Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/96/5a2220abcbd027eebcf8bedd28207a2de168899e51be13ba01ebdd4147a1/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_11_0_arm64.whl", hash = "sha256:5328db1a92d07abd988730517ec02aa8390d3e6ef7ce98c8b57ecba2f43a39ba", size = 102179, upload-time = "2025-09-12T08:54:29.163Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/41/a5bd1d9e1808f400102bd7d328c4ac17b65fb2fc8014014ec6f23d02f662/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_aarch64.whl", hash = "sha256:312c4c1dd5509613ed6bc1e95a8dbb75a36b6dcc4120f50dc3892b40172e9053", size = 230039, upload-time = "2025-09-12T08:54:30.201Z" },
+    { url = "https://files.pythonhosted.org/packages/80/aa/3b503c448609dee6cb4e7138b4109338f0e65b97be107ab85562269d378d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_x86_64.whl", hash = "sha256:59c53387dc08c62e8bed86bbe3a8d53ab1b27161281ffa0e7f27b64284e2627c", size = 241984, upload-time = "2025-09-12T08:54:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2d/bfe39a42cad8e80b02bf5f7cae19ba67832c1810bbd3624a8e83153d74a4/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_aarch64.whl", hash = "sha256:c6f292fdaf3f9a99e598ede6582d21c523a6f51f8f5e66213849101a6bcdc699", size = 231052, upload-time = "2025-09-12T08:54:32.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/02/6e639e90f181dc9127046e00d0528f9f7ad12d428972e3a5378b9aefdb0b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_x86_64.whl", hash = "sha256:7916034efa867927892635733a3b6af8cd95ceb10566fd7f1e0d2763c2ee8b12", size = 243525, upload-time = "2025-09-12T08:54:34.006Z" },
+    { url = "https://files.pythonhosted.org/packages/84/06/cb588ca65561defe0fc48d1df4c2ac12569b81231ae4f2b52ab37007d0bd/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win32.whl", hash = "sha256:6c9549da71b93e367b4d71438798daae1da2592039fd14204a80a1a2348ae127", size = 552685, upload-time = "2025-09-12T08:54:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/86/27/00c9c96af18ac0a5eac2ff61cbe306551a2d770d7173f396d0792ee1a59e/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win_amd64.whl", hash = "sha256:6292d5d6634d668cd23d337e6089491d3945a9aa4ac6e1667b0003520d7caa51", size = 559466, upload-time = "2025-09-12T08:54:37.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/87/de0b33f6f00687499ca1371f22aa73396341b85bf88f1a284f9da8842493/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_10_6_intel.whl", hash = "sha256:2aab89d2d9535635ba011fc7303390685169a1aa6731ad580d08d043524b8899", size = 105326, upload-time = "2026-01-28T05:57:56.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a6/6ea2f73ad4474896d9e38b3ffbe6ffd5a802c738392269e99e8c6621a461/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:23936202a107039b5372f0b88ae1d11080746aa1c78910a45d4a0c4cf408cfaa", size = 102180, upload-time = "2026-01-28T05:57:57.787Z" },
+    { url = "https://files.pythonhosted.org/packages/58/19/d81b19e8261b9cb51b81d1402167791fef81088dfe91f0c4e9d136fdc5ca/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_aarch64.whl", hash = "sha256:7be06d0838f61df67bd54cb6266a6193d54083acb3624ff3c3812a6358406fa4", size = 230038, upload-time = "2026-01-28T05:57:59.105Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/b035636cd82198b97b51a93efe9cfc4343d6b15cefbd336a3f2be871d848/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_x86_64.whl", hash = "sha256:91d36b3582a766512eff8e3b5dcc2d3ffcbf10b7cf448551085a08a10f1b8244", size = 241983, upload-time = "2026-01-28T05:58:00.352Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b4/f7b6cc022dd7c68b6c702d19da5d591f978f89c958b9bd3090615db0c739/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_aarch64.whl", hash = "sha256:27c9e9a2d5e1dc3c9e3996171d844d9df9a5a101e797cb94cce217b7afcf8fd9", size = 231053, upload-time = "2026-01-28T05:58:01.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload-time = "2026-01-28T05:58:03.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload-time = "2026-01-28T05:58:05.649Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload-time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload-time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload-time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload-time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload-time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload-time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
 ]
 
 [[package]]
@@ -1011,6 +1077,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
     { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
     { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
+name = "mujoco"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", extra = ["epath"] },
+    { name = "glfw" },
+    { name = "numpy" },
+    { name = "pyopengl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/3b/c76837b7fdb007f7605ff783689a0bd23a5a49b065928bec2f1fa7ea3d67/mujoco-3.10.0.tar.gz", hash = "sha256:c9e8d5d87d82204ed5bccc87d843c0a53e75aaf381de2938ec46d04f1ac6e24e", size = 1094987, upload-time = "2026-06-22T17:40:59.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/bd/c3a4ad6884e60bbbff3d77df75358570bcf9b97ff8d81a0ea3b311b0276e/mujoco-3.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:62b7e9faf714f1582e1dd923ba3ea769a939cc572f6d77909752cbb31db5409f", size = 7758349, upload-time = "2026-06-22T17:40:02.329Z" },
+    { url = "https://files.pythonhosted.org/packages/41/69/4c55c05fe602d72be5526d911e6802de1e67ad70c9301f556eef1d78a4bb/mujoco-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b812e0e36e8b2dde8ce4ad9b25e189b658b9c94f5e798aa64783261abb88321", size = 19348907, upload-time = "2026-06-22T17:40:04.634Z" },
+    { url = "https://files.pythonhosted.org/packages/05/19/a8a560f29f7f0137da6d41d633bc892a9e8ebc36af64c31a3db5882d26d8/mujoco-3.10.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0eff9fb64c39c21f5e29f39996c152ed9a2a5c783818b524c77abf41f6e5751", size = 19654107, upload-time = "2026-06-22T17:40:07.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/07/a37fc7fa55d38e9225884b80c3d241e669357e83f7e23f80b8860a7e14cd/mujoco-3.10.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5489e18a8dd09da2dd71d28563e17889a2e5a0ad07943ebcaa1446d6c4d4e1dd", size = 20789312, upload-time = "2026-06-22T17:40:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/82/84/6548d32afc49fb79015a0b98d1119628ce94dd8befb4526c2cd10429e13f/mujoco-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:45a27a8982e6f89f09e87e4578a5d3e7c9b5667f3db07052e518993b78c9b3ea", size = 17757305, upload-time = "2026-06-22T17:40:13.448Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a2/4dd9f4cec6ce92f836a8b2de1cc799c4458af1467d7a044ef8014217bdb4/mujoco-3.10.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:47d4a22b7667c60e24e7ef6acb027c13abe9abba9acf17cc8db6fb250ba275ea", size = 7772567, upload-time = "2026-06-22T17:40:16.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7d/ebe5342c136de27e0c430ba781f829df2cd66c00ed22627c1964fbd5d7fe/mujoco-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4d35e9d0b13ff9ad3196294a7dac363f1d0cdaa988832d0b687d42d98f4ee29", size = 19380823, upload-time = "2026-06-22T17:40:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5d/43d1b2b9fe97676e5af03020e132ac497b45a0333a4c61de657d0d52170a/mujoco-3.10.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb7f0d7c148a588f3633020807fc0ec3f3a9aff1f647406e3e0ffe96b05dfd57", size = 19705628, upload-time = "2026-06-22T17:40:22.549Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/11/c69199e4123935f98068ab6ab6b35955b4de0f6a91d3f9883805a5789394/mujoco-3.10.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:966d12f88e77e2b188e7530667b519d6963b9b906cff83bab534e5e4279325a0", size = 20904309, upload-time = "2026-06-22T17:40:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/07bf2550c7dcd69ee8c7fd1f5c400a4ba2e4ede0a29a463ad3ac4cc9da90/mujoco-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:708edb5aceee96f2767b1072641523060043b2c67000e39e6e9797addf073696", size = 17865123, upload-time = "2026-06-22T17:40:28.996Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/a9a19f025d3b323aca9d00e34fdc177e7290c5f23adf6341109a7e961920/mujoco-3.10.0-cp313-cp313-macosx_10_16_x86_64.whl", hash = "sha256:396a49c1baeb4cb1efd1fc213e54baf6d2a5ca42bcd99da82278501a32cb5d42", size = 7772943, upload-time = "2026-06-22T17:40:31.951Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ea/15dfc7cc10f44f46286a0634499f3a63e03269adb4788903f3751e964be0/mujoco-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db794d8b8a64e3bb6a0f226a9200293a4890f490c93411fcc531a145f373521b", size = 19381290, upload-time = "2026-06-22T17:40:34.251Z" },
+    { url = "https://files.pythonhosted.org/packages/76/82/ab50abb150805e711e02b7b7424b86bd12297bc5476fb1455ce739fa0d1b/mujoco-3.10.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:720174e7132ccf5f7e9eb86a0855c1b1e93330755f734c21fa58e7bde65bd140", size = 19705727, upload-time = "2026-06-22T17:40:36.968Z" },
+    { url = "https://files.pythonhosted.org/packages/52/49/f6f0c7c54c646adda647aa7495bdc69572419480c37d5cd0bee132ebacd6/mujoco-3.10.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0a5725cc9c9a4da1d5f2b8314ad6d39007e09430ac00aa8d023995ce1f2a3e9", size = 20904596, upload-time = "2026-06-22T17:40:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ea/53c7bcef3ef4de63563d9536e4fe6728996f0fc13e82040b1614ad0e32d9/mujoco-3.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:928dca15b06161b88153df2dc2f7c141d41f39e08e20d1804df8d53f42d9f62c", size = 17865523, upload-time = "2026-06-22T17:40:43.233Z" },
+    { url = "https://files.pythonhosted.org/packages/24/69/a55911e462181ec5793cdcd6e4a8bf35dedbe4c8cb8f71f51ad38f724f55/mujoco-3.10.0-cp314-cp314-macosx_10_16_x86_64.whl", hash = "sha256:d8c9a865b04030933de15842823856ce0ef20a12bf5c972a3782e27e78158e41", size = 7835852, upload-time = "2026-06-22T17:40:46.062Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6d/e96037c529e3639f86ac7a62252f464bea2683ef534833bc76658a44f8f6/mujoco-3.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1cdc8f3487e5d73fc330c446fd6e521e81fb28b39b4f735e1cc934c09044ec5b", size = 19400276, upload-time = "2026-06-22T17:40:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c5/f5937fc94d6922d85c750434642a0c02be361de06e5ae35b3b5b4426907a/mujoco-3.10.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4ebc3f494cb2dabcdab499154ba7e02b2d2e98f83612961a4fb6365abb79ba", size = 19719062, upload-time = "2026-06-22T17:40:51.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/1df28d466b09f57f414a5c165075789e123b25b3127c9faf2ded5deca616/mujoco-3.10.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04b57f3f9a58b35b99d5966f8be12f68158ad0c7393b219378af0686f3856dbe", size = 20905473, upload-time = "2026-06-22T17:40:54.665Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d2/14e60c0d3ea248782e8b5ce4844f8970a4d812078b2536aff61385876e94/mujoco-3.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:cb48d042682d227188ba22b51c31b72975bf7ea7d89f0cafed3d40634337f88e", size = 18572894, upload-time = "2026-06-22T17:40:57.73Z" },
 ]
 
 [[package]]
@@ -1900,6 +2001,9 @@ demo = [
     { name = "viser" },
     { name = "yourdfpy" },
 ]
+mjcf = [
+    { name = "mujoco" },
+]
 urdf = [
     { name = "urchin" },
 ]
@@ -1907,6 +2011,7 @@ urdf = [
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
+    { name = "mujoco" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "robot-descriptions" },
@@ -1926,6 +2031,7 @@ docs = [
 requires-dist = [
     { name = "cython", specifier = ">=3.1" },
     { name = "imageio", marker = "extra == 'demo'", specifier = ">=2.34" },
+    { name = "mujoco", marker = "extra == 'mjcf'", specifier = ">=3.10.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "robot-descriptions", marker = "extra == 'demo'", specifier = ">=2.0.0" },
     { name = "scipy", specifier = ">=1.13" },
@@ -1934,11 +2040,12 @@ requires-dist = [
     { name = "viser", marker = "extra == 'demo'", specifier = ">=1.0" },
     { name = "yourdfpy", marker = "extra == 'demo'", specifier = ">=0.0.60" },
 ]
-provides-extras = ["demo", "urdf"]
+provides-extras = ["demo", "mjcf", "urdf"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = ">=6.112" },
+    { name = "mujoco", specifier = ">=3.0" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=8" },
     { name = "robot-descriptions", specifier = ">=2.0.0" },
@@ -2386,6 +2493,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/19/20c50861f30aff7720f9a601f386d73760c2df9961de1f98d0dbf3b85e69/yourdfpy-0.0.60.tar.gz", hash = "sha256:2af2d8bdeea1b85b642590a3b4236fdb35746d7b3e38ce460a169c18d9c4f868", size = 538238, upload-time = "2026-01-23T07:32:47.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/60/4ea0d6df0b497d51bf2ef87eaab0eb26f8bc3b3313c012da5df3383cced9/yourdfpy-0.0.60-py3-none-any.whl", hash = "sha256:8a187a8b18c98db87c76e9a950581b3c875b761e00df83942526c17ea693166c", size = 22194, upload-time = "2026-01-23T07:32:46.481Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #343 (first sub-task of #83: format coverage beyond URDF).

## What

Adds `ssik._mjcf.load_mjcf_kinbody_normalized(path, base_body, ee_body)` — MuJoCo MJCF → POE-normalized `KinBody`, so MuJoCo-native arms and Menagerie MJCF-only entries work with every ssik solver (dispatcher + solvers are format-agnostic).

## Approach: parse via mujoco, don't hand-roll XML

MJCF is rich (`<default>` classes, `<compiler>` angle/coordinate, `<include>`, keyframes). Instead of a fragile XML parser, load with `mujoco.MjModel.from_xml_path` (which compiles all of that) and read the POE form straight off the **q=0 (`qpos0`) forward pass**: `data.xaxis` (world joint axes) + `data.xanchor` (world anchors) + body poses *are* the normalized chain. `mujoco` is an optional dep — the `[mjcf]` extra, mirroring `urchin` for `[urdf]`.

Bonus: `mj_forward` is the **gold-standard reference FK**, so the tests need no separate oracle.

## Validated

- KinBody FK matches mujoco `mj_forward` to **6e-15** over random q on the UR5e Menagerie MJCF.
- End-to-end **MJCF → dispatch (`three_parallel`) → solve** → 6 sols at FK 1.2e-14.
- The angle-convention gotcha is handled *for free*: a `range="-2 2"` with mujoco's default `angle="degree"` compiles to ±0.035 rad and the loader reads the compiled radians — exactly why parsing via mujoco beats hand-rolling.

## Refactor

Extracted the shared `records → KinBody` construction into `_kinbody.build_poe_kinbody`, now used by both the URDF and MJCF loaders. The artifact snapshot test confirms **byte-identical URDF artifacts** after the refactor.

## Scope

Hinge (revolute) + slide (prismatic) single-DOF joints; raises on ball/free. `mujoco` added to the dev group so CI runs the tests.

## Tests (gated on `mujoco`)

FK parity vs `mj_forward` on a committed toy 3R fixture (varied axes + a non-trivial body quat + a limited joint), limit reading, and missing-body / ball-joint error paths.

## Follow-ups
- Wire MJCF into `ssik add-arm` (accept `.xml`).
- USD / SDF loaders (#83).