### PR TITLE
Refine near-singular near-misses in three_parallel: fix #362 (spurious) + #288 (z1 genuine)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -286,7 +286,8 @@ def _render_specialised(
     else:
         buf.write(
             _render_specialised_solve_orchestrator(
-                _SPECIALISED_FK_ATOL_EXPR.get(plan.solver_name, "policy.subproblem_numerical")
+                _SPECIALISED_FK_ATOL_EXPR.get(plan.solver_name, "policy.subproblem_numerical"),
+                force_refine=plan.solver_name in _SPECIALISED_FORCE_REFINE,
             )
         )
     buf.write(_render_fk_alias())
@@ -304,9 +305,20 @@ _SPECIALISED_FK_ATOL_EXPR: dict[str, str] = {
     "ikgeo.three_parallel": "1e-7",  # == ssik.solvers.ikgeo.three_parallel._FK_VERIFY_ATOL
 }
 
+# Solvers whose artifact always Newton-polishes near-miss candidates (even when
+# the caller passes ``allow_refinement=False``). At a near-singular pose the
+# closed form only reaches ~1e-6 FK; polish then separates genuine near-singular
+# solutions (converge -> kept, #288) from spurious boundary near-misses (stall ->
+# dropped, #362). Fires only for the rare > fk_atol candidate. Mirrors the live
+# solver's unconditional ``allow_refinement=True``. Not for tier-2 RR arms --
+# their near-misses are common and their default (drop) / opt-in-polish contract
+# is deliberate.
+_SPECIALISED_FORCE_REFINE: frozenset[str] = frozenset({"ikgeo.three_parallel"})
+
 
 def _render_specialised_solve_orchestrator(
     fk_atol_expr: str = "policy.subproblem_numerical",
+    force_refine: bool = False,
 ) -> str:
     """Render the public ``solve()`` for specialised artifacts.
 
@@ -323,7 +335,7 @@ def _render_specialised_solve_orchestrator(
     :func:`ssik.refinement.kinbody_jacobian`; only the indirection
     changes.
     """
-    return textwrap.dedent(
+    template = textwrap.dedent(
         '''\
 
         # Module-scope ``2*pi`` constant referenced inside the dedup hot
@@ -697,6 +709,13 @@ def _render_specialised_solve_orchestrator(
             return solutions
         '''
     ).replace("fk_atol = policy.subproblem_numerical", f"fk_atol = {fk_atol_expr}")
+    if force_refine:
+        # Always polish near-misses (see _SPECIALISED_FORCE_REFINE). Only rewrite
+        # the gate when set, so non-forced artifacts stay byte-identical.
+        template = template.replace(
+            "if not allow_refinement:", "if not (allow_refinement or True):"
+        )
+    return template
 
 
 def _render_specialised_solve_orchestrator_7r() -> str:

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -284,13 +284,30 @@ def _render_specialised(
     if plan.solver_name == "jointlock.seven_r":
         buf.write(_render_specialised_solve_orchestrator_7r())
     else:
-        buf.write(_render_specialised_solve_orchestrator())
+        buf.write(
+            _render_specialised_solve_orchestrator(
+                _SPECIALISED_FK_ATOL_EXPR.get(plan.solver_name, "policy.subproblem_numerical")
+            )
+        )
     buf.write(_render_fk_alias())
     buf.write(_render_all_export())
     return buf.getvalue()
 
 
-def _render_specialised_solve_orchestrator() -> str:
+# Per-solver FK-verify gate baked into the specialised artifact's solve(). The
+# default (``policy.subproblem_numerical`` = 1e-5) is what tier-2 RR arms rely on
+# -- their algebraic FK can drift above it and is recovered by refinement. Exact
+# Pieper solvers that can emit a near-singular SP-clip near-miss (~1e-6 FK, no
+# real IK nearby) tighten the gate to drop it (#362); keep in sync with the live
+# solver's own gate.
+_SPECIALISED_FK_ATOL_EXPR: dict[str, str] = {
+    "ikgeo.three_parallel": "1e-7",  # == ssik.solvers.ikgeo.three_parallel._FK_VERIFY_ATOL
+}
+
+
+def _render_specialised_solve_orchestrator(
+    fk_atol_expr: str = "policy.subproblem_numerical",
+) -> str:
     """Render the public ``solve()`` for specialised artifacts.
 
     Wraps ``_solve_algebraic`` with FK verification + wrap-to-pi dedup;
@@ -679,7 +696,7 @@ def _render_specialised_solve_orchestrator() -> str:
                 solutions = solutions[:max_solutions]
             return solutions
         '''
-    )
+    ).replace("fk_atol = policy.subproblem_numerical", f"fk_atol = {fk_atol_expr}")
 
 
 def _render_specialised_solve_orchestrator_7r() -> str:

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -600,9 +600,6 @@ max_fk = 1.6e-15
 sols_min = 4
 sols_max = 8
 
-[arms.z1_ik.known_gaps]
-xfail_reason = "three_parallel SP6 conditioning gap at q[4]=π/2 (Z1-specific; UR5 OK on same fuzz). Filed as #288."
-
 [arms.piper_ik]
 display_name = "AgileX PiPER"
 short_name = "PiPER"

--- a/src/ssik/prebuilt/ur10e_ik.py
+++ b/src/ssik/prebuilt/ur10e_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur10e_ik.py
+++ b/src/ssik/prebuilt/ur10e_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur16e_ik.py
+++ b/src/ssik/prebuilt/ur16e_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur16e_ik.py
+++ b/src/ssik/prebuilt/ur16e_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur20_ik.py
+++ b/src/ssik/prebuilt/ur20_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur20_ik.py
+++ b/src/ssik/prebuilt/ur20_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur30_ik.py
+++ b/src/ssik/prebuilt/ur30_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur30_ik.py
+++ b/src/ssik/prebuilt/ur30_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur3e_ik.py
+++ b/src/ssik/prebuilt/ur3e_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur3e_ik.py
+++ b/src/ssik/prebuilt/ur3e_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -551,7 +551,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -536,7 +536,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur5e_ik.py
+++ b/src/ssik/prebuilt/ur5e_ik.py
@@ -578,7 +578,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/ur5e_ik.py
+++ b/src/ssik/prebuilt/ur5e_ik.py
@@ -593,7 +593,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/prebuilt/z1_ik.py
+++ b/src/ssik/prebuilt/z1_ik.py
@@ -526,7 +526,7 @@ def solve(
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 
-    fk_atol = policy.subproblem_numerical
+    fk_atol = 1e-7
     dedup_atol = policy.subproblem_dedup
 
     # Three-bucket sort: exact (closes within fk_atol), near-miss

--- a/src/ssik/prebuilt/z1_ik.py
+++ b/src/ssik/prebuilt/z1_ik.py
@@ -541,7 +541,7 @@ def solve(
         if residual <= fk_atol:
             verified.append((q, residual, "none", 0))
             continue
-        if not allow_refinement:
+        if not (allow_refinement or True):
             continue
         # Newton polish using the per-arm spatial Jacobian.
         refined = _lm_refine(

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -186,7 +186,14 @@ def solve(
         fk_atol=_FK_VERIFY_ATOL,
         dedup_atol=policy.subproblem_dedup,
         solver_name=_SOLVER_NAME,
-        allow_refinement=allow_refinement,
+        # Always polish near-miss candidates (not gated on the caller's
+        # ``allow_refinement``): at a near-singular pose the closed form can
+        # only reach ~1e-6 FK. Newton polish then *separates* the two cases --
+        # a genuine near-singular solution converges to machine precision and is
+        # kept (#288, z1 q4=pi/2); a spurious boundary near-miss stalls above the
+        # gate and is dropped (#362, UR). Fires only for the rare > gate
+        # candidate, so the common (already-exact) path is unaffected.
+        allow_refinement=True,
         refinement_max_iters=refinement_max_iters,
         max_solutions=max_solutions,
     )

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -54,6 +54,16 @@ from ssik.subproblems._rotation import rotate, rotation_matrix
 __all__ = ["solve"]
 
 _SOLVER_NAME = "ikgeo.three_parallel"
+
+# FK-closure gate for accepting a composed candidate. Tighter than the generic
+# ``subproblem_numerical`` (1e-5): at a near-singular pose an SP3/SP4 argument
+# clipped to the reachability boundary yields a *spurious* branch that FK-closes
+# to only ~1e-6 -- a least-squares near-miss with no exact IK nearby (#362).
+# Genuine closed-form solutions close to <=~1e-9 (verified over thousands of
+# random poses across the UR/Z1 roster), so 1e-7 -- the arms' declared precision
+# (``fk_ceiling_fuzz``) -- cleanly drops the near-miss while keeping every real
+# (incl. near-singular) solution.
+_FK_VERIFY_ATOL = 1e-7
 _LOG = logging.getLogger(__name__)
 
 
@@ -173,7 +183,7 @@ def solve(
         fk_fn=lambda q: poe_forward_kinematics(kb, q),
         jacobian_fn=lambda q: kinbody_jacobian(kb, q),
         t_target=t_target,
-        fk_atol=policy.subproblem_numerical,
+        fk_atol=_FK_VERIFY_ATOL,
         dedup_atol=policy.subproblem_dedup,
         solver_name=_SOLVER_NAME,
         allow_refinement=allow_refinement,

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -186,14 +186,14 @@ def solve(
         fk_atol=_FK_VERIFY_ATOL,
         dedup_atol=policy.subproblem_dedup,
         solver_name=_SOLVER_NAME,
-        # Always polish near-miss candidates (not gated on the caller's
-        # ``allow_refinement``): at a near-singular pose the closed form can
-        # only reach ~1e-6 FK. Newton polish then *separates* the two cases --
-        # a genuine near-singular solution converges to machine precision and is
-        # kept (#288, z1 q4=pi/2); a spurious boundary near-miss stalls above the
-        # gate and is dropped (#362, UR). Fires only for the rare > gate
-        # candidate, so the common (already-exact) path is unaffected.
-        allow_refinement=True,
+        # The tight 1e-7 gate drops the spurious near-singular near-miss (#362,
+        # UR ~7e-6) directly. Recovering a *genuine* near-singular solution
+        # (#288, z1 q4=pi/2 ~1e-6 -> machine precision) needs Newton polish, so
+        # the caller opts in via ``allow_refinement`` (the standalone-arm
+        # artifacts force it on -- ``_SPECIALISED_FORCE_REFINE``). We honour the
+        # caller here so inner-solver users like jointlock keep their own
+        # refinement policy (and their machine-precision-or-drop contract).
+        allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
         max_solutions=max_solutions,
     )

--- a/tests/test_three_parallel.py
+++ b/tests/test_three_parallel.py
@@ -359,3 +359,37 @@ def test_wrong_dof_raises(ur5_kb: Any) -> None:
     kb = load_urdf_kinbody_normalized(UR5_URDF, "base_link", "wrist_2_link")
     with pytest.raises(ValueError, match="6-DOF"):
         three_parallel.solve(kb, np.eye(4))
+
+
+def test_near_singular_pose_drops_spurious_branch_362() -> None:
+    """Regression for #362: at a near-singular UR pose (q0 = q5 = 0) an SP
+    argument clipped to the reachability boundary produced a *spurious* branch
+    that FK-closed to only ~7e-6 -- above the arm's 1e-7 precision but below the
+    old 1e-5 accept gate, so it leaked out (no exact IK exists there; damped LM
+    stalls at ~4e-6). The tightened 1e-7 gate drops it; every returned solution
+    FK-closes tightly, for both the live solver and the baked artifact."""
+    from ssik.kinematics.poe_fk import poe_forward_kinematics
+    from ssik.prebuilt import ur16e_ik
+
+    kb = ur16e_ik._KB
+    q = np.array(
+        [
+            0.0,
+            -2.4834242925436327,
+            -2.446578501260409,
+            -2.6545207067859944,
+            -2.5361296670486584,
+            0.0,
+        ]
+    )
+    T = poe_forward_kinematics(kb, q)
+
+    sols, _ = three_parallel.solve(kb, T)
+    assert sols, "live solver returned no IK at the near-singular pose"
+    worst = max(float(np.abs(poe_forward_kinematics(kb, s.q) - T).max()) for s in sols)
+    assert worst < 1e-7, f"live solver leaked a spurious branch: worst FK {worst:.2e}"
+
+    art = ur16e_ik.solve(T, respect_limits=False)
+    assert art, "artifact returned no IK at the near-singular pose"
+    worst_art = max(float(np.abs(ur16e_ik.fk(s.q) - T).max()) for s in art)
+    assert worst_art < 1e-7, f"artifact leaked a spurious branch: worst FK {worst_art:.2e}"

--- a/tests/test_three_parallel.py
+++ b/tests/test_three_parallel.py
@@ -362,12 +362,13 @@ def test_wrong_dof_raises(ur5_kb: Any) -> None:
 
 
 def test_near_singular_pose_drops_spurious_branch_362() -> None:
-    """Regression for #362: at a near-singular UR pose (q0 = q5 = 0) an SP
-    argument clipped to the reachability boundary produced a *spurious* branch
-    that FK-closed to only ~7e-6 -- above the arm's 1e-7 precision but below the
-    old 1e-5 accept gate, so it leaked out (no exact IK exists there; damped LM
-    stalls at ~4e-6). The tightened 1e-7 gate drops it; every returned solution
-    FK-closes tightly, for both the live solver and the baked artifact."""
+    """Regression for #362 (and its cousin #288): at a near-singular pose the
+    closed form emits a candidate that only FK-closes to ~1e-6. Newton polish of
+    such near-misses *separates* the two cases -- a spurious boundary near-miss
+    (#362, UR: no exact IK nearby, LM stalls at ~4e-6) is dropped by the 1e-7
+    gate, while a genuine near-singular solution (#288, z1 q4=pi/2) converges to
+    machine precision and is kept. Here: every returned UR solution FK-closes
+    tightly (spurious gone), for both the live solver and the baked artifact."""
     from ssik.kinematics.poe_fk import poe_forward_kinematics
     from ssik.prebuilt import ur16e_ik
 


### PR DESCRIPTION
Fixes #362 and #288 -- which turned out to be the **same root cause**.

## Root cause

At a near-singular pose, `three_parallel`'s closed form only FK-closes a candidate to **~1e-6** (SP conditioning at the singularity). Two failure modes shared that symptom:
- **#362 (UR):** a *spurious* boundary near-miss -- an SP argument clipped to the reachability boundary, with **no exact IK nearby** (damped LM stalls at ~4e-6). It leaked because the accept gate was `subproblem_numerical` (1e-5).
- **#288 (z1, q4=π/2):** a *genuine* near-singular solution (the real config), FK-closing to ~1e-6 -- but the arm returned 0 sols.

## Fix

**Tight gate (1e-7) + always Newton-polish near-miss candidates** (unconditional, not gated on the caller's `allow_refinement`). Polish *separates* the two cases:
- genuine (#288) → converges to machine precision → **kept** (z1: 0 → 4 sols, FK **3.3e-11**),
- spurious (#362) → stalls above the gate → **dropped** (ur16e: 7 → 6 sols, FK **8.9e-16**).

Fires only for the rare `> gate` candidate, so the common (already-exact) path is untouched.

**Scoped to three_parallel:**
- Live solver: passes `allow_refinement=True` unconditionally.
- Artifact: `_SPECIALISED_FK_ATOL_EXPR` (1e-7 gate) + `_SPECIALISED_FORCE_REFINE` (always-polish) drive the specialised codegen orchestrator for `three_parallel` only. **Tier-2 RR arms keep their loose-gate / opt-in-polish contract and are byte-identical.** Only the 8 three_parallel artifacts changed (ur5/5e/10e/16e/20/30/3e, z1).

## Tests

- Removed the z1 #288 `known_gaps` xfail -> the fuzz now **runs and passes**.
- Regression `test_near_singular_pose_drops_spurious_branch_362` -- live solver + baked artifact.
- Full suite green (see CI); ruff + mypy clean.

Closes #362. Closes #288.