### PR TITLE
Polish well-conditioned T-perturbation rescues to machine precision (#384)

### DIFF
--- a/src/ssik/refinement/rescue.py
+++ b/src/ssik/refinement/rescue.py
@@ -43,6 +43,16 @@ from numpy.typing import NDArray
 from ssik.core.solution import Solution
 from ssik.refinement import lm_refine
 
+# Tight polish target tried before the loose acceptability gate. A rescue whose
+# perturbation landed off-ridge (the common case) is well-conditioned and
+# converges to machine precision in a step or two; aiming for it there means we
+# return the *exact* solution rather than one that merely cleared ``fk_atol``
+# (the #384 gen3 case: lm_refine stopped at ~6e-9 the instant it dipped under
+# the 1e-8 gate, leaving the machine precision it would reach one iteration
+# later unused). Genuinely rank-deficient ridge poses (#319) stall above this
+# and fall back to the loose polish, so ridge recovery is unchanged.
+_TIGHT_POLISH_FK_ATOL = 1e-12
+
 
 def rescue_via_T_perturbation(
     fk_fn: Callable[[NDArray[np.float64]], NDArray[np.float64]],
@@ -166,14 +176,27 @@ def rescue_via_T_perturbation(
 
         for sol in pert_sols:
             q_seed = np.asarray(sol.q, dtype=np.float64)
+            # Polish as tightly as the pose allows: aim for machine precision
+            # first so a well-conditioned rescue returns its exact solution, and
+            # fall back to the loose acceptability target only when the tight
+            # polish can't converge (a genuinely rank-deficient ridge, #319).
             result = lm_refine(
                 q_seed,
                 fk_fn,
                 T_target,
-                fk_atol=fk_atol,
+                fk_atol=min(_TIGHT_POLISH_FK_ATOL, fk_atol),
                 max_iters=refinement_max_iters,
                 jacobian_fn=jacobian_fn,
             )
+            if result is None:
+                result = lm_refine(
+                    q_seed,
+                    fk_fn,
+                    T_target,
+                    fk_atol=fk_atol,
+                    max_iters=refinement_max_iters,
+                    jacobian_fn=jacobian_fn,
+                )
             if result is None:
                 continue
             q_ref, fk_resid, _iters = result

--- a/tests/test_refinement_rescue.py
+++ b/tests/test_refinement_rescue.py
@@ -204,3 +204,28 @@ def test_rescue_idempotent_when_direct_solve_succeeds() -> None:
             f"rescue produced FK-incorrect sol on healthy pose: "
             f"q={sol.q.tolist()}, fk_err={fk_err:.2e}"
         )
+
+
+def test_rescue_polishes_well_conditioned_to_machine_precision_384() -> None:
+    """#384 regression: a rescue whose perturbation lands off-ridge is
+    well-conditioned and must be polished to machine precision, not merely to
+    the loose 1e-8 acceptability gate.
+
+    The gen3 pose below routes to ``srs_polished``, which returns [] (its
+    approximate pivots don't clear the strict polish filter here), so the
+    thin-wrapper rescue fires. Its solutions FK-close to <=~6e-9 under the old
+    early-stopping polish -- above gen3's 1e-9 fuzz ceiling -- even though one
+    more Newton step reaches ~5e-13. The tight-then-loose polish now delivers
+    that: every returned branch closes well under the ceiling.
+    """
+    from ssik.prebuilt import gen3_ik
+
+    q_star = np.array([0.125, 0.46875, 2.125, 0.4765625, 1.5, 1.0, 0.5])
+    T = gen3_ik.fk(q_star)
+    sols = gen3_ik.solve(T, respect_limits=False)
+    assert sols, "expected the rescue to recover solutions at this gen3 pose"
+    worst = max(s.fk_residual for s in sols)
+    assert worst < 1e-9, (
+        f"rescue left a branch under-polished at {worst:.2e} (> gen3 1e-9 ceiling); "
+        f"the tight polish should reach machine precision on this well-conditioned pose"
+    )


### PR DESCRIPTION
## Why

`rescue_via_T_perturbation` conflated one `fk_atol = 1e-8` as **both** `lm_refine`'s convergence target **and** the acceptability gate. When a rescue's perturbation lands off-ridge — well-conditioned, the common case — the polish dips under `1e-8` on the very first Newton step and stops, returning a solution at ~`6e-9` when one more iteration reaches ~`5e-13`.

On **approximately-SRS gen3** this bites: `srs_polished` returns `[]` at some poses (its best-fit pivots don't clear the strict polish filter there), so the thin-wrapper rescue fires — and its under-polished branches land above gen3's `1e-9` fuzz ceiling. That's the intermittent, Hypothesis-stochastic `test_prebuilt_7r_random_q_roundtrip[gen3_ik]` failure (residual `5.79e-9`), which reproduces on `main`.

Fixes #384.

## What

Separate the two roles in the rescue's polish loop:

- **Tight target first** (`1e-12`): a well-conditioned rescue converges to machine precision in a step or two, so it returns its *exact* solution.
- **Loose fallback** (`fk_atol`, `1e-8`): only when the tight polish can't converge — a genuinely rank-deficient ridge (#319 JACO 2) — recovering at ~`1e-8`, still accepted at the same gate. **Ridge recovery is unchanged.**

The diagnosis confirmed these gen3 branches are *not* singular (cond(J) ~46) and reach `5e-13` in **one** extra Newton iteration — the polish was simply stopping early, not stalling.

## Verification

- gen3 at the falsifying `q* = [0.125, 0.46875, 2.125, 0.4765625, 1.5, 1.0, 0.5]`: worst FK **5.79e-9 → 5.24e-13**.
- New deterministic regression test `test_rescue_polishes_well_conditioned_to_machine_precision_384`.
- #319 rescue suite (`test_refinement_rescue.py`) + full uniform fuzz: green.
- Full suite: **1589 passed, 6 xfailed, 5 xpassed** (all pre-existing). ruff + mypy clean.

Unblocks #383 (seeded tracking), which was reddened by this pre-existing flake.