### PR TITLE
Xacro / modular-URDF support across all loader entry points (closes #327)

### DIFF
--- a/docs/setting_up_your_robot.md
+++ b/docs/setting_up_your_robot.md
@@ -24,6 +24,18 @@ ssik's URDF loader (`ssik._urdf`, backed by `urchin`) is strict about valid URDF
 - ❌ Mid-chain fixed joints — must be either welded into adjacent revolute frames or expanded. Ssik treats the chain as 6R or 7R revolute; fixed joints break the chain.
 - ❌ Continuous joints without limits — ssik treats unset limits as `±2π`, which may produce out-of-range IKs. Set explicit `limit` tags.
 
+### Xacro and MJCF descriptions
+
+You don't need to pre-convert other formats — every loader entry point (`Manipulator.from_urdf`, `ssik build`, `ssik classify`, `ssik add-arm`) accepts them directly:
+
+- **Xacro** (`.xacro` / `*.urdf.xacro`, or a `.urdf` with a xacro namespace) — expanded via `xacrodoc` (`pip install ssik[xacro]`). This resolves `<xacro:include>`, macros, and substitution args, so multi-file descriptions like the Universal Robots family just work. Pass parametrized args with `--xacro-arg name:=value` (repeatable), e.g.:
+  ```bash
+  ssik build ur.xacro --base base_link --ee tool0 --xacro-arg ur_type:=ur10e
+  ```
+- **MJCF** (MuJoCo `.xml`) — load via `ssik._mjcf.load_mjcf_kinbody_normalized(path, base_body, ee_body)` (`pip install ssik[mjcf]`). Parsed through `mujoco` itself, so `<default>` classes, `<compiler>` settings, and `<include>` are all honored.
+
+`ssik add-arm` vendors a **plain, expanded, kinematics-only URDF** into `tests/fixtures/` regardless of the input format.
+
 ### Calibrated URDFs (UR's `.calibrated_urdf`, etc.)
 
 UR ships per-arm calibration offsets that nudge the nominal DH parameters by ~mm. Two paths:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ demo = [
 mjcf = [
     "mujoco>=3.10.0",
 ]
+# ``pip install ssik[xacro]`` to load xacro descriptions (multi-file / macros /
+# substitution args) directly, e.g. the Universal Robots family.
+xacro = [
+    "urchin>=0.0.27",
+    "xacrodoc>=2.0.1",
+]
 
 [project.urls]
 Repository = "https://github.com/personalrobotics/ssik"
@@ -217,6 +223,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "mujoco.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "xacrodoc.*"
 ignore_missing_imports = true
 
 # cython runtime ships ``py.typed`` from 3.1+ but the marker is missing

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -14,7 +14,10 @@ will wrap this.
 
 from __future__ import annotations
 
+import os
+import tempfile
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,9 +27,16 @@ from numpy.typing import NDArray
 from ssik._kinbody import Joint, JointType, KinBody, Link, build_poe_kinbody
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
+    from collections.abc import Iterator
+
     from urchin import Joint as UrchinJoint
 
-__all__ = ["load_urdf_kinbody", "load_urdf_kinbody_normalized", "strip_urdf_to_fixture"]
+__all__ = [
+    "load_urdf_kinbody",
+    "load_urdf_kinbody_normalized",
+    "process_xacro",
+    "strip_urdf_to_fixture",
+]
 
 # Non-kinematic elements stripped when vendoring a URDF as a test fixture:
 # everything irrelevant to inverse kinematics. Keeps fixtures small and free of
@@ -80,6 +90,60 @@ def _import_urchin() -> object:
     return urchin
 
 
+def _import_xacrodoc() -> object:
+    try:
+        import xacrodoc
+    except ImportError as err:
+        raise ImportError(
+            "Xacro descriptions require the optional 'xacro' extra: "
+            "`pip install ssik[xacro]` (or `uv add xacrodoc`)."
+        ) from err
+    return xacrodoc
+
+
+def _is_xacro(path: Path) -> bool:
+    """True if ``path`` is a xacro description -- by extension (``.xacro`` /
+    ``*.urdf.xacro``) or by a xacro namespace/macro in a ``.urdf`` file."""
+    name = path.name.lower()
+    if name.endswith(".xacro"):
+        return True
+    try:
+        head = path.read_text(errors="ignore")
+    except OSError:
+        return False
+    return "xmlns:xacro" in head or "<xacro:" in head
+
+
+def process_xacro(source: str | Path, subargs: dict[str, str] | None = None) -> str:
+    """Expand a xacro description to a flat URDF string via ``xacrodoc``
+    (resolving ``<xacro:include>``, macros, and substitution args).
+
+    :param subargs: xacro substitution args (e.g. ``{"ur_type": "ur10e"}``) for
+        parametrized descriptions.
+    """
+    xacrodoc = _import_xacrodoc()
+    doc = xacrodoc.XacroDoc.from_file(str(source), subargs=subargs or {})  # type: ignore[attr-defined]
+    return str(doc.to_urdf_string())
+
+
+@contextmanager
+def _as_plain_urdf(source: str | Path, subargs: dict[str, str] | None = None) -> Iterator[Path]:
+    """Yield a plain-URDF path for ``source``: the path itself for a URDF, or a
+    temporary expanded URDF for a xacro description (cleaned up on exit)."""
+    src = Path(source)
+    if not _is_xacro(src):
+        yield src
+        return
+    urdf_text = process_xacro(src, subargs)
+    fd, tmp_name = tempfile.mkstemp(suffix=".urdf", prefix=f"{src.stem}_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(urdf_text)
+        yield Path(tmp_name)
+    finally:
+        Path(tmp_name).unlink(missing_ok=True)
+
+
 def _walk_chain(urdf: object, base_link: str, ee_link: str) -> list[UrchinJoint]:
     """Return the ordered list of URDF joints from ``base_link`` to ``ee_link``,
     walking the public ``joints`` list (no private-graph internals).
@@ -129,9 +193,10 @@ def load_urdf_kinbody(
     ee_link: str,
     *,
     lazy_load_meshes: bool = True,
+    xacro_args: dict[str, str] | None = None,
 ) -> KinBody:
-    """Load a URDF file and build a :class:`KinBody` for the chain between
-    ``base_link`` and ``ee_link``.
+    """Load a URDF (or xacro) file and build a :class:`KinBody` for the chain
+    between ``base_link`` and ``ee_link``.
 
     Active joints (revolute / continuous / prismatic) become :class:`Joint`s in
     the kinbody. Fixed joints are fused into the adjacent active joint's
@@ -141,9 +206,12 @@ def load_urdf_kinbody(
 
     :param lazy_load_meshes: forwarded to ``urchin.URDF.load``; default ``True``
         since we don't need mesh geometry for kinematics.
+    :param xacro_args: substitution args for parametrized xacro descriptions
+        (see :func:`process_xacro`); ignored for plain URDFs.
     """
     urchin = _import_urchin()
-    urdf = urchin.URDF.load(str(urdf_path), lazy_load_meshes=lazy_load_meshes)  # type: ignore[attr-defined]
+    with _as_plain_urdf(urdf_path, xacro_args) as plain:
+        urdf = urchin.URDF.load(str(plain), lazy_load_meshes=lazy_load_meshes)  # type: ignore[attr-defined]
 
     chain = _walk_chain(urdf, base_link, ee_link)
 
@@ -221,8 +289,9 @@ def load_urdf_kinbody_normalized(
     ee_link: str,
     *,
     lazy_load_meshes: bool = True,
+    xacro_args: dict[str, str] | None = None,
 ) -> KinBody:
-    """Load a URDF and build a **POE-normalized** :class:`KinBody` for the
+    """Load a URDF (or xacro) and build a **POE-normalized** :class:`KinBody` for the
     chain between ``base_link`` and ``ee_link``.
 
     The resulting chain is kinematically identical to :func:`load_urdf_kinbody`
@@ -251,9 +320,12 @@ def load_urdf_kinbody_normalized(
     q=0, making the structure visible. See #33 for the full analysis.
 
     :param lazy_load_meshes: forwarded to ``urchin.URDF.load``.
+    :param xacro_args: substitution args for parametrized xacro descriptions
+        (see :func:`process_xacro`); ignored for plain URDFs.
     """
     urchin = _import_urchin()
-    urdf = urchin.URDF.load(str(urdf_path), lazy_load_meshes=lazy_load_meshes)  # type: ignore[attr-defined]
+    with _as_plain_urdf(urdf_path, xacro_args) as plain:
+        urdf = urchin.URDF.load(str(plain), lazy_load_meshes=lazy_load_meshes)  # type: ignore[attr-defined]
 
     chain = _walk_chain(urdf, base_link, ee_link)
 

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ssik._urdf import load_urdf_kinbody_normalized, strip_urdf_to_fixture
+from ssik._urdf import _as_plain_urdf, load_urdf_kinbody_normalized, strip_urdf_to_fixture
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.subproblems._rotation import rotation_matrix
@@ -176,7 +176,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("urdf", type=Path, help="Path to the URDF file.")
+    parser.add_argument("urdf", type=Path, help="Path to the URDF or xacro file.")
     parser.add_argument(
         "--base",
         required=True,
@@ -187,6 +187,31 @@ def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
         required=True,
         help="Link name to treat as the end-effector of the kinematic chain.",
     )
+    parser.add_argument(
+        "--xacro-arg",
+        action="append",
+        default=[],
+        metavar="NAME:=VALUE",
+        dest="xacro_arg",
+        help=(
+            "Xacro substitution arg for parametrized descriptions (repeatable), "
+            "e.g. --xacro-arg ur_type:=ur10e. Ignored for plain URDFs."
+        ),
+    )
+
+
+def _parse_xacro_args(args: argparse.Namespace) -> dict[str, str] | None:
+    """Parse ``--xacro-arg NAME:=VALUE`` pairs into a substitution dict."""
+    pairs: list[str] = getattr(args, "xacro_arg", []) or []
+    if not pairs:
+        return None
+    out: dict[str, str] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition(":=")
+        if not sep or not key:
+            raise SystemExit(f"[ssik] ERROR: bad --xacro-arg {pair!r}; expected NAME:=VALUE")
+        out[key] = value
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +246,9 @@ def _configure_logging(verbose_count: int) -> None:
 
 def _run_classify(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
-    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
+    kb = load_urdf_kinbody_normalized(
+        args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
+    )
     print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
     plan = dispatch(kb)
     _print_dispatch_summary(plan)
@@ -235,7 +262,9 @@ def _run_classify(args: argparse.Namespace) -> int:
 
 def _run_build(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
-    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
+    kb = load_urdf_kinbody_normalized(
+        args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
+    )
     print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
 
     print("[ssik] Classifying topology")
@@ -433,15 +462,21 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     if not args.urdf.is_file():
         print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
         return 1
-    kb = load_urdf_kinbody_normalized(args.urdf, args.base, args.ee)
-    print(f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
+    # Resolve xacro -> plain URDF once, then load + vendor from the same source
+    # (vendoring a self-contained, expanded URDF, never the raw xacro).
+    with _as_plain_urdf(args.urdf, _parse_xacro_args(args)) as plain_urdf:
+        kb = load_urdf_kinbody_normalized(plain_urdf, args.base, args.ee)
+        print(
+            f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK"
+        )
 
-    print("[ssik add-arm] Classifying topology")
-    plan = dispatch(kb)
-    _print_dispatch_summary(plan)
+        print("[ssik add-arm] Classifying topology")
+        plan = dispatch(kb)
+        _print_dispatch_summary(plan)
 
-    print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {urdf_dest.relative_to(repo_root)}")
-    n_links, n_joints = strip_urdf_to_fixture(args.urdf, urdf_dest)
+        rel = urdf_dest.relative_to(repo_root)
+        print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {rel}")
+        n_links, n_joints = strip_urdf_to_fixture(plain_urdf, urdf_dest)
     kb_bytes = urdf_dest.stat().st_size
     print(f"[ssik add-arm]   stripped to {n_links} links, {n_joints} joints, {kb_bytes:,} bytes")
 

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -113,19 +113,26 @@ class Manipulator:
         base: str,
         ee: str,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+        xacro_args: dict[str, str] | None = None,
     ) -> Manipulator:
-        """Load a URDF and build a :class:`Manipulator` for the chain
+        """Load a URDF (or xacro) and build a :class:`Manipulator` for the chain
         between ``base`` and ``ee``.
 
         The kinematic chain is POE-normalised internally so the dispatcher
         can match the arm's topology against the solver roster. Mesh loading
         is lazy (the URDF parser does not load STL files unless asked).
 
-        :param path: path to the URDF file.
+        Xacro descriptions (``.xacro`` / ``*.urdf.xacro``, or a ``.urdf`` with a
+        xacro namespace) are expanded automatically via ``xacrodoc``
+        (``pip install ssik[xacro]``).
+
+        :param path: path to the URDF or xacro file.
         :param base: name of the base link in the URDF.
         :param ee: name of the end-effector link in the URDF.
         :param policy: tolerance policy. Defaults to
             :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+        :param xacro_args: substitution args for parametrized xacro descriptions
+            (e.g. ``{"ur_type": "ur10e"}``); ignored for plain URDFs.
 
         :raises FileNotFoundError: if ``path`` doesn't exist.
         :raises ValueError: if ``base`` or ``ee`` are not link names in the URDF.
@@ -142,7 +149,7 @@ class Manipulator:
         if not path_obj.exists():
             raise FileNotFoundError(f"URDF file not found: {path_obj}")
 
-        kb = load_urdf_kinbody_normalized(path, base, ee)
+        kb = load_urdf_kinbody_normalized(path, base, ee, xacro_args=xacro_args)
         return cls(kb, policy=policy)
 
     # ------------------------------------------------------------------

--- a/tests/fixtures/toy2r.urdf.xacro
+++ b/tests/fixtures/toy2r.urdf.xacro
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- Minimal parametrized xacro for the xacro-adapter tests (#327): exercises a
+     substitution arg ($(arg len2)), a property, and a ${} expression so the
+     loader proves it actually expands xacro rather than parsing it as URDF. -->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="toy2r">
+  <xacro:arg name="len2" default="0.3"/>
+  <xacro:property name="L2" value="$(arg len2)"/>
+  <link name="base_link"/>
+  <link name="link1"/>
+  <link name="link2"/>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+  <joint name="j2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="${L2} 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+</robot>

--- a/tests/test_xacro.py
+++ b/tests/test_xacro.py
@@ -1,0 +1,82 @@
+"""Xacro description support (#327): detection, expansion, substitution args.
+
+Gated on the optional ``xacrodoc`` dependency (the ``xacro`` extra; also in the
+dev group so CI runs these).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("xacrodoc")
+pytest.importorskip("urchin")
+
+from ssik._urdf import (
+    _is_xacro,
+    load_urdf_kinbody_normalized,
+    process_xacro,
+)
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+
+FIXTURES = Path(__file__).parent / "fixtures"
+XACRO = FIXTURES / "toy2r.urdf.xacro"
+
+
+def test_is_xacro_by_extension_and_content(tmp_path: Path) -> None:
+    assert _is_xacro(XACRO)
+    plain = tmp_path / "plain.urdf"
+    plain.write_text("<robot name='r'><link name='base_link'/></robot>")
+    assert not _is_xacro(plain)
+    # a .urdf that is actually xacro (namespace) is detected by content
+    sneaky = tmp_path / "sneaky.urdf"
+    sneaky.write_text("<robot xmlns:xacro='http://www.ros.org/wiki/xacro' name='r'/>")
+    assert _is_xacro(sneaky)
+
+
+def test_process_xacro_expands_default_and_subargs() -> None:
+    default = process_xacro(XACRO)
+    assert "<xacro:" not in default  # macros expanded
+    assert "xmlns:xacro" not in default  # namespace gone
+    assert 'xyz="0.3 0 0"' in default  # default len2
+    overridden = process_xacro(XACRO, {"len2": "0.55"})
+    assert 'xyz="0.55 0 0"' in overridden
+
+
+def test_load_xacro_builds_kinbody() -> None:
+    kb = load_urdf_kinbody_normalized(XACRO, "base_link", "link2")
+    assert len(kb.joints) == 2
+    # link2 sits L2=0.3 along x and 0.2 up at q=0.
+    T = poe_forward_kinematics(kb, np.zeros(2))
+    assert T[:3, 3] == pytest.approx([0.3, 0.0, 0.2])
+
+
+def test_load_xacro_honors_subargs() -> None:
+    kb = load_urdf_kinbody_normalized(XACRO, "base_link", "link2", xacro_args={"len2": "0.55"})
+    T = poe_forward_kinematics(kb, np.zeros(2))
+    assert T[:3, 3] == pytest.approx([0.55, 0.0, 0.2])
+
+
+def test_vendor_xacro_to_plain_urdf(tmp_path: Path) -> None:
+    """The ``add-arm`` path -- expand xacro then strip -- yields a plain,
+    FK-equivalent fixture (no xacro tags, no mesh/visual)."""
+    from ssik._urdf import _as_plain_urdf, strip_urdf_to_fixture
+
+    dest = tmp_path / "vendored.urdf"
+    with _as_plain_urdf(XACRO) as plain:
+        strip_urdf_to_fixture(plain, dest)
+    text = dest.read_text()
+    assert "<xacro:" not in text
+    assert "xmlns:xacro" not in text
+    assert "<visual" not in text
+    assert "package://" not in text
+
+    kb_vendored = load_urdf_kinbody_normalized(dest, "base_link", "link2")
+    kb_src = load_urdf_kinbody_normalized(XACRO, "base_link", "link2")
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        q = rng.uniform(-1.0, 1.0, size=len(kb_src.joints))
+        drift = np.abs(poe_forward_kinematics(kb_vendored, q) - poe_forward_kinematics(kb_src, q))
+        assert drift.max() < 1e-12, f"vendored xacro FK drift {drift.max():.2e}"

--- a/uv.lock
+++ b/uv.lock
@@ -2007,6 +2007,10 @@ mjcf = [
 urdf = [
     { name = "urchin" },
 ]
+xacro = [
+    { name = "urchin" },
+    { name = "xacrodoc" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2037,10 +2041,12 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13" },
     { name = "sympy", specifier = ">=1.10" },
     { name = "urchin", marker = "extra == 'urdf'", specifier = ">=0.0.27" },
+    { name = "urchin", marker = "extra == 'xacro'", specifier = ">=0.0.27" },
     { name = "viser", marker = "extra == 'demo'", specifier = ">=1.0" },
+    { name = "xacrodoc", marker = "extra == 'xacro'", specifier = ">=2.0.1" },
     { name = "yourdfpy", marker = "extra == 'demo'", specifier = ">=0.0.60" },
 ]
-provides-extras = ["demo", "mjcf", "urdf"]
+provides-extras = ["demo", "mjcf", "urdf", "xacro"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #327. Second format-coverage win after MJCF (#343) — and the actual engine for the URDF coverage sprint.

## Why

The Universal Robots family and many ROS descriptions ship as **xacro** (macros, `<xacro:include>`, substitution args), not flat URDF. Previously you had to pre-expand by hand. Now every loader entry point accepts xacro directly:

- `Manipulator.from_urdf(...)`
- `ssik build` / `ssik classify` / `ssik add-arm`

## How

Centralized so every consumer benefits from one change: a new `_as_plain_urdf` context manager **detects** xacro (by `.xacro` / `*.urdf.xacro` extension *or* a xacro namespace inside a `.urdf`) and **expands** it via `xacrodoc` to a temp URDF. Both `load_urdf_kinbody` and `load_urdf_kinbody_normalized` route `urchin.URDF.load` through it. Plain URDFs are a zero-cost passthrough.

- `process_xacro(source, subargs)` — public expansion helper.
- `xacro_args` kwarg on both loaders + `Manipulator.from_urdf`; `--xacro-arg NAME:=VALUE` (repeatable) on the CLI for parametrized descriptions:
  ```bash
  ssik build ur.xacro --base base_link --ee tool0 --xacro-arg ur_type:=ur10e
  ```
- `ssik add-arm` resolves xacro → plain URDF **once**, then loads + vendors a self-contained, expanded, kinematics-only fixture (never the raw xacro).
- New optional `[xacro]` extra (`urchin` + `xacrodoc`). `xacrodoc` is already in the dev group, so CI runs these tests. mypy override for the unstubbed `xacrodoc`.

## Verified

ur10e xacro → POE-normalize → dispatch `three_parallel` tier 0 (same class as the shipped ur5). URDF regression (56 tests) stays green after the loader rewrap.

## Tests (gated on `xacrodoc`)

Detection (extension + content), expansion with default and overridden subargs, FK-correct load at both, and the add-arm vendoring path (expand → strip → plain FK-equivalent URDF).

## Docs

`setting_up_your_robot.md` gains a Xacro/MJCF format-support section (and stops listing xacro as a *problem*).

## Unblocks
The UR-family coverage wave — ur10e / ur3e / ur16e / ur20 now drop in via the one-click `add-arm` → `regen_artifacts` → `regen_bench --docs` flow.