### PR TITLE
Route + solve spherical-wrist 6R arms with a flange offset (#377)

### DIFF
--- a/src/ssik/_kinbody.py
+++ b/src/ssik/_kinbody.py
@@ -27,13 +27,29 @@ This module is private. The public solver entry points
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Literal, overload
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 from numpy.typing import NDArray
 
-__all__ = ["Joint", "JointSpec", "KinBody", "Link", "build_kinbody", "build_poe_kinbody"]
+if TYPE_CHECKING:
+    from ssik.core.tolerances import TolerancePolicy
+
+__all__ = [
+    "Joint",
+    "JointSpec",
+    "KinBody",
+    "Link",
+    "build_kinbody",
+    "build_poe_kinbody",
+    "canonicalize_spherical_wrist",
+]
+
+# A revolute joint's frame origin may sit anywhere along its own axis without
+# changing kinematics; below this the residual off-axis component of a wrist
+# offset is treated as zero (a genuine spherical wrist meets to ~1e-15).
+_WRIST_PERP_ATOL = 1e-9
 
 JointType = Literal["revolute", "prismatic"]
 
@@ -383,3 +399,74 @@ def build_poe_kinbody(
             )
         )
     return KinBody(links=links, joints=joints)
+
+
+def canonicalize_spherical_wrist(kb: KinBody, policy: TolerancePolicy | None = None) -> KinBody:
+    """Return ``kb`` with its spherical wrist expressed in the canonical gauge.
+
+    The ik-geo ``spherical`` family consolidates the wrist as
+    ``p[3] = T_left[3] + T_left[4] + T_left[5]`` (a telescoping sum that reduces
+    to the *last* wrist joint's origin) and reads the tool-flange offset from
+    ``T_right[5]``. A URDF that places the last wrist joint's frame a fixed
+    distance *along its own rotation axis* from the wrist-center intersection --
+    the flange offset, standard on industrial arms like the ABB IRB 6700 (#377)
+    -- breaks that: the offset lands in the consolidated ``p[3]`` instead of the
+    tool term, so the wrist center is computed wrong and the solver returns
+    nothing.
+
+    A revolute joint's origin may slide freely along its own axis without
+    changing kinematics (a translation along the axis commutes with the joint
+    rotation: ``R(axis, q)^-1 @ Trans(d) @ R(axis, q) == Trans(d)`` for
+    ``d || axis``). This returns a copy with the last wrist joint slid onto the
+    axis intersection and the along-axis offset moved into ``T_right`` -- exactly
+    FK-identical, and canonical for the solver's consolidation. It is a no-op
+    (returns ``kb`` unchanged) when the last three axes are not concurrent or the
+    wrist is already canonical, so it is safe to call unconditionally at solver
+    entry. Only the *along-axis* component is a gauge freedom; an off-axis origin
+    is a genuinely non-spherical wrist and is left untouched.
+
+    Gauge-invariance lives here, in the solver path, rather than in construction:
+    the un-gauged representation is what other solvers (SRS / jointlock / HP) and
+    the baked artifacts depend on, so nothing outside the spherical solve is
+    perturbed (#377).
+    """
+    # Local imports keep the module's import surface flat and cycle-free
+    # (``predicates`` imports this module only under TYPE_CHECKING).
+    from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+    from ssik.kinematics.predicates import axes_meet_at_common_point
+
+    if policy is None:
+        policy = DEFAULT_TOLERANCE_POLICY
+
+    joints = kb.joints
+    n = len(joints)
+    if n < 3:
+        return kb
+    last = joints[-1]
+    if not last.IsRevolute(0):
+        return kb
+
+    p = axes_meet_at_common_point(joints, (n - 3, n - 2, n - 1), policy)
+    if p is None:
+        return kb
+
+    # Last wrist joint origin in the base frame (T_left is a pure translation
+    # post-normalization, so origins accumulate along the chain).
+    origin = np.zeros(3, dtype=np.float64)
+    for j in joints:
+        origin = origin + j.T_left[:3, 3]
+
+    axis = last.axis
+    delta = origin - p
+    along = float(np.dot(delta, axis)) * axis
+    if float(np.linalg.norm(delta - along)) > _WRIST_PERP_ATOL:
+        return kb  # off-axis: genuinely non-spherical, not a gauge freedom
+    if float(np.linalg.norm(along)) < _WRIST_PERP_ATOL:
+        return kb  # already canonical
+
+    new_left = last.T_left.copy()
+    new_left[:3, 3] = new_left[:3, 3] - along
+    new_right = last.T_right.copy()
+    new_right[:3, 3] = new_right[:3, 3] + along
+    new_joints = [*joints[:-1], replace(last, T_left=new_left, T_right=new_right)]
+    return KinBody(links=list(kb.links), joints=new_joints)

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -63,8 +63,8 @@ import numpy as np
 from ssik._kinbody import KinBody
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import (
+    axes_meet_at_common_point,
     axis_parallel,
-    three_consecutive_intersecting,
     three_consecutive_parallel,
 )
 
@@ -253,7 +253,14 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
         raise ValueError(f"dispatch supports 6-DOF and 7-DOF chains; got {len(kb.joints)} joints.")
 
     parallel_triple = three_consecutive_parallel(kb.joints, policy)
-    intersecting_triple = three_consecutive_intersecting(kb.joints, policy)
+    # Gauge-invariant spherical-wrist test: the wrist axes (3, 4, 5) meeting at a
+    # common point is the true Pieper condition, independent of where the joint
+    # frame origins sit along those axes. A URDF flange offset (last wrist joint
+    # placed along its own axis, e.g. ABB IRB 6700, #377) still routes here; the
+    # spherical solver re-gauges it via ``canonicalize_spherical_wrist`` before
+    # consolidating. (``three_consecutive_intersecting`` additionally requires
+    # origin coincidence -- a consolidation convenience, not a routing condition.)
+    wrist_meets = axes_meet_at_common_point(kb.joints, (3, 4, 5), policy) is not None
     j12_parallel = axis_parallel(kb.joints[1].axis, kb.joints[2].axis, policy)
     p1_norm = float(np.linalg.norm(kb.joints[1].T_left[:3, 3]))
     p1_on_axis = p1_norm < policy.axis_intersect
@@ -273,7 +280,7 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
         return plan
 
     # Tier 0 -- spherical wrist (Pieper class).
-    if intersecting_triple == (3, 4, 5):
+    if wrist_meets:
         if j12_parallel and p1_on_axis:
             # Both shoulder specializations match (Puma-560 case). Prefer the
             # parallel-shoulder solver -- typically smaller IK set and slightly

--- a/src/ssik/solvers/ikgeo/spherical.py
+++ b/src/ssik/solvers/ikgeo/spherical.py
@@ -56,7 +56,7 @@ import cython
 import numpy as np
 from numpy.typing import NDArray
 
-from ssik._kinbody import KinBody
+from ssik._kinbody import KinBody, canonicalize_spherical_wrist
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_fk import poe_forward_kinematics
@@ -105,6 +105,10 @@ def solve(
     """
     if len(kb.joints) != 6:
         raise ValueError(f"spherical requires a 6-DOF chain; got {len(kb.joints)} joints")
+    # Re-gauge a URDF flange offset (last wrist joint placed along its own axis)
+    # onto the wrist intersection so the p[3] consolidation below is correct;
+    # FK-identical and a no-op for already-canonical wrists (#377).
+    kb = canonicalize_spherical_wrist(kb, policy)
     triple = three_consecutive_intersecting(kb.joints, policy)
     if triple != (3, 4, 5):
         raise ValueError(

--- a/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_intersecting.py
@@ -51,7 +51,7 @@ import logging
 import numpy as np
 from numpy.typing import NDArray
 
-from ssik._kinbody import KinBody
+from ssik._kinbody import KinBody, canonicalize_spherical_wrist
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_fk import poe_forward_kinematics
@@ -93,6 +93,10 @@ def solve(
         raise ValueError(
             f"spherical_two_intersecting requires a 6-DOF chain; got {len(kb.joints)} joints"
         )
+    # Re-gauge a URDF flange offset (last wrist joint placed along its own axis)
+    # onto the wrist intersection so the p[3] consolidation below is correct;
+    # FK-identical and a no-op for already-canonical wrists (#377).
+    kb = canonicalize_spherical_wrist(kb, policy)
     triple = three_consecutive_intersecting(kb.joints, policy)
     if triple != (3, 4, 5):
         raise ValueError(

--- a/src/ssik/solvers/ikgeo/spherical_two_parallel.py
+++ b/src/ssik/solvers/ikgeo/spherical_two_parallel.py
@@ -56,7 +56,7 @@ import logging
 import numpy as np
 from numpy.typing import NDArray
 
-from ssik._kinbody import KinBody
+from ssik._kinbody import KinBody, canonicalize_spherical_wrist
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_fk import poe_forward_kinematics
@@ -98,6 +98,10 @@ def solve(
         raise ValueError(
             f"spherical_two_parallel requires a 6-DOF chain; got {len(kb.joints)} joints"
         )
+    # Re-gauge a URDF flange offset (last wrist joint placed along its own axis)
+    # onto the wrist intersection so the p[3] consolidation below is correct;
+    # FK-identical and a no-op for already-canonical wrists (#377).
+    kb = canonicalize_spherical_wrist(kb, policy)
     triple = three_consecutive_intersecting(kb.joints, policy)
     if triple != (3, 4, 5):
         raise ValueError(

--- a/tests/test_wrist_gauge_canonicalization.py
+++ b/tests/test_wrist_gauge_canonicalization.py
@@ -1,0 +1,155 @@
+"""Gauge-invariant spherical-wrist handling (#377).
+
+A spherical-wrist 6R whose last joint's URDF frame sits a fixed distance *along
+its own rotation axis* from the wrist-center intersection (the flange offset --
+ABB IRB 6700 and other standard industrial arms) was mis-classified: the strict
+``three_consecutive_intersecting`` predicate requires the wrist origins to
+coincide with the intersection, so dispatch fell back to the ~100x-slower
+``ikgeo.general_6r``.
+
+The fix is gauge-invariant and scoped to the spherical-solve path -- no global
+representation change:
+
+* Dispatch routes on :func:`ssik.kinematics.predicates.axes_meet_at_common_point`
+  -- the true Pieper condition (wrist axes concurrent), independent of origin
+  placement.
+* :func:`ssik._kinbody.canonicalize_spherical_wrist` slides the along-axis offset
+  onto the intersection (into the tool transform, an exact gauge move) at solver
+  entry, on a copy.
+
+This pins: the fix routes + solves at machine precision; canonicalization is
+FK-identical and does not mutate its input; construction is untouched (so 7R
+SRS/jointlock arms and baked artifacts are unaffected -- the iiwa #155
+rejection still holds); and an *off-axis* offset (a genuinely non-spherical
+wrist) is left alone.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import JointSpec, build_kinbody, canonicalize_spherical_wrist
+from ssik.core.dispatcher import dispatch
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.kinematics.predicates import three_consecutive_intersecting
+from ssik.solvers.ikgeo import spherical_two_parallel
+
+_Z = np.array([0.0, 0.0, 1.0])
+_Y = np.array([0.0, 1.0, 0.0])
+_X = np.array([1.0, 0.0, 0.0])
+
+
+def _trans(x: float, y: float, z: float) -> np.ndarray:
+    m = np.eye(4)
+    m[:3, 3] = (x, y, z)
+    return m
+
+
+def _spherical_wrist_6r(flange: np.ndarray) -> list[JointSpec]:
+    """Anthropomorphic spherical-wrist 6R: shoulder/elbow axes parallel (the
+    ``spherical_two_parallel`` class) and wrist axes (3, 4, 5) concurrent at one
+    point. ``flange`` is the last joint's frame offset from that point -- along
+    +x it is an along-axis gauge offset; along +z it is off-axis.
+    """
+    return [
+        JointSpec(parent_link_T=_trans(0, 0, 0), axis=_Z, joint_type="revolute"),
+        JointSpec(parent_link_T=_trans(0, 0, 0.5), axis=_Y, joint_type="revolute"),
+        JointSpec(parent_link_T=_trans(0.5, 0, 0), axis=_Y, joint_type="revolute"),
+        JointSpec(parent_link_T=_trans(0.5, 0, 0), axis=_X, joint_type="revolute"),
+        JointSpec(parent_link_T=_trans(0, 0, 0), axis=_Y, joint_type="revolute"),
+        JointSpec(
+            parent_link_T=_trans(float(flange[0]), float(flange[1]), float(flange[2])),
+            axis=_X,
+            joint_type="revolute",
+        ),
+    ]
+
+
+def test_along_axis_flange_routes_to_spherical_and_solves() -> None:
+    """The along-axis flange offset routes to the Tier-0 spherical solver and
+    solves at machine precision (#377)."""
+    kb = build_kinbody(_spherical_wrist_6r(np.array([0.2, 0.0, 0.0])))
+    plan = dispatch(kb)
+    assert plan.solver_name == "ikgeo.spherical_two_parallel", plan.solver_name
+    assert plan.tier == 0
+
+    rng = np.random.default_rng(0)
+    worst = 0.0
+    solved = 0
+    for _ in range(200):
+        q = rng.uniform(-2.0, 2.0, size=6)
+        t = poe_forward_kinematics(kb, q)
+        sols, _ = spherical_two_parallel.solve(kb, t)
+        if sols:
+            solved += 1
+            worst = max(
+                worst, min(float(np.max(np.abs(poe_forward_kinematics(kb, s.q) - t))) for s in sols)
+            )
+    assert solved == 200, f"only solved {solved}/200"
+    assert worst < 1e-9, f"worst FK closure {worst:.2e}"
+
+
+def test_off_axis_flange_stays_general_6r() -> None:
+    """An *off-axis* last-joint offset is a genuinely non-spherical wrist (the
+    axis misses the intersection): it is NOT routed to the spherical solver."""
+    kb = build_kinbody(_spherical_wrist_6r(np.array([0.0, 0.0, 0.2])))
+    assert dispatch(kb).solver_name == "ikgeo.general_6r"
+
+
+def test_canonicalize_is_fk_identical_and_non_mutating() -> None:
+    """``canonicalize_spherical_wrist`` returns an FK-identical copy and leaves
+    the input untouched -- gauge-invariance without side effects."""
+    kb = build_kinbody(_spherical_wrist_6r(np.array([0.2, 0.0, 0.0])))
+    before_left = kb.joints[-1].T_left[:3, 3].copy()
+    before_right = kb.joints[-1].T_right[:3, 3].copy()
+
+    kb_canon = canonicalize_spherical_wrist(kb)
+
+    # Input unchanged.
+    assert np.array_equal(kb.joints[-1].T_left[:3, 3], before_left)
+    assert np.array_equal(kb.joints[-1].T_right[:3, 3], before_right)
+    # Copy is re-gauged: the 0.2 moved from the joint frame into the tool.
+    assert not np.allclose(kb_canon.joints[-1].T_left[:3, 3], before_left)
+    # FK identical at random configs.
+    rng = np.random.default_rng(3)
+    for _ in range(50):
+        q = rng.uniform(-3.0, 3.0, size=6)
+        assert (
+            np.max(np.abs(poe_forward_kinematics(kb, q) - poe_forward_kinematics(kb_canon, q)))
+            < 1e-12
+        )
+
+
+def test_construction_does_not_gauge_the_wrist() -> None:
+    """Building the KinBody must NOT canonicalize -- gauge-invariance lives in the
+    solver path only, so nothing outside a spherical solve sees a changed
+    representation (this is what keeps 7R artifacts + the #155 contract intact)."""
+    flange = np.array([0.2, 0.0, 0.0])
+    kb = build_kinbody(_spherical_wrist_6r(flange))
+    # The flange still sits in the last joint's T_left (as authored), not folded
+    # into the tool transform.
+    assert np.allclose(kb.joints[-1].T_left[:3, 3], flange)
+    assert np.allclose(kb.joints[-1].T_right[:3, 3], np.zeros(3))
+    # And the strict predicate still rejects the un-gauged wrist.
+    assert three_consecutive_intersecting(kb.joints) is None
+
+
+def test_canonicalize_noop_on_canonical_and_nonspherical() -> None:
+    """No-op (returns the same object) when the wrist is already canonical or
+    the chain has no spherical wrist -- safe to call unconditionally."""
+    canonical = build_kinbody(_spherical_wrist_6r(np.array([0.0, 0.0, 0.0])))
+    assert canonicalize_spherical_wrist(canonical) is canonical
+
+    off_axis = build_kinbody(_spherical_wrist_6r(np.array([0.0, 0.0, 0.2])))
+    assert canonicalize_spherical_wrist(off_axis) is off_axis
+
+
+def test_seven_r_untouched_by_construction() -> None:
+    """A 7R chain with an along-axis wrist offset is left exactly as built and is
+    not routed to a 6R spherical solver -- the SRS/jointlock path owns it."""
+    specs = [
+        JointSpec(parent_link_T=_trans(0, 0, 0.2 * i), axis=_Z, joint_type="revolute")
+        for i in range(7)
+    ]
+    kb = build_kinbody(specs)
+    assert np.allclose(kb.joints[-1].T_right[:3, 3], np.zeros(3))


### PR DESCRIPTION
## Why

A spherical-wrist 6R whose last wrist joint's URDF frame sits a fixed distance **along its own rotation axis** from the wrist-center intersection — the flange offset, standard on industrial arms (ABB IRB 6700 and others) — was dispatched to the **~100× slower** `ikgeo.general_6r`. Two users reported this (#377); one also saw validation failures.

Root cause: the strict `three_consecutive_intersecting` predicate requires the wrist origins to *coincide* with the intersection, which the flange offset violates; and the ik-geo consolidation `p[3] = ΣT_left[3..5]` (which telescopes to the last wrist origin) folded the offset into the computed wrist center, so the solver returned nothing.

Fixes #377.

## The insight

A revolute joint's frame origin may slide freely **along its own axis** without changing kinematics — a translation along the axis commutes with the joint rotation (`R(axis,q)⁻¹·Trans(d)·R(axis,q) == Trans(d)` for `d ∥ axis`). The flange offset is therefore pure **gauge**. A genuine spherical wrist is defined by its axes being **concurrent**, independent of where the origins sit along them.

## What (gauge-invariant, scoped to the spherical-solve path — no global representation change)

- **Dispatch** routes on `axes_meet_at_common_point((3,4,5))` — the true Pieper condition — instead of origin-coincidence. (An existing predicate, already used by the SRS solvers.)
- **`canonicalize_spherical_wrist`** (new, in `_kinbody`) slides the along-axis offset onto the intersection and into the tool transform, **on a copy**, at the entry of all three spherical solvers (`spherical_two_parallel` / `spherical_two_intersecting` / `spherical`). FK-identical; a no-op for already-canonical or non-spherical wrists.

Construction stays untouched, so 7R SRS/jointlock arms, their locked sub-chains, and **every committed artifact** are unaffected — the iiwa #155 rejection still holds. This was the key correctness point: an earlier construction-time approach rippled into 7R conditioning; doing it in the solver path is side-effect-free.

## Verification

- **Both reporters' actual URDFs** (IRB 6700 + a second spherical-wrist 6R): now dispatch `spherical_two_parallel`, solve **300/300** random poses at **~5e-15**.
- Both shoulder variants (`two_parallel`, `two_intersecting`) with a flange: 200/200 at machine precision.
- `tests/test_wrist_gauge_canonicalization.py` (self-contained synthetic fixture — no proprietary URDFs): routing, machine-precision solve, FK-identical + non-mutating canonicalization, off-axis offset correctly stays `general_6r`, construction does not gauge the wrist, no-op cases, 7R untouched.
- Full suite: **1605 passed, 6 xfailed, 5 xpassed** (all pre-existing). ruff + mypy clean.

## Known follow-up (not this PR)

Concurrency uses the absolute `policy.axis_intersect` (1e-8); a very large arm whose URDF rounds the wrist intersection to ~1e-6 would still miss. Same limitation as the prior predicate (not a regression); a scale-relative tolerance is a separate hardening.