### PR TITLE
Quantize cached-RR cache keys to fix ~140x Linux slowdown (#350)

### DIFF
--- a/src/ssik/solvers/ikgeo/_raghavan_roth.py
+++ b/src/ssik/solvers/ikgeo/_raghavan_roth.py
@@ -431,6 +431,21 @@ _DerivationValue = tuple[
 ]
 _DERIVATION_CACHE: dict[_DerivationKey, _DerivationValue] = {}
 
+# Both caches are keyed on per-sample sub-chain DH (from ``poe_to_dh``). Those
+# values differ in the last bits across BLAS backends (OpenBLAS vs Accelerate,
+# ~1e-12); keying on exact floats then misses *across platforms* -- the
+# macOS-baked key != the Linux-runtime key -- silently dropping the cached-RR
+# fast path into the ~200x-slower ``search_1d`` fallback (#350: 55/176 keys
+# missed on Linux, xarm7 5.3 s/solve vs 23 ms on macOS). Quantizing the key to
+# 1e-6 absorbs the cross-backend jitter while keeping distinct sub-chains (which
+# differ by >= 1e-2 between lock samples) separate. The full-precision DH is
+# still used for the derivation itself; only the dict *key* is rounded.
+_DH_KEY_DECIMALS = 6
+
+
+def _dh_key(values: tuple[float, ...] | NDArray[np.float64]) -> tuple[float, ...]:
+    return tuple(round(float(x), _DH_KEY_DECIMALS) for x in values)
+
 
 def _cached_derivation(
     alpha: tuple[float, ...],
@@ -439,7 +454,7 @@ def _cached_derivation(
     linearity_joint: int = 2,
     apply_so3: bool = False,
 ) -> _DerivationValue:
-    key = (alpha, a, d, int(linearity_joint), bool(apply_so3))
+    key = (_dh_key(alpha), _dh_key(a), _dh_key(d), int(linearity_joint), bool(apply_so3))
     cached = _DERIVATION_CACHE.get(key)
     if cached is not None:
         return cached
@@ -486,7 +501,10 @@ def prime_derivation(
     alpha_t = tuple(float(x) for x in alpha)
     a_t = tuple(float(x) for x in a)
     d_t = tuple(float(x) for x in d)
-    _PRIMED_LINEARITY_MAP[(alpha_t, a_t, d_t)] = (int(linearity_joint), bool(apply_so3))
+    _PRIMED_LINEARITY_MAP[(_dh_key(alpha_t), _dh_key(a_t), _dh_key(d_t))] = (
+        int(linearity_joint),
+        bool(apply_so3),
+    )
     _cached_derivation(alpha_t, a_t, d_t, int(linearity_joint), bool(apply_so3))
 
 
@@ -579,14 +597,16 @@ def prime_derivation_from_blob(blob: bytes) -> None:
         "_sym_t_target": T_syms,
     }
     key = (
-        payload["alpha"],
-        payload["a"],
-        payload["d"],
+        _dh_key(payload["alpha"]),
+        _dh_key(payload["a"]),
+        _dh_key(payload["d"]),
         payload["linearity_joint"],
         payload["apply_so3"],
     )
     _DERIVATION_CACHE[key] = (p_sin_fn, p_cos_fn, p_one_fn, q_fn, metadata)
-    _PRIMED_LINEARITY_MAP[(payload["alpha"], payload["a"], payload["d"])] = (
+    _PRIMED_LINEARITY_MAP[
+        (_dh_key(payload["alpha"]), _dh_key(payload["a"]), _dh_key(payload["d"]))
+    ] = (
         payload["linearity_joint"],
         payload["apply_so3"],
     )
@@ -629,9 +649,12 @@ def _prime_aot(
         "right_bilinear": right_bilinear,
         "drop_joint": int(drop_joint),
     }
-    key = (alpha, a, d, int(linearity_joint), bool(apply_so3))
+    key = (_dh_key(alpha), _dh_key(a), _dh_key(d), int(linearity_joint), bool(apply_so3))
     _DERIVATION_CACHE[key] = (p_sin_fn, p_cos_fn, p_one_fn, q_fn, metadata)
-    _PRIMED_LINEARITY_MAP[(alpha, a, d)] = (int(linearity_joint), bool(apply_so3))
+    _PRIMED_LINEARITY_MAP[(_dh_key(alpha), _dh_key(a), _dh_key(d))] = (
+        int(linearity_joint),
+        bool(apply_so3),
+    )
 
 
 def primed_linearity_for_dh(
@@ -649,10 +672,7 @@ def primed_linearity_for_dh(
     fast-path. The lookup is O(1) and free of sympy work, so it's safe
     to call on every per-sample inner dispatch.
     """
-    alpha_t = tuple(float(x) for x in alpha)
-    a_t = tuple(float(x) for x in a)
-    d_t = tuple(float(x) for x in d)
-    return _PRIMED_LINEARITY_MAP.get((alpha_t, a_t, d_t))
+    return _PRIMED_LINEARITY_MAP.get((_dh_key(alpha), _dh_key(a), _dh_key(d)))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rr_serialize_roundtrip.py
+++ b/tests/test_rr_serialize_roundtrip.py
@@ -29,6 +29,7 @@ from ssik.solvers.ikgeo._raghavan_roth import (
     _DERIVATION_CACHE,
     _PRIMED_LINEARITY_MAP,
     _cached_best_leftvar,
+    _dh_key,
     prime_derivation_from_blob,
     primed_linearity_for_dh,
     serialize_derivation,
@@ -97,8 +98,35 @@ def test_prime_from_blob_populates_cache(fresh_cache) -> None:
     _DERIVATION_CACHE.clear()
     _PRIMED_LINEARITY_MAP.clear()
     prime_derivation_from_blob(blob)
-    assert (_ALPHA, _A, _D, linearity, False) in _DERIVATION_CACHE
+    # Caches are keyed on the quantized DH (#350: exact floats miss across BLAS
+    # backends); the public lookup quantizes internally.
+    assert (_dh_key(_ALPHA), _dh_key(_A), _dh_key(_D), linearity, False) in _DERIVATION_CACHE
     assert primed_linearity_for_dh(_ALPHA, _A, _D) == (linearity, False)
+
+
+def test_primed_lookup_tolerates_blas_jitter() -> None:
+    """#350 regression: a sub-chain primed on one BLAS backend must still be
+    found when ``poe_to_dh`` returns DH that differs in the last ~1e-12 bits on
+    another backend (OpenBLAS vs Accelerate). Before quantization, 55/176 of
+    xarm7's lock-sample lookups missed on Linux -> cached-RR returned None ->
+    jointlock fell to the ~200x-slower search solver (xarm7 5.3 s vs 23 ms).
+
+    Fast + deterministic: exercises the keying directly, no sympy derivation.
+    """
+    base = (0.1, -0.5, 1.0, 0.0, 0.25, -0.3)
+    # Perturb by BLAS-jitter scale (well under the 1e-6 key grid), alternating
+    # sign so it isn't a uniform shift.
+    jittered = tuple(x + (1e-11 if i % 2 else -1e-11) for i, x in enumerate(base))
+    assert jittered != base
+    assert _dh_key(base) == _dh_key(jittered)
+
+    key = (_dh_key(base), _dh_key(base), _dh_key(base))
+    _PRIMED_LINEARITY_MAP[key] = (2, False)
+    try:
+        # Lookup with the jittered DH must still hit the primed entry.
+        assert primed_linearity_for_dh(jittered, jittered, jittered) == (2, False)
+    finally:
+        _PRIMED_LINEARITY_MAP.pop(key, None)
 
 
 def test_prime_from_blob_rejects_version_mismatch() -> None:


### PR DESCRIPTION
Fixes the root cause in #350 (Part 1). Split out from the CI-speedup work (#349) for a clean, reviewable history — this is the actual product fix; #349 is the CI infra.

## The bug (user-facing)
`xarm7_ik.solve()` ran **~140× slower on Linux/OpenBLAS than macOS/Accelerate** (5307 ms vs 23 ms per solve). It affected every cached-RR arm on Linux, not just CI.

## Root cause
The cached-RR caches (`_PRIMED_LINEARITY_MAP`, `_DERIVATION_CACHE`) were keyed on **exact DH float tuples**. `poe_to_dh` produces values differing in the last ~1e-12 bits across BLAS backends, so the macOS-baked key ≠ the Linux-runtime key for **55/176** lock-sample sub-chains → cached-RR returned `None` → jointlock fell through to the ~200×-slower `two_intersecting`/`search_1d` path.

## Fix
Quantize the DH key to 1e-6 (round to 6 decimals) at every store + lookup site. Absorbs the cross-backend jitter while keeping distinct sub-chains (≥1e-2 apart) separate. The full-precision DH still drives the derivation itself; only the dict *key* is rounded. macOS is unaffected (it already matched).

## Verified
- On the **Linux/OpenBLAS runner** (instrumented diag): `_try_cached_rr` 176/176 primed, **0 misses, 38 ms/solve** (was 121 primed / 55 None / 5307 ms).
- End-to-end: with this fix, xarm7's 500-pose fuzz runs per-PR on Linux and the full suite passes in ~10 min.
- Regression test: a sub-chain primed on one BLAS backend stays found under ~1e-12 DH jitter (fast — no sympy).

## Follow-ups (filed)
- #350 Part 2: harden or retire the `search_1d` fallback (it's 2.7 s/solve even on macOS when hit).
- #351: compile the pure-Python hot kernels (`_rotation`, `_scalar3`) — broad perf + narrows the platform gap.