### PR TITLE
Extract parameter-agnostic feasible-interval core (#148 step 1)

### DIFF
--- a/src/ssik/solvers/seven_r/_feasible_param.py
+++ b/src/ssik/solvers/seven_r/_feasible_param.py
@@ -144,6 +144,7 @@ def feasible_arcs(
     (parameter-independent) joints are the caller's responsibility to pre-check.
     Empty iff no ``t`` keeps all swept joints in-limits.
     """
+
     def joint(i: int) -> Callable[[float], float]:
         return lambda t: float(q_scalar(t)[i])
 

--- a/src/ssik/solvers/seven_r/_feasible_param.py
+++ b/src/ssik/solvers/seven_r/_feasible_param.py
@@ -1,0 +1,157 @@
+"""Generic feasible-interval core for 1-parameter redundancy families (#148).
+
+A 7R arm with one redundant DOF has, for each fixed IK branch, a smooth
+1-parameter joint family ``q(t)`` (``t`` in ``[-pi, pi)``): the SRS elbow swivel
+(:mod:`._swivel_limits`, #359), or -- the motivation for lifting this out -- a
+locked-joint redundancy for non-SRS 7R (#148). This module computes the *exact*
+set of ``t`` with every joint inside its limits, independent of how ``q(t)`` is
+generated.
+
+Per joint the feasibility test is
+
+    phi_i(t) = cos(q_i(t) - c_i) - cos(h_i) >= 0
+
+with ``c_i`` / ``h_i`` the limit centre / half-width. The ``cos`` removes the
+``atan2`` branch-wrap discontinuity, so ``phi_i`` is smooth and its sign-zeros
+are the exact arc boundaries -- bracketed on a precomputed grid, refined by
+bisection. The per-branch feasible set is the intersection of the swept joints'
+arcs (a fixed joint, constant in ``t``, is checked once by the caller).
+
+Dependency-free on purpose: the SRS import chain stays scipy-free to keep
+iiwa's import lean.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from itertools import pairwise
+
+import numpy as np
+from numpy.typing import NDArray
+
+_TWO_PI = 2.0 * np.pi
+_EPS = 1e-9
+ARC_GRID = 180  # bracketing resolution for phi sign-zeros (refined by bisection)
+PARAM_GRID: NDArray[np.float64] = np.linspace(-np.pi, np.pi, ARC_GRID, endpoint=False)
+
+
+def wrap(a: float) -> float:
+    return float((a + np.pi) % _TWO_PI - np.pi)
+
+
+def bisect(f: Callable[[float], float], a: float, b: float, tol: float = 1e-8) -> float:
+    """Root of monotone-crossing ``f`` in ``[a, b]`` (dependency-free). ``tol``
+    on the bracket width is ample: callers return arc *centres* and FK-verify."""
+    fa = f(a)
+    while b - a > tol:
+        m = 0.5 * (a + b)
+        fm = f(m)
+        if fm == 0.0:
+            return m
+        if fa * fm < 0:
+            b = m
+        else:
+            a, fa = m, fm
+    return 0.5 * (a + b)
+
+
+def merge(arcs: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    if not arcs:
+        return []
+    arcs = sorted(arcs)
+    out = [list(arcs[0])]
+    for a, b in arcs[1:]:
+        if a <= out[-1][1] + _EPS:
+            out[-1][1] = max(out[-1][1], b)
+        else:
+            out.append([a, b])
+    return [(a, b) for a, b in out]
+
+
+def intersect(
+    a_arcs: list[tuple[float, float]], b_arcs: list[tuple[float, float]]
+) -> list[tuple[float, float]]:
+    out: list[tuple[float, float]] = []
+    for a0, a1 in a_arcs:
+        for b0, b1 in b_arcs:
+            lo, hi = max(a0, b0), min(a1, b1)
+            if hi - lo > _EPS:
+                out.append((lo, hi))
+    return merge(out)
+
+
+def to_limits(v: float, lo: float, hi: float) -> float:
+    """The 2*pi-equivalent of ``v`` nearest the limit centre."""
+    k = round((0.5 * (lo + hi) - v) / _TWO_PI)
+    return v + _TWO_PI * k
+
+
+def arcs_for_joint(
+    q_of: Callable[[float], float],
+    lo: float,
+    hi: float,
+    grid: NDArray[np.float64],
+    q_col: NDArray[np.float64],
+) -> list[tuple[float, float]]:
+    """Feasible-``t`` arcs for a single joint ``q_of(t)`` in ``[lo, hi]``.
+
+    ``q_col`` is ``q_of`` evaluated on ``grid`` (precomputed, so the batched joint
+    family is evaluated once); sign changes of ``phi`` on it bracket the exact
+    boundaries, refined by bisection on the scalar ``phi``.
+    """
+    c = 0.5 * (lo + hi)
+    half = 0.5 * (hi - lo)
+    if half >= np.pi:  # unconstrained (continuous) joint
+        return [(-np.pi, np.pi)]
+    thr = float(np.cos(half))
+    val = np.cos(q_col - c) - thr
+
+    def phi(p: float) -> float:
+        return float(np.cos(q_of(p) - c)) - thr
+
+    n_grid = grid.shape[0]
+    roots: list[float] = []
+    for k in range(n_grid):
+        a = float(grid[k])
+        b = float(grid[k + 1]) if k + 1 < n_grid else np.pi
+        if val[k] * val[(k + 1) % n_grid] < 0:
+            roots.append(bisect(phi, a, b))
+    if not roots:
+        return [(-np.pi, np.pi)] if val[0] >= 0 else []
+    roots.sort()
+    arcs: list[tuple[float, float]] = []
+    for u, w in pairwise([*roots, roots[0] + _TWO_PI]):
+        if phi(wrap(0.5 * (u + w))) >= 0:
+            if w <= np.pi:
+                arcs.append((u, w))
+            else:  # arc straddles +pi: split
+                arcs.append((u, np.pi))
+                arcs.append((-np.pi, wrap(w)))
+    return merge(arcs)
+
+
+def feasible_arcs(
+    q_scalar: Callable[[float], NDArray[np.float64]],
+    q_grid: NDArray[np.float64],
+    swept_joints: Sequence[int],
+    limits: list[tuple[float, float]],
+    grid: NDArray[np.float64] = PARAM_GRID,
+) -> list[tuple[float, float]]:
+    """Exact feasible-``t`` set: the intersection of every swept joint's arcs.
+
+    ``q_scalar(t) -> (K,)`` is the joint family; ``q_grid`` is it evaluated on
+    ``grid`` (shape ``(N, K)``), so each joint's grid column is reused. Fixed
+    (parameter-independent) joints are the caller's responsibility to pre-check.
+    Empty iff no ``t`` keeps all swept joints in-limits.
+    """
+    def joint(i: int) -> Callable[[float], float]:
+        return lambda t: float(q_scalar(t)[i])
+
+    arcs: list[tuple[float, float]] = [(-np.pi, np.pi)]
+    for i in swept_joints:
+        arcs = intersect(
+            arcs, arcs_for_joint(joint(i), limits[i][0], limits[i][1], grid, q_grid[:, i])
+        )
+        if not arcs:
+            return []
+    return arcs

--- a/src/ssik/solvers/seven_r/_swivel_limits.py
+++ b/src/ssik/solvers/seven_r/_swivel_limits.py
@@ -18,19 +18,15 @@ to the base SRS solver -- so the closed forms hold for non-Z*Z shoulders/wrists:
 
 1. Enumerate the <=8 discrete branches (2 elbow x 2 shoulder-sign x 2 wrist-sign)
    natively at ``psi = 0`` from the general-path geometry (``R_sh(0)``, ``q_3``).
-2. Per joint, the feasible arcs of ``psi`` come from ``phi_i(psi) = cos(q_i(psi)
-   - c_i) - cos(h_i) >= 0`` (``c_i``/``h_i`` = limit centre/half-width). The
-   ``cos`` removes the ``atan2`` branch-wrap discontinuity, so ``phi_i`` is
-   smooth and its sign-zeros are the exact arc boundaries.
-3. Intersect the 6 non-elbow joints' arcs; union over branches.
-4. Sample representative ``psi`` (arc centres = max limit margin) and emit the
+2. Per branch, intersect the 6 non-elbow joints' feasible-``psi`` arcs -- the
+   parameter-agnostic feasible-interval core in :mod:`._feasible_param` (shared
+   with the non-SRS locked-joint redundancy of #148); union over branches.
+3. Sample representative ``psi`` (arc centres = max limit margin) and emit the
    wrapped-to-limits joint vectors.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from itertools import pairwise
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -46,6 +42,11 @@ from ssik.kinematics.predicates import (
     is_approximately_srs_7r,
 )
 from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian, lm_refine_batch
+from ssik.solvers.seven_r._feasible_param import (
+    PARAM_GRID,
+    feasible_arcs,
+    to_limits,
+)
 from ssik.solvers.seven_r.srs import (
     _arm_constants,
     _min_rotation,
@@ -57,13 +58,7 @@ from ssik.solvers.seven_r.srs import (
 if TYPE_CHECKING:  # pragma: no cover
     from ssik._kinbody import KinBody
 
-_TWO_PI = 2.0 * np.pi
-_ARC_GRID = 180  # bracketing resolution for phi sign-zeros (refined by bisection)
 _EPS = 1e-9
-
-
-def _wrap(a: float) -> float:
-    return float((a + np.pi) % _TWO_PI - np.pi)
 
 
 def _signed_angle(k: NDArray[np.float64], a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
@@ -81,23 +76,6 @@ def _signed_angle_batch(
     bp = b - k[None, :] * (b @ k)[:, None]
     out: NDArray[np.float64] = np.arctan2(np.cross(ap, bp) @ k, (ap * bp).sum(axis=1))
     return out
-
-
-def _bisect(f: Callable[[float], float], a: float, b: float, tol: float = 1e-8) -> float:
-    """Root of monotone-crossing ``f`` in ``[a, b]`` (dependency-free; the SRS
-    import chain stays scipy-free to keep iiwa's import lean). ``tol`` on the
-    bracket width is ample: we return arc *centres* and FK-verify downstream."""
-    fa = f(a)
-    while b - a > tol:
-        m = 0.5 * (a + b)
-        fm = f(m)
-        if fm == 0.0:
-            return m
-        if fa * fm < 0:
-            b = m
-        else:
-            a, fa = m, fm
-    return 0.5 * (a + b)
 
 
 def _triple_phase(
@@ -194,92 +172,12 @@ class _Branch:
         return np.stack([q0, q1, q2, np.full_like(q0, self.q3), q4, q5, q6], axis=1)
 
 
-def _arcs_for_joint(
-    branch: _Branch,
-    i: int,
-    lo: float,
-    hi: float,
-    grid: NDArray[np.float64],
-    q_col: NDArray[np.float64],
-) -> list[tuple[float, float]]:
-    """Feasible-``psi`` arcs for joint ``i`` in ``[lo, hi]``.
-
-    Feasibility is ``phi(psi) = cos(q_i(psi) - c) - cos(half) >= 0`` (``c`` /
-    ``half`` = limit centre / half-width); ``cos`` removes the ``atan2`` wrap so
-    ``phi`` is smooth. Sign changes on the precomputed grid ``q_col`` bracket the
-    exact boundaries, refined by Brent on the scalar ``phi``.
-    """
-    c = 0.5 * (lo + hi)
-    half = 0.5 * (hi - lo)
-    if half >= np.pi:  # unconstrained (continuous) joint
-        return [(-np.pi, np.pi)]
-    thr = float(np.cos(half))
-    val = np.cos(q_col - c) - thr
-
-    def phi(p: float) -> float:
-        return float(np.cos(branch.q(p)[i] - c)) - thr
-
-    n_grid = grid.shape[0]
-    roots: list[float] = []
-    for k in range(n_grid):
-        a = float(grid[k])
-        b = float(grid[k + 1]) if k + 1 < n_grid else np.pi
-        if val[k] * val[(k + 1) % n_grid] < 0:
-            roots.append(_bisect(phi, a, b))
-    if not roots:
-        return [(-np.pi, np.pi)] if val[0] >= 0 else []
-    roots.sort()
-    arcs: list[tuple[float, float]] = []
-    for u, w in pairwise([*roots, roots[0] + _TWO_PI]):
-        if phi(_wrap(0.5 * (u + w))) >= 0:
-            if w <= np.pi:
-                arcs.append((u, w))
-            else:  # arc straddles +pi: split
-                arcs.append((u, np.pi))
-                arcs.append((-np.pi, _wrap(w)))
-    return _merge(arcs)
-
-
-def _merge(arcs: list[tuple[float, float]]) -> list[tuple[float, float]]:
-    if not arcs:
-        return []
-    arcs = sorted(arcs)
-    out = [list(arcs[0])]
-    for a, b in arcs[1:]:
-        if a <= out[-1][1] + _EPS:
-            out[-1][1] = max(out[-1][1], b)
-        else:
-            out.append([a, b])
-    return [(a, b) for a, b in out]
-
-
-def _intersect(
-    A: list[tuple[float, float]], B: list[tuple[float, float]]
-) -> list[tuple[float, float]]:
-    out: list[tuple[float, float]] = []
-    for a0, a1 in A:
-        for b0, b1 in B:
-            lo, hi = max(a0, b0), min(a1, b1)
-            if hi - lo > _EPS:
-                out.append((lo, hi))
-    return _merge(out)
-
-
-_GRID = np.linspace(-np.pi, np.pi, _ARC_GRID, endpoint=False)
-
-
 def _branch_arcs(branch: _Branch, limits: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    # The elbow q3 is fixed along the swivel: pre-check it, then sweep the rest.
     if not (limits[3][0] <= branch.q3 <= limits[3][1]):
         return []
-    q_grid = branch.q_grid(_GRID)  # (N, 7) -- one batched eval per branch
-    arcs = [(-np.pi, np.pi)]
-    for i in (0, 1, 2, 4, 5, 6):
-        arcs = _intersect(
-            arcs, _arcs_for_joint(branch, i, limits[i][0], limits[i][1], _GRID, q_grid[:, i])
-        )
-        if not arcs:
-            return []
-    return arcs
+    q_grid = branch.q_grid(PARAM_GRID)  # (N, 7) -- one batched eval per branch
+    return feasible_arcs(branch.q, q_grid, (0, 1, 2, 4, 5, 6), limits, PARAM_GRID)
 
 
 def _enumerate_branches(
@@ -327,12 +225,6 @@ def _enumerate_branches(
     return branches
 
 
-def _to_limits(v: float, lo: float, hi: float) -> float:
-    """The 2*pi-equivalent of ``v`` nearest the limit centre."""
-    k = round((0.5 * (lo + hi) - v) / _TWO_PI)
-    return v + _TWO_PI * k
-
-
 def feasible_in_limits_solutions(
     kb: KinBody,
     cls: SrsClassification,
@@ -362,9 +254,7 @@ def feasible_in_limits_solutions(
             for psi in psis:
                 q = branch.q(float(psi))
                 out.append(
-                    np.array(
-                        [_to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)]
-                    )
+                    np.array([to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)])
                 )
                 if max_solutions is not None and len(out) >= max_solutions:
                     return out


### PR DESCRIPTION
## Why

Step 1 of #148 (parametric redundancy for non-SRS 7R). The validation probe on Franka confirmed its locked-joint redundancy `q_i(q_lock)` is a **smooth 1-parameter family** (240/240 tracked, FK closure 1.9e-15, ≤2 stationary points per joint) — the *same structure* the v3.1.0 feasible-swivel resolver (#359/#369) exploits for the SRS elbow swivel. So the exact in-limits machinery generalizes: it's independent of *how* `q_i(t)` is generated.

This PR lifts that machinery out so the upcoming non-SRS `q_lock` family reuses it, giving non-SRS 7R the same exact `respect_limits=True` guarantee (Deliverable B in the [#148 design](https://github.com/personalrobotics/ssik/issues/148#issuecomment-4963389350)).

## What

New `src/ssik/solvers/seven_r/_feasible_param.py` holds the parameter-agnostic core:
- `bisect` — dependency-free root finder (keeps the SRS chain scipy-free / iiwa import lean)
- `merge` / `intersect` — interval algebra
- `arcs_for_joint` — per-joint feasible-`t` arcs via `phi_i(t) = cos(q_i(t) - c_i) - cos(h_i)` sign-zeros (the `cos` removes the `atan2` wrap so `phi` is smooth)
- `feasible_arcs` — intersect the swept joints' arcs; takes `q(t)` as a callback
- `to_limits`, `PARAM_GRID`

`_swivel_limits.py` keeps only SRS-specific geometry (`_Branch` closed-form `q(psi)`, `_enumerate_branches`) and calls `feasible_arcs(branch.q, ...)`.

## No behaviour change

Pure refactor. `resolve_in_limits` (the only public symbol, embedded in every 7R prebuilt) is unchanged → no prebuilt regeneration. The moved helpers were used nowhere else.

## Test plan

- `tests/test_swivel_limits.py` — 6 passed (4 SRS arms exact + gen3 approximate + non-SRS no-op)
- `tests/test_prebuilt_uniform_fuzz.py` (7R + limits) — 21 passed, 1 xfailed (pre-existing gen3 #299 gap, unchanged)
- ruff + mypy clean

Part of #148.