### PR TITLE
Wire the T-perturbation rescue into thin-wrapper (SRS-family) arms (#358)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -169,6 +169,16 @@ def _render_thin_wrapper(
     buf.write("    within_seed_tolerance as _ps_within_seed_tolerance,\n")
     buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
     buf.write(")\n")
+    # Bulletproof rescue fallback (#319 / #358): thin-wrapper solvers (the
+    # SRS family -- seven_r.srs / srs_polished) get the same T-perturbation
+    # rescue the specialised orchestrators have, so a reachable-but-degenerate
+    # pose the analytical path empties on is recovered instead of returning [].
+    buf.write("import functools as _functools\n")
+    buf.write("from ssik.refinement import kinbody_jacobian as _kinbody_jacobian\n")
+    buf.write(
+        "from ssik.refinement.rescue import "
+        "rescue_via_T_perturbation as _rescue_via_T_perturbation\n"
+    )
     buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -1326,6 +1336,7 @@ def _render_solve_function(solver_short: str) -> str:
             q_seed=None,
             respect_limits: bool = True,
             allow_refinement: bool = False,
+            allow_rescue: bool = True,
             policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
             refinement_max_iters: int = 15,
             seed_metric: str = "wrap_linf",
@@ -1356,12 +1367,22 @@ def _render_solve_function(solver_short: str) -> str:
             :param allow_refinement: when ``True`` (default), Newton polish
                 fires on near-miss algebraic candidates. Tightens FK
                 closure to machine precision.
+            :param allow_rescue: when ``True`` (default), if the analytical
+                path returns no solutions but the target is within the arm's
+                reach-sphere, ``solve()`` recovers the IK via the
+                T-perturbation rescue (#319) -- reachable-but-degenerate poses
+                (near-singular / near-parallel-axis) return LM-polished
+                solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+                Set ``False`` for a guaranteed-analytical-or-empty result.
+                Gated by the reach-sphere, so far-field unreachable targets
+                stay cheap (no rescue fired).
             :param policy: tolerance policy. Rarely customised.
             :param refinement_max_iters: cap on Newton iterations per
                 candidate when ``allow_refinement=True``.
             :returns: list of :class:`Solution`, one per analytical IK
-                branch. Empty list iff no candidate met the FK tolerance
-                -- check ``if not sols:`` for "unreachable target".
+                branch (plus any rescued at a degenerate pose). Empty list
+                iff the target is unreachable or ``allow_rescue=False`` and
+                the analytical path found nothing.
 
             Solver: {solver_short}.
             \"\"\"
@@ -1374,6 +1395,31 @@ def _render_solve_function(solver_short: str) -> str:
                 allow_refinement=allow_refinement,
                 refinement_max_iters=refinement_max_iters,
             )
+            # Bulletproof fallback (#319 / #358): the analytical path found
+            # nothing. If the target is within the arm's max reach it may be a
+            # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+            # near-parallel-axis spherical joint) the algebraic extraction
+            # can't resolve -- rather than an unreachable target. Recover via
+            # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+            # an exact upper bound by the triangle inequality, so it never
+            # rejects a reachable pose) is checked only in this rare empty
+            # branch and keeps far-field targets cheap. Perturbed re-solves run
+            # with allow_rescue=False (recursion guard + analytical escape
+            # hatch); the rescue calls back with respect_limits=False, so the
+            # rescued set flows through the same limit/seed postprocess below.
+            if not sols and allow_rescue:
+                _reach_radius = sum(
+                    float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+                    for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+                )
+                _T = np.asarray(T_target, dtype=np.float64)
+                if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+                    sols = _rescue_via_T_perturbation(
+                        fk,
+                        _functools.partial(solve, allow_rescue=False),
+                        _T,
+                        jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                    )
             if respect_limits:
                 sols = _ps_wrap_to_limits(sols, _KB)
                 sols = _ps_respect_limits(sols, _KB)

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -453,7 +453,13 @@ supported = false
 refusal = "Currently, only 1-6R robots are solvable with EAIK"
 
 [arms.gen3_ik.known_gaps]
-xfail_reason = "srs_polished coverage gap on q*=[0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875] (0 sols at q*, 5 sols at q* + 0.01 on q5, 1 sol at q* + 0.01 on q7). Same shape as #286 / #288 / #298. Filed as #299."
+# The bulletproof rescue (#358) now recovers this pose for callers -- default
+# solve() returns ~86 LM-polished sols tagged "lm" instead of [] (regression-
+# guarded by 299_gen3 in tests/test_refinement_rescue.py::GROUP_A). The uniform
+# fuzz stays xfailed because it asserts the strict 1e-9 *analytical* ceiling,
+# which the LM rescue (fk_atol 1e-8) doesn't meet -- the analytical srs_polished
+# gap itself is still open (#299).
+xfail_reason = "srs_polished analytical coverage gap on q*=[0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875] (0 sols at q*); recovered for callers by the #358 rescue at ~1e-8, but the strict 1e-9 analytical fuzz stays gated. Filed as #299."
 
 [arms.franka_panda_ik]
 display_name = "Franka Emika Panda (no hand)"

--- a/src/ssik/prebuilt/gen3_ik.py
+++ b/src/ssik/prebuilt/gen3_ik.py
@@ -49,6 +49,9 @@ from ssik.postprocess import (
     within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r.srs_polished import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs_polished"
@@ -158,6 +161,7 @@ def solve(
     q_seed=None,
     respect_limits: bool = True,
     allow_refinement: bool = False,
+    allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
@@ -188,12 +192,22 @@ def solve(
     :param allow_refinement: when ``True`` (default), Newton polish
         fires on near-miss algebraic candidates. Tightens FK
         closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
     :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Empty list iff no candidate met the FK tolerance
-        -- check ``if not sols:`` for "unreachable target".
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
 
     Solver: srs_polished.
     """
@@ -206,6 +220,31 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
     if respect_limits:
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)

--- a/src/ssik/prebuilt/iiwa14_ik.py
+++ b/src/ssik/prebuilt/iiwa14_ik.py
@@ -49,6 +49,9 @@ from ssik.postprocess import (
     within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r.srs import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs"
@@ -158,6 +161,7 @@ def solve(
     q_seed=None,
     respect_limits: bool = True,
     allow_refinement: bool = False,
+    allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
@@ -188,12 +192,22 @@ def solve(
     :param allow_refinement: when ``True`` (default), Newton polish
         fires on near-miss algebraic candidates. Tightens FK
         closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
     :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Empty list iff no candidate met the FK tolerance
-        -- check ``if not sols:`` for "unreachable target".
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
 
     Solver: srs.
     """
@@ -206,6 +220,31 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
     if respect_limits:
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)

--- a/src/ssik/prebuilt/openarm_left_ik.py
+++ b/src/ssik/prebuilt/openarm_left_ik.py
@@ -49,6 +49,9 @@ from ssik.postprocess import (
     within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r.srs import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs"
@@ -158,6 +161,7 @@ def solve(
     q_seed=None,
     respect_limits: bool = True,
     allow_refinement: bool = False,
+    allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
@@ -188,12 +192,22 @@ def solve(
     :param allow_refinement: when ``True`` (default), Newton polish
         fires on near-miss algebraic candidates. Tightens FK
         closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
     :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Empty list iff no candidate met the FK tolerance
-        -- check ``if not sols:`` for "unreachable target".
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
 
     Solver: srs.
     """
@@ -206,6 +220,31 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
     if respect_limits:
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)

--- a/src/ssik/prebuilt/openarm_right_ik.py
+++ b/src/ssik/prebuilt/openarm_right_ik.py
@@ -49,6 +49,9 @@ from ssik.postprocess import (
     within_seed_tolerance as _ps_within_seed_tolerance,
     wrap_to_limits as _ps_wrap_to_limits,
 )
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r.srs import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.srs"
@@ -158,6 +161,7 @@ def solve(
     q_seed=None,
     respect_limits: bool = True,
     allow_refinement: bool = False,
+    allow_rescue: bool = True,
     policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
@@ -188,12 +192,22 @@ def solve(
     :param allow_refinement: when ``True`` (default), Newton polish
         fires on near-miss algebraic candidates. Tightens FK
         closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
     :param policy: tolerance policy. Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
     :returns: list of :class:`Solution`, one per analytical IK
-        branch. Empty list iff no candidate met the FK tolerance
-        -- check ``if not sols:`` for "unreachable target".
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
 
     Solver: srs.
     """
@@ -206,6 +220,31 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
     if respect_limits:
         sols = _ps_wrap_to_limits(sols, _KB)
         sols = _ps_respect_limits(sols, _KB)

--- a/tests/test_refinement_rescue.py
+++ b/tests/test_refinement_rescue.py
@@ -52,6 +52,15 @@ GROUP_A = [
         4,
         id="280_kassow",
     ),
+    # #299 gen3 exercises the *thin-wrapper* rescue path (seven_r.srs_polished),
+    # which #358 wired to match the orchestrator arms above. Raw srs_polished
+    # returns 0 sols here; the rescue recovers dozens (86 on macOS).
+    pytest.param(
+        "gen3_ik",
+        np.array([0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875]),
+        4,
+        id="299_gen3",
+    ),
 ]
 
 


### PR DESCRIPTION
Closes #358. Stacked on #356 (base = `generalize-srs-integration`; retarget to `main` once #356 merges).

## Why

The #319 bulletproof rescue was wired into the specialised orchestrators but **not** the thin-wrapper template, so the SRS family had no safety net — a reachable-but-degenerate pose returned `[]` instead of an LM-polished recovery:

| Prebuilt | Solver | rescue before | after |
|---|---|---|---|
| iiwa14, openarm_left/right | `seven_r.srs` | ❌ | ✅ |
| gen3 | `seven_r.srs_polished` | ❌ | ✅ |
| *(all RR / jointlock / tier-0)* | ... | ✅ | ✅ |

## What

Rescue added to `_render_thin_wrapper` / `_render_solve_function`, mirroring the orchestrator: gated on `not sols and allow_rescue and ||T_pos|| <= reach-sphere`, recursion-guarded (`allow_rescue=False`), analytic Jacobian via `kinbody_jacobian(_KB, q)`. `allow_rescue=True` default + `allow_rescue=False` escape hatch. 4 artifacts regenerated (only those change).

**Design choice — fires on *raw* (pre-limits) emptiness**, unlike the orchestrator's post-limits check. The SRS swivel sweep returns many out-of-limits sols on tight-limit redundant arms (OpenArm), and firing the expensive rescue there would add seconds without helping — that swivel-vs-limits gap is a *separate* redundancy-resolution problem (**#359**) the rescue can't fix. Pre-limits firing targets exactly the rank-deficient ridges the rescue is for.

## Verification

- **gen3 #299 recovered:** default `solve()` returns ~86 LM sols tagged `"lm"` (was `[]`); `allow_rescue=False` → `[]`; unreachable → `[]` (reach-sphere gate). Regression-guarded by the new `299_gen3` case in `GROUP_A` (direct-returns-0 / rescue-recovers / bulletproof-auto-recovers).
- gen3's fuzz known-gap kept, reason updated: the strict **1e-9 analytical** ceiling still gates it (the LM rescue closes to ~1e-8; the `srs_polished` analytical gap itself remains #299).
- Full non-slow suite **1545 passed**; iiwa/openarm normal operation unchanged; `ruff` + `mypy` clean.

Also filed **#359** (reachable in-limits poses returning `[]` on tight-limit redundant 7R — pre-existing, distinct from the rescue; SRS is already better than the old jointlock path there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)