### PR TITLE
Close #299: gen3 srs_polished analytical coverage gap is fixed

### DIFF
--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -452,15 +452,6 @@ sols_max = 92
 supported = false
 refusal = "Currently, only 1-6R robots are solvable with EAIK"
 
-[arms.gen3_ik.known_gaps]
-# The bulletproof rescue (#358) now recovers this pose for callers -- default
-# solve() returns ~86 LM-polished sols tagged "lm" instead of [] (regression-
-# guarded by 299_gen3 in tests/test_refinement_rescue.py::GROUP_A). The uniform
-# fuzz stays xfailed because it asserts the strict 1e-9 *analytical* ceiling,
-# which the LM rescue (fk_atol 1e-8) doesn't meet -- the analytical srs_polished
-# gap itself is still open (#299).
-xfail_reason = "srs_polished analytical coverage gap on q*=[0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875] (0 sols at q*); recovered for callers by the #358 rescue at ~1e-8, but the strict 1e-9 analytical fuzz stays gated. Filed as #299."
-
 [arms.franka_panda_ik]
 display_name = "Franka Emika Panda (no hand)"
 short_name = "Franka Panda"

--- a/tests/test_seven_r_srs_polished.py
+++ b/tests/test_seven_r_srs_polished.py
@@ -134,6 +134,10 @@ _HAND_PICKED_Q = [
     np.array([-0.5, 0.3, -0.7, 1.0, -0.4, 0.5, -0.3]),
     np.array([0.0, 0.5, 0.0, 1.5, 0.0, -0.5, 0.0]),
     np.array([1.2, -0.8, 0.3, 0.4, 1.1, -0.6, 0.9]),
+    # #299 regression: the srs_polished *analytical* path once returned 0 sols
+    # here (recovered only by the #358 LM rescue at ~1e-8); the general-Davenport
+    # SRS work (#354/#356) closed the analytical gap -- now 13 sols at ~2e-16.
+    np.array([0.51171875, 0.51171875, 1.01953125, 0.625, -0.6484375, -2.75, 0.875]),
 ]
 
 


### PR DESCRIPTION
Fixes #299.

## Finding

The gap turned out to be **already closed** by intervening work. The `srs_polished` *analytical* path once returned 0 sols at `q* = [0.512, 0.512, 1.020, 0.625, -0.648, -2.75, 0.875]` (recovered only by the #358 LM rescue at ~1e-8, below the strict 1e-9 analytical fuzz bar). The **general-Davenport SRS generalization (#354/#356)** -- which `srs_polished` runs on the best-fit pivots -- closed it: the pose now returns **13 sols at ~2e-16**.

Neighborhood (was: 0 at q*, escaping with a 10 mrad bump) is now uniformly covered.

## Change

- Remove the gen3 `known_gaps` xfail. The uniform fuzz `test_prebuilt_7r_random_q_roundtrip[gen3_ik]` passes across seeds (PYTHONHASHSEED 1/2/3).
- Add q* to the `srs_polished` hand-picked FK-closure regression (`test_gen3_hand_picked_fk_closure`) so the analytical coverage stays guarded.

Not a tolerance widening (the strict 1e-9 analytical bar is unchanged) -- a real coverage fix, verified.

Full suite: **1588 passed, 6 xfailed** (was 7; gen3 removed). The #358 rescue regression guard (`test_refinement_rescue::299_gen3`) still holds.