### PR TITLE
Make perf gates noise-robust with shared best-of-N timing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,11 @@ ignore_missing_imports = true
 module = "ur5"
 ignore_missing_imports = true
 
+# Same for tests/fixtures/_perf.py (shared perf-gate timing helper).
+[[tool.mypy.overrides]]
+module = "_perf"
+ignore_missing_imports = true
+
 # Generated per-arm artifacts under src/ssik/prebuilt/ are byte-stable
 # emitted code; their format is dictated by ``ssik.core.codegen`` and
 # validated via byte-equal snapshot tests. mypy excludes the directory

--- a/tests/fixtures/_perf.py
+++ b/tests/fixtures/_perf.py
@@ -1,0 +1,48 @@
+"""Shared timing helper for ``@pytest.mark.perf`` gates.
+
+CI perf gates run on shared runners where OS-scheduling noise is strictly
+**additive** -- a preemption only ever makes a call look *slower*, never faster.
+The robust statistic for a micro-benchmark regression gate is therefore the
+**best of N runs** (the minimum): it estimates the true compute cost, is immune
+to transient runner load, and still rises under a genuine regression (which
+inflates every run, including the fastest). Median/mean of a sub-millisecond
+call, by contrast, get dragged over the gate by a single stray preemption --
+the #383 flake was iiwa14 ``max_solutions=1`` (0.23 ms compute) whose *median*
+of 20 measured 1.00 ms under runner load and tripped a ``< 1 ms`` gate.
+
+Every absolute perf gate routes through :func:`best_call_ms` so the whole suite
+shares one noise-robust definition of "how long does this call take". Existing
+thresholds keep all their headroom (``min <= median <= mean`` always), and now
+read as "best-case cost must stay under X" -- exactly what a regression gate
+wants.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+
+def best_call_ms(fn: Callable[[], object], *, warmup: int = 3, runs: int = 20) -> float:
+    """Best-of-``runs`` wall-clock time for ``fn``, in milliseconds.
+
+    ``warmup`` untimed calls first prime import / cache / branch-predictor
+    state; the minimum over ``runs`` timed calls is the noise-floor estimate of
+    true compute cost. Deterministic single-input benchmarks (the perf gates'
+    usage) are unimodal, so the minimum is the genuine floor -- a real compute
+    regression shifts the whole distribution, minimum included, while runner
+    load only ever inflates the slower samples the minimum discards.
+
+    :param fn: zero-argument callable to time (wrap the call in a lambda).
+    :param warmup: untimed priming calls before measurement.
+    :param runs: timed calls; the fastest is returned.
+    :returns: best observed call time in milliseconds.
+    """
+    for _ in range(warmup):
+        fn()
+    best = float("inf")
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t0)
+    return best * 1000.0

--- a/tests/test_husty_pfurner_eliminate.py
+++ b/tests/test_husty_pfurner_eliminate.py
@@ -49,13 +49,18 @@ Bulletproof tolerance philosophy (per ``feedback_bulletproof_solvers.md``,
 from __future__ import annotations
 
 import math
-import time
+import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
 import sympy as sp
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from _perf import best_call_ms
 
 from ssik.solvers.husty_pfurner._eliminate import (
     EliminatePrecompute,
@@ -457,9 +462,10 @@ def test_pencil_eigenvalues_match_sympy_rational_resultant() -> None:
 
 @pytest.mark.perf
 def test_eliminate_uw_numeric_under_perf_gate() -> None:
-    """Average over 30 runs after a warmup. Tests on baseline DH so this
-    is the *typical* expected runtime (large-alpha and other extremes
-    may run slightly slower; full perf characterisation is Phase 5h).
+    """Best-of-N per-call time (see :mod:`tests._perf`) on baseline DH, so
+    this is the *typical* expected runtime tracked robustly against
+    shared-runner noise (large-alpha and other extremes may run slightly
+    slower; full perf characterisation is Phase 5h).
     """
     dh = _DH_BASELINE
     v = (0.30, -0.40, 0.60, 0.20, 0.50, -0.70)
@@ -470,15 +476,8 @@ def test_eliminate_uw_numeric_under_perf_gate() -> None:
         ls=(dh["l_1"], dh["l_2"], dh["l_3"], dh["l_4"], dh["l_5"]),
         d=(dh["d_2"], dh["d_3"], dh["d_4"], dh["d_5"]),
     )
-    # Warmup
-    for _ in range(3):
-        eliminate_uw_numeric(pre, sigma_E, drop_indices=(7,))
-    N = 30
-    t0 = time.perf_counter()
-    for _ in range(N):
-        eliminate_uw_numeric(pre, sigma_E, drop_indices=(7,))
-    avg_ms = (time.perf_counter() - t0) * 1000 / N
-    assert avg_ms < 50.0, f"avg per call {avg_ms:.2f}ms exceeds 50ms gate"
+    best_ms = best_call_ms(lambda: eliminate_uw_numeric(pre, sigma_E, drop_indices=(7,)), runs=30)
+    assert best_ms < 50.0, f"best per call {best_ms:.2f}ms exceeds 50ms gate"
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -17,7 +17,6 @@ already exist (e.g. test_kinova_gen3.py); this file is the API contract.
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 
 import numpy as np
@@ -29,6 +28,8 @@ from ssik.kinematics.poe_fk import poe_forward_kinematics
 
 FIXTURES = Path(__file__).parent / "fixtures"
 sys.path.insert(0, str(FIXTURES))
+
+from _perf import best_call_ms  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # URDF-based fixtures: full smoke matrix
@@ -335,29 +336,19 @@ def test_ik_overhead_under_300us() -> None:
     """
     arm = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
     T = arm.fk(np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
-
-    # Warm
-    for _ in range(20):
-        arm.solve(T)
-
-    # Manipulator path
-    t = time.perf_counter()
-    for _ in range(200):
-        arm.solve(T)
-    manip_per = (time.perf_counter() - t) / 200
-
-    # Raw solver path
     from ssik.solvers.ikgeo import three_parallel
 
-    t = time.perf_counter()
-    for _ in range(200):
-        three_parallel.solve(arm.kinbody, T)
-    raw_per = (time.perf_counter() - t) / 200
+    # Overhead = wrapper-path best minus raw-solver best. Best-of-N on each side
+    # (see tests._perf) is the noise floor, so their difference isolates the
+    # Manipulator wrapper's true per-call cost instead of the differenced
+    # scheduler noise of two means (which can even go negative under load).
+    manip_ms = best_call_ms(lambda: arm.solve(T), warmup=20, runs=200)
+    raw_ms = best_call_ms(lambda: three_parallel.solve(arm.kinbody, T), warmup=20, runs=200)
 
-    overhead = (manip_per - raw_per) * 1e6
+    overhead = (manip_ms - raw_ms) * 1e3  # ms -> us
     assert overhead < 300.0, (
         f"Manipulator.solve overhead {overhead:.1f} us > 300 us regression gate "
-        f"(manip={manip_per * 1e6:.1f} us, raw={raw_per * 1e6:.1f} us)"
+        f"(manip={manip_ms * 1e3:.1f} us, raw={raw_ms * 1e3:.1f} us)"
     )
 
 

--- a/tests/test_seven_r_srs.py
+++ b/tests/test_seven_r_srs.py
@@ -18,7 +18,6 @@ Test contract (per `feedback_bulletproof_solvers`):
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 
 import numpy as np
@@ -28,6 +27,7 @@ from hypothesis import strategies as st
 
 sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
 
+from _perf import best_call_ms
 from kuka_iiwa14 import kuka_iiwa14_specs
 
 from ssik._kinbody import build_kinbody
@@ -160,47 +160,37 @@ def test_iiwa14_srs_vs_jointlock_both_find_fk_correct_ik(q_star: np.ndarray) -> 
 
 @pytest.mark.perf
 def test_iiwa14_full_sweep_under_2ms() -> None:
-    """Full swivel sweep + 8-branch enumeration on iiwa14 must take < 2 ms median.
+    """Full swivel sweep + 8-branch enumeration on iiwa14 must take < 2 ms.
 
     Empirical (M3, single-thread): ~17 ms today. The 2 ms gate is the
     target after #186 (Cython compile of the inner FK loop). Until #186
     lands, we use a generous gate to catch *regressions*; the true
-    target is sub-ms.
+    target is sub-ms. Best-of-N timing (see :mod:`tests._perf`) so the gate
+    tracks compute cost, not shared-runner scheduling noise.
     """
     kb = build_kinbody(kuka_iiwa14_specs())
     q_star = _HAND_PICKED_Q[0]
     T_target = poe_forward_kinematics(kb, q_star)
-    # Warmup
-    srs_solve(kb, T_target)
-    times = []
-    for _ in range(20):
-        t0 = time.perf_counter()
-        srs_solve(kb, T_target)
-        times.append(time.perf_counter() - t0)
-    median_ms = float(np.median(times)) * 1000
+    best_ms = best_call_ms(lambda: srs_solve(kb, T_target))
     # Conservative gate: 50 ms catches >2.5x regression from current ~17 ms
     # baseline. Tighten to 2 ms target after #186 Cython compile.
-    assert median_ms < 50, f"SRS full-sweep too slow: {median_ms:.2f} ms"
+    assert best_ms < 50, f"SRS full-sweep too slow: {best_ms:.2f} ms"
 
 
 @pytest.mark.perf
 def test_iiwa14_max_solutions_one_under_1ms() -> None:
-    """`max_solutions=1` (give-me-any-IK use case) must take < 1 ms median.
+    """`max_solutions=1` (give-me-any-IK use case) must take < 1 ms.
 
     Empirical (M3, single-thread): ~0.23 ms today. Gate set generously
-    at 1 ms to catch regressions.
+    at 1 ms to catch regressions. Best-of-N timing (see :mod:`tests._perf`):
+    at 0.23 ms compute a single scheduler preemption dragged the *median*
+    of 20 to 1.00 ms on CI (#383 flake); the best-of-N is the noise floor.
     """
     kb = build_kinbody(kuka_iiwa14_specs())
     q_star = _HAND_PICKED_Q[0]
     T_target = poe_forward_kinematics(kb, q_star)
-    srs_solve(kb, T_target, max_solutions=1)  # warmup
-    times = []
-    for _ in range(20):
-        t0 = time.perf_counter()
-        srs_solve(kb, T_target, max_solutions=1)
-        times.append(time.perf_counter() - t0)
-    median_ms = float(np.median(times)) * 1000
-    assert median_ms < 1.0, f"SRS max_solutions=1 too slow: {median_ms:.2f} ms"
+    best_ms = best_call_ms(lambda: srs_solve(kb, T_target, max_solutions=1))
+    assert best_ms < 1.0, f"SRS max_solutions=1 too slow: {best_ms:.2f} ms"
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_seven_r_srs_polished.py
+++ b/tests/test_seven_r_srs_polished.py
@@ -22,7 +22,6 @@ Test contract (per `feedback_bulletproof_solvers`):
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 
 import numpy as np
@@ -39,6 +38,7 @@ from ssik.solvers.seven_r import srs_polished
 
 sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
 
+from _perf import best_call_ms
 
 GEN3_URDF = Path(__file__).parent / "fixtures" / "gen3.urdf"
 RIZON4_URDF = Path(__file__).parent / "fixtures" / "rizon4.urdf"
@@ -284,19 +284,15 @@ def test_gen3_polished_under_400ms() -> None:
 
     Empirical: ~95 ms on Apple M3, ~210 ms on the slower x86_64 GHA
     runner. The 400 ms gate covers both with margin and still catches
-    >1.5x regressions against the slow-runner baseline.
+    >1.5x regressions against the slow-runner baseline. Best-of-N timing
+    (see :mod:`tests._perf`) so the gate tracks compute cost, not
+    shared-runner scheduling noise.
     """
     kb = _gen3_kb()
     q_star = _HAND_PICKED_Q[0]
     T_target = poe_forward_kinematics(kb, q_star)
-    srs_polished.solve(kb, T_target)  # warmup
-    times = []
-    for _ in range(10):
-        t0 = time.perf_counter()
-        srs_polished.solve(kb, T_target)
-        times.append(time.perf_counter() - t0)
-    median_ms = float(np.median(times)) * 1000
-    assert median_ms < 400, f"Gen3 srs_polished too slow: {median_ms:.1f} ms"
+    best_ms = best_call_ms(lambda: srs_polished.solve(kb, T_target), runs=10)
+    assert best_ms < 400, f"Gen3 srs_polished too slow: {best_ms:.1f} ms"
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The `@pytest.mark.perf` gates timed sub-millisecond calls with **median/mean**, which is fragile on shared CI runners where OS-scheduling noise is strictly *additive* — a preemption only ever makes a call look slower. On the #383 CI run, `test_iiwa14_max_solutions_one_under_1ms` (0.23 ms compute) had its median-of-20 dragged to **1.00 ms** under runner load and tripped its `< 1 ms` gate, blocking an unrelated PR.

## What

One shared helper — `tests/fixtures/_perf.best_call_ms` — returns the **best-of-N** call time. Because noise is additive, the minimum is the noise-floor estimate of true compute cost: it's immune to transient load yet still rises under a genuine regression (which inflates every run, the fastest included). The perf-gate benchmarks are deterministic single-input calls, so their distribution is unimodal and the minimum is the honest floor.

Every absolute perf gate now routes through it:

| gate | before | after |
|------|--------|-------|
| `seven_r.srs` full-sweep | median/20 | best-of-N |
| `seven_r.srs` `max_solutions=1` (the flake) | median/20 | best-of-N |
| `seven_r.srs_polished` gen3 sweep | median/10 | best-of-N |
| `husty_pfurner` `eliminate_uw_numeric` | **mean**/30 (noisier than median) | best-of-N |
| `Manipulator.solve` overhead | mean − mean (can go negative under load) | best(wrapper) − best(raw) |

**Thresholds are unchanged.** Since `min ≤ median ≤ mean`, every gate keeps all its headroom and now reads as "best-case cost must stay under X" — exactly a regression gate's intent.

## Verification

- Best-of-N spread on the formerly-flaky gate: **0.40–0.41 ms across 30 trials** (vs the 1.00 ms median spike that failed CI).
- All perf files: **102 passed**. Full suite: **1599 passed, 6 xfailed, 5 xpassed** (all pre-existing). ruff + mypy clean.

Follow-up to #383. No `src/` changes — test infrastructure only.