### PR TITLE
Harden gaps revealed by the v3.0.0 release: version guard + default-path fuzz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,28 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Verify built version matches the tag
+        # Same guard as publish_pypi (#364): catch a version/tag mismatch in
+        # the rc dry-run, before the real release.
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "tag version: $TAG"; ls -1 dist/
+          SDIST=$(ls dist/ssik-*.tar.gz 2>/dev/null | head -1)
+          [ -n "$SDIST" ] || { echo "::error::no sdist in dist/"; exit 1; }
+          BUILT=$(basename "$SDIST" .tar.gz); BUILT="${BUILT#ssik-}"
+          echo "built version: $BUILT"
+          if [ "$BUILT" != "$TAG" ]; then
+            echo "::error::built version '$BUILT' != tag '$TAG' -- refusing to publish (likely two tags on one commit; ensure a single v* tag points at the release commit)"
+            exit 1
+          fi
+          for w in dist/ssik-*.whl; do
+            case "$(basename "$w")" in
+              ssik-"$TAG"-*) ;;
+              *) echo "::error::wheel $(basename "$w") is not version $TAG"; exit 1 ;;
+            esac
+          done
+          echo "OK: all dist artifacts are version $TAG"
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -115,6 +137,32 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: Verify built version matches the tag
+        # Guard against the "two v* tags on one commit" footgun (#364): when
+        # both e.g. v3.0.0rc1 and v3.0.0 point at the same commit, hatch-vcs
+        # (via ``git describe``) can resolve the *rc*, so the v3.0.0 run builds
+        # ssik-3.0.0rc1 wheels and would publish those to real PyPI. Refuse to
+        # publish unless every artifact carries the tag's exact version. Tag
+        # convention: ``vX.Y.Z`` / ``vX.Y.ZrcN`` (no dash; already PEP 440).
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "tag version: $TAG"; ls -1 dist/
+          SDIST=$(ls dist/ssik-*.tar.gz 2>/dev/null | head -1)
+          [ -n "$SDIST" ] || { echo "::error::no sdist in dist/"; exit 1; }
+          BUILT=$(basename "$SDIST" .tar.gz); BUILT="${BUILT#ssik-}"
+          echo "built version: $BUILT"
+          if [ "$BUILT" != "$TAG" ]; then
+            echo "::error::built version '$BUILT' != tag '$TAG' -- refusing to publish (likely two tags on one commit; ensure a single v* tag points at the release commit)"
+            exit 1
+          fi
+          for w in dist/ssik-*.whl; do
+            case "$(basename "$w")" in
+              ssik-"$TAG"-*) ;;
+              *) echo "::error::wheel $(basename "$w") is not version $TAG"; exit 1 ;;
+            esac
+          done
+          echo "OK: all dist artifacts are version $TAG"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/test_prebuilt_uniform_fuzz.py
+++ b/tests/test_prebuilt_uniform_fuzz.py
@@ -243,3 +243,73 @@ def test_prebuilt_7r_tight_policy_machine_precision(arm_name: str, q_star: np.nd
     assert max_fk < 1e-7, (
         f"{arm_name}: tight-policy max FK {max_fk:.2e} > 1e-7 at q*={q_star.tolist()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Default-path (respect_limits=True) in-limits coverage (#359).
+#
+# The round-trip fuzz above deliberately passes ``respect_limits=False`` to
+# isolate the analytical solver from URDF joint-limit filtering. But the
+# DEFAULT ``solve()`` applies ``respect_limits=True`` -- the path every user
+# actually takes. Nothing exercised it, which is exactly why the swivel-vs-
+# limits gap (#359) stayed invisible. This test closes that: sample q strictly
+# within each arm's joint limits (so an in-limits IK provably exists), FK, and
+# assert the default solve() returns >= 1 solution.
+#
+# Redundant 7R arms with tight joint limits (OpenArm, R1 Pro) return [] on a
+# small fraction of these: the elbow-swivel sweep samples [-pi, pi] uniformly
+# and can miss the narrow in-limits swivel arc. Tracked as #359, xfailed below
+# so the gap is visible; the other 7 arms get a real 0-empty guarantee.
+# ---------------------------------------------------------------------------
+
+# The SRS-family swivel-sampled arms (seven_r.srs / srs_polished) with tight
+# joint limits. iiwa14 is also seven_r.srs but has wide limits, so its in-limits
+# swivel arc is never narrow enough to miss -- it holds the guarantee.
+_LIMITS_GAP_7R = {
+    "gen3_ik",
+    "openarm_left_ik",
+    "openarm_right_ik",
+    "r1pro_left_ik",
+    "r1pro_right_ik",
+}
+
+
+def _joint_ranges(kb: object) -> list[tuple[float, float]]:
+    """Per-joint (lo, hi) sampling range; continuous joints (no limit) -> +/-pi."""
+    out: list[tuple[float, float]] = []
+    for j in kb.joints:  # type: ignore[attr-defined]
+        lim = j.limits
+        if lim is None or lim[0] is None or lim[1] is None:
+            out.append((-np.pi, np.pi))
+        else:
+            out.append((float(lim[0]), float(lim[1])))
+    return out
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "arm_name",
+    [a[0] for a in PREBUILT_ARMS_7R],
+    ids=[a[0] for a in PREBUILT_ARMS_7R],
+)
+def test_prebuilt_7r_in_limits_default_path(arm_name: str) -> None:
+    """Every reachable *in-limits* pose returns >= 1 IK on the DEFAULT
+    ``solve()`` path (``respect_limits=True``) -- the path users take (the
+    round-trip fuzz above uses ``respect_limits=False``). 200 deterministic
+    in-limits poses per arm. Redundant tight-limit arms are xfailed for the
+    swivel-vs-limits gap (#359)."""
+    if arm_name in _LIMITS_GAP_7R:
+        pytest.xfail(
+            f"{arm_name}: redundant 7R with tight joint limits -- the elbow-swivel "
+            "sweep can miss the narrow in-limits arc, so some reachable in-limits "
+            "poses return [] on the default respect_limits=True path (#359)"
+        )
+    mod = _load(arm_name)
+    ranges = _joint_ranges(mod._KB)
+    rng = np.random.default_rng(0)
+    for _ in range(200):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in ranges])
+        assert mod.solve(mod.fk(q)), (
+            f"{arm_name}: reachable in-limits pose q={q.tolist()} returned [] "
+            "on the default respect_limits=True path"
+        )


### PR DESCRIPTION
Two hardening fixes for gaps this release cycle exposed. Both are cheap, high-leverage, and each is a self-contained commit.

## 1. Release version guard (#364)
The v3.0.0 cut had `v3.0.0rc1` and `v3.0.0` on the **same commit**; hatch-vcs resolved the rc, so the "v3.0.0" run built + published **`ssik-3.0.0rc1`** to real PyPI. Add a *"Verify built version matches the tag"* step to both publish jobs in `release.yml`: refuse to publish unless every dist artifact carries the tag's exact version. Validated locally against the incident case (tag `3.0.0` + rc1 dists → refuse) and both happy paths. The rc dry-run carries the same guard, so a mismatch is caught on TestPyPI *before* the real release.

## 2. Default-path (`respect_limits=True`) fuzz for 7R arms (#359)
**Meta-finding:** the round-trip fuzz uses `respect_limits=False`, so *nothing* exercised the default `solve()` path users actually take — which is exactly why the swivel-vs-limits gap stayed invisible. `test_prebuilt_7r_in_limits_default_path` closes it: sample q strictly within each arm's joint limits (so an in-limits IK provably exists), FK, assert the default `solve()` returns ≥1 IK.

- **7 arms** (iiwa14 + the jointlock 7R set) now have a real **0-empty guarantee** on the default path — previously untested.
- **5 SRS-family tight-limit arms** (gen3, OpenArm L/R, R1 Pro L/R) are xfailed, tied to **#359**. The test immediately caught **gen3** as a gap arm my by-hand probing had missed (returns 52 sols, none in-limits, while an in-limits solution exists).

#359 updated with the redundancy-resolution approach (sample within the admissible swivel-arc instead of filtering after a uniform sweep). When fixed, drop arms from `_LIMITS_GAP_7R` and the test enforces the guarantee.

## Verification
- Guard: unit-validated (incident → refuse; 3.0.0 / 3.0.0rc1 → ok).
- Test: `7 passed, 5 xfailed`; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)