### PR TITLE
Support Python 3.10 and numpy 1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Analytical inverse kinematics for 6R and 7R revolute arms. Return
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [{ name = "Siddhartha Srinivasa" }]
 keywords = ["robotics", "inverse-kinematics", "ik-geo", "kinematics"]
 classifiers = [
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "numpy>=2.0",
+    "numpy>=1.26",
     # scipy.linalg / scipy.signal are imported at module top in
     # ``ssik._pencil`` and ``ssik.solvers.husty_pfurner._eliminate``; HP backs
     # every non-SRS 7R prebuilt (Franka, Rizon, Kassow). Without scipy a

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -50,6 +50,24 @@ from ssik.manipulator import Manipulator
 # the ``ssik`` namespace explicitly.
 _logging.getLogger(__name__).addHandler(_logging.NullHandler())
 
+# Python 3.10 and numpy 1.x install and work, but they sit below the versions
+# CI exercises and below the Scientific Python SPEC 0 support window
+# (https://scientific-python.org/specs/spec-0000/, which recommends dropping
+# Python 3 years and numpy 2 years after release). We allow them on a
+# best-effort, untested basis and warn once so users know. See #366.
+import sys as _sys
+import warnings as _warnings
+
+if _sys.version_info < (3, 11):
+    _warnings.warn(
+        f"ssik is running on Python {_sys.version_info.major}."
+        f"{_sys.version_info.minor}, below the tested minimum (3.11) and the "
+        "Scientific Python SPEC 0 support window. It is supported on a "
+        "best-effort, untested basis. See "
+        "https://github.com/personalrobotics/ssik/issues/366.",
+        stacklevel=2,
+    )
+
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",
     "Diagnostic",


### PR DESCRIPTION
Closes #366.

## What

Lowers the minimum supported runtime versions to broaden install compatibility:

- `requires-python`: `>=3.11` → `>=3.10`
- `numpy` dependency floor: `>=2.0` → `>=1.26`

Plus a one-time import warning for users on the below-floor versions.

## Why

Enables installation in environments still pinned to Python 3.10 / the numpy 1.26 series, without forcing a numpy 2.x upgrade.

## Support policy — best-effort, untested

Both targets are below the Scientific Python [SPEC 0][spec0] window, which recommends dropping Python 3 years and numpy 2 years after release:

- Python 3.10 (Oct 2021) → SPEC 0 EOL ~Q4 2024
- numpy 1.26 (Sep 2023) → SPEC 0 EOL ~Q3 2025

We support them anyway because the cost is near zero (a two-line constraint relaxation, no source changes to the solvers), but we do **not** test them: CI and `test-requires` stay on the tested floor (Python 3.11+, numpy 2.0).
To make this explicit to users, importing `ssik` under Python < 3.11 emits a one-time `UserWarning` pointing here.
The `Python :: 3.10` trove classifier is intentionally omitted for the same reason.

[spec0]: https://scientific-python.org/specs/spec-0000/

## Testing

Verified the package installs, imports, and functions under Python 3.10 with numpy 1.26.
