### PR TITLE
Extend feasible-swivel limit resolution to approximate-SRS / gen3 (#370)

### DIFF
--- a/src/ssik/solvers/seven_r/_swivel_limits.py
+++ b/src/ssik/solvers/seven_r/_swivel_limits.py
@@ -43,7 +43,9 @@ from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import (
     SrsClassification,
     _classify_srs_7r_geometric,
+    is_approximately_srs_7r,
 )
+from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian, lm_refine_batch
 from ssik.solvers.seven_r.srs import (
     _arm_constants,
     _min_rotation,
@@ -338,23 +340,34 @@ def feasible_in_limits_solutions(
     limits: list[tuple[float, float]],
     *,
     max_solutions: int | None = None,
+    samples_per_arc: int = 1,
 ) -> list[NDArray[np.float64]]:
-    """Exact in-limits IK solutions via feasible-swivel resolution.
+    """In-limits IK solutions via feasible-swivel resolution.
 
-    Returns wrapped-to-limits joint vectors, one per feasible swivel arc
-    (sampled at the arc centre = maximum joint-limit margin). Empty iff no
-    in-limits solution exists (target unreachable-in-limits).
+    Returns wrapped-to-limits joint vectors. ``samples_per_arc=1`` (the exact-SRS
+    default) takes each arc's centre (maximum joint-limit margin); >1 spreads
+    that many interior samples per arc -- used by the approximate-SRS path, where
+    each seed is LM-polished and only some stay in-limits after the polish shift.
+    Empty iff no in-limits solution exists (target unreachable-in-limits).
     """
     T = np.asarray(T, dtype=np.float64)
     out: list[NDArray[np.float64]] = []
     for branch in _enumerate_branches(kb, cls, T):
         for a, b in _branch_arcs(branch, limits):
-            psi = 0.5 * (a + b)
-            q = branch.q(psi)
-            q = np.array([_to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)])
-            out.append(q)
-            if max_solutions is not None and len(out) >= max_solutions:
-                return out
+            psis = (
+                [0.5 * (a + b)]
+                if samples_per_arc == 1
+                else np.linspace(a, b, samples_per_arc + 2)[1:-1].tolist()
+            )
+            for psi in psis:
+                q = branch.q(float(psi))
+                out.append(
+                    np.array(
+                        [_to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)]
+                    )
+                )
+                if max_solutions is not None and len(out) >= max_solutions:
+                    return out
     return out
 
 
@@ -369,6 +382,15 @@ def _joint_limits(kb: KinBody) -> list[tuple[float, float]]:
     return lims
 
 
+_APPROX_MAX_DRIFT_M = 0.04  # matches seven_r.srs_polished's default gate
+_APPROX_SAMPLES_PER_ARC = 5  # LM shift can push the arc centre out of limits
+_APPROX_FK_ATOL = 1e-8
+
+
+def _in_limits(q: NDArray[np.float64], limits: list[tuple[float, float]]) -> bool:
+    return all(lo - 1e-9 <= q[i] <= hi + 1e-9 for i, (lo, hi) in enumerate(limits))
+
+
 def resolve_in_limits(
     kb: KinBody,
     T_target: NDArray[np.float64],
@@ -376,23 +398,57 @@ def resolve_in_limits(
     *,
     max_solutions: int | None = None,
 ) -> list[Solution]:
-    """Exact joint-limit-aware IK for SRS-class 7R via feasible-swivel resolution.
+    """Joint-limit-aware IK for SRS-class 7R via feasible-swivel resolution.
 
     Intended as the ``respect_limits`` fallback for the SRS-family prebuilt
     ``solve()``: when the blind swivel sweep samples no in-limits candidate, the
-    feasible-swivel arcs recover the in-limits solution(s) exactly (#359).
-    Returns FK-verified :class:`Solution` objects (already wrapped into limits);
-    empty when the chain is not SRS-class or no in-limits solution exists.
+    feasible-swivel arcs recover the in-limits solution(s) (#359). Returns
+    FK-verified, in-limits :class:`Solution` objects; empty when the chain is not
+    SRS-class or no in-limits solution exists.
+
+    Exactly-concurrent SRS chains are solved in closed form (machine precision).
+    Approximately-SRS chains (e.g. Kinova Gen3) run the resolver on the best-fit
+    pivots to seed candidates, then LM-polish each to machine-precision FK against
+    the true URDF, keeping those still in-limits (#370).
     """
-    cls = _classify_srs_7r_geometric(kb, policy)
-    if cls is None or len(kb.joints) != 7:
+    if len(kb.joints) != 7:
         return []
-    limits = _joint_limits(kb)
     T = np.asarray(T_target, dtype=np.float64)
-    fk_atol = policy.subproblem_numerical
-    out: list[Solution] = []
-    for q in feasible_in_limits_solutions(kb, cls, T, limits, max_solutions=max_solutions):
-        residual = float(np.linalg.norm(poe_forward_kinematics(kb, q) - T))
-        if residual <= fk_atol:
-            out.append(Solution(q=q, fk_residual=residual, refinement_used="none"))
-    return out
+    limits = _joint_limits(kb)
+
+    cls = _classify_srs_7r_geometric(kb, policy)
+    if cls is not None:
+        fk_atol = policy.subproblem_numerical
+        exact: list[Solution] = []
+        for q in feasible_in_limits_solutions(kb, cls, T, limits, max_solutions=max_solutions):
+            residual = float(np.linalg.norm(poe_forward_kinematics(kb, q) - T))
+            if residual <= fk_atol:
+                exact.append(Solution(q=q, fk_residual=residual, refinement_used="none"))
+        return exact
+
+    # Approximately-SRS (#370): best-fit resolver seeds + LM polish.
+    approx = is_approximately_srs_7r(kb, max_drift_m=_APPROX_MAX_DRIFT_M, policy=policy)
+    if approx is None:
+        return []
+    seeds = feasible_in_limits_solutions(
+        kb, approx.base, T, limits, samples_per_arc=_APPROX_SAMPLES_PER_ARC
+    )
+    if not seeds:
+        return []
+
+    def _fk(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        t: NDArray[np.float64] = poe_forward_kinematics(kb, q)
+        return t
+
+    def _jac(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        j: NDArray[np.float64] = kinbody_jacobian(kb, q)
+        return j
+
+    q_polished, residuals, _iters = lm_refine_batch(np.asarray(seeds), _fk, _jac, T)
+    polished: list[Solution] = [
+        Solution(q=q_polished[i], fk_residual=float(residuals[i]), refinement_used="lm")
+        for i in range(q_polished.shape[0])
+        if residuals[i] <= _APPROX_FK_ATOL and _in_limits(q_polished[i], limits)
+    ]
+    out = dedup_by_wrap_close(polished, policy.subproblem_dedup)
+    return out[:max_solutions] if max_solutions is not None else out

--- a/tests/test_prebuilt_uniform_fuzz.py
+++ b/tests/test_prebuilt_uniform_fuzz.py
@@ -262,15 +262,11 @@ def test_prebuilt_7r_tight_policy_machine_precision(arm_name: str, q_star: np.nd
 # so the gap is visible; the other 7 arms get a real 0-empty guarantee.
 # ---------------------------------------------------------------------------
 
-# gen3 (seven_r.srs_polished, *approximately* SRS) still gaps: the exact
-# feasible-swivel resolver (#359) only applies to exactly-concurrent SRS chains,
-# so it no-ops here and gen3 falls back to the blind sweep. The exactly-SRS
-# arms (iiwa14 + openarm + r1pro) now hold the in-limits guarantee via the
-# resolver. Extending it to approximate-SRS (relaxed-pivot + LM polish) is a
-# follow-up.
-_LIMITS_GAP_7R = {
-    "gen3_ik",
-}
+# Every shipped 7R arm now holds the default-path in-limits guarantee: the
+# exactly-SRS arms via the closed-form feasible-swivel resolver (#359), and the
+# approximately-SRS gen3 via the same resolver on best-fit pivots + LM polish
+# (#370). Empty set = no arm is allowed to drop a reachable in-limits pose.
+_LIMITS_GAP_7R: set[str] = set()
 
 
 def _joint_ranges(kb: object) -> list[tuple[float, float]]:

--- a/tests/test_swivel_limits.py
+++ b/tests/test_swivel_limits.py
@@ -64,6 +64,34 @@ def test_resolves_every_in_limits_pose(name: str, base: str, ee: str) -> None:
     assert worst < 1e-9, f"{name}: worst in-limits FK closure {worst:.2e}"
 
 
+def test_resolves_approximate_srs_gen3() -> None:
+    """Kinova Gen3 is only *approximately* SRS (~12 mm axis drift), so the exact
+    resolver no-ops; the approximate path (#370) seeds from best-fit pivots and
+    LM-polishes to the true FK. At the #299/#359 gen3 gap pose (raw solve returns
+    a set none of which is in-limits) it must return in-limits ``"lm"`` solutions.
+    """
+    kb = load_urdf_kinbody_normalized(FIXTURES / "gen3.urdf", "base_link", "end_effector_link")
+    lims = _limits(kb)
+    q_gap = np.array(
+        [
+            1.6474334178,
+            0.5114245864,
+            -1.1049209077,
+            1.1166184280,
+            -0.0972974297,
+            2.0879156524,
+            1.7343580230,
+        ]
+    )
+    T = poe_forward_kinematics(kb, q_gap)
+    sols = resolve_in_limits(kb, T)
+    assert sols, "gen3: approximate resolver returned no in-limits solution at the gap pose"
+    for s in sols:
+        assert all(lims[i][0] - 1e-9 <= s.q[i] <= lims[i][1] + 1e-9 for i in range(7))
+        assert s.refinement_used == "lm"
+        assert float(np.linalg.norm(poe_forward_kinematics(kb, s.q) - T)) < 1e-8
+
+
 def test_returns_empty_for_non_srs_chain() -> None:
     """Non-SRS chains (no spherical shoulder+wrist) are not resolvable this way;
     the resolver must no-op so it is safe as a universal thin-wrapper fallback."""


### PR DESCRIPTION
Closes #370. Completes the redundancy-under-limits story: **every shipped 7R arm now holds the default-path in-limits guarantee.**

## Context
#369 closed #359 for exactly-concurrent SRS arms via the closed-form feasible-swivel resolver. Kinova Gen3 is only *approximately* SRS (~12 mm axis drift), so the exact resolver no-op'd on it and gen3 still dropped reachable in-limits poses on the default `respect_limits=True` path (it stayed xfailed).

## What
Add an approximate path to `resolve_in_limits`, mirroring `seven_r.srs_polished`:
1. Run the feasible-swivel resolver on the **best-fit pivots** (`ApproxSrsClassification.base`) to seed in-limits candidates — **several samples per feasible arc**, since the LM shift can push an arc centre just out of limits.
2. **LM-polish** each seed to machine-precision FK against the true URDF (`lm_refine_batch` + `kinbody_jacobian`).
3. Keep those still in-limits, dedup, tag `"lm"`.

Stays **scipy-free** (iiwa's import stays lean).

## Result
- gen3 default-path in-limits empty rate → **0**. The #299/#359 gap pose now returns 32 in-limits `"lm"` solutions at FK ~1e-12.
- `_LIMITS_GAP_7R` is now **empty** — `test_prebuilt_7r_in_limits_default_path` **12 passed, no xfails** (gen3 flipped from xfail to pass).

## Not in scope
gen3's strict-1e-9 *analytical* uniform-fuzz gap (#299) is separate (`respect_limits=False`; the LM rescue closes it only to ~1e-8) and stays xfailed.

## Verification
Full non-slow suite **1567 passed**; new gen3 case in `tests/test_swivel_limits.py`; no artifact regen needed (imports by reference); `ruff` + `mypy` clean; scipy-free import chain preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)