### PR TITLE
Wire the solver-matched in-limits resolver into thin-wrapper artifacts (D1)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import textwrap
 from dataclasses import dataclass
+from importlib import import_module
 from io import StringIO
 from typing import TYPE_CHECKING
 
@@ -186,12 +187,19 @@ def _render_thin_wrapper(
         "from ssik.refinement.rescue import "
         "rescue_via_T_perturbation as _rescue_via_T_perturbation\n"
     )
-    # Exact joint-limit-aware swivel resolution for SRS-class 7R (#359): recovers
-    # in-limits solutions the blind swivel sweep drops. No-op (returns []) for
-    # non-SRS chains, so it's safe to import for every thin-wrapper arm.
-    buf.write(
-        "from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits\n"
+    # Exact joint-limit-aware redundancy resolution (#359): recovers in-limits
+    # solutions the coarse redundancy sweep drops. Each redundant-7R solver family
+    # ships its own resolver (SRS swivel vs spherical-shoulder q6), so wire the one
+    # that matches this arm's solver -- importing the SRS resolver for a
+    # spherical-shoulder arm is a silent no-op (#377 audit / D1, #389). Derived
+    # from the solver module itself (has-attr), not a hand-kept map, so a new
+    # thin-wrapper solver that defines ``resolve_in_limits`` is wired automatically.
+    _resolver_module = (
+        solver_module
+        if hasattr(import_module(solver_module), "resolve_in_limits")
+        else "ssik.solvers.seven_r._swivel_limits"
     )
+    buf.write(f"from {_resolver_module} import resolve_in_limits as _resolve_in_limits\n")
     buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -226,7 +234,6 @@ def _render_specialised(
     composer_func_name = composer.__name__
 
     # Local import to avoid a hard dep cycle.
-    from importlib import import_module
 
     comp_mod = import_module(composer_module)
     compose = getattr(comp_mod, composer_func_name)
@@ -1142,7 +1149,6 @@ ComposerFn = Callable[["KinBody"], str]
 
 
 def _import_composer(module_path: str, func_name: str) -> ComposerFn:
-    from importlib import import_module
 
     fn = getattr(import_module(module_path), func_name)
     return fn  # type: ignore[no-any-return]

--- a/src/ssik/prebuilt/fr3_ik.py
+++ b/src/ssik/prebuilt/fr3_ik.py
@@ -53,7 +53,7 @@ import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
+from ssik.solvers.seven_r.spherical_shoulder import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.spherical_shoulder import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.spherical_shoulder"

--- a/src/ssik/prebuilt/franka_panda_ik.py
+++ b/src/ssik/prebuilt/franka_panda_ik.py
@@ -53,7 +53,7 @@ import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
+from ssik.solvers.seven_r.spherical_shoulder import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.spherical_shoulder import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.spherical_shoulder"

--- a/src/ssik/prebuilt/xarm7_ik.py
+++ b/src/ssik/prebuilt/xarm7_ik.py
@@ -53,7 +53,7 @@ import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
+from ssik.solvers.seven_r.spherical_shoulder_polished import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.spherical_shoulder_polished import solve as _solver_solve
 
 SOLVER_NAME = "seven_r.spherical_shoulder_polished"

--- a/tests/test_in_limits_resolver_wiring.py
+++ b/tests/test_in_limits_resolver_wiring.py
@@ -1,0 +1,85 @@
+"""In-limits resolver wiring for thin-wrapper 7R prebuilts (D1, #389).
+
+Each redundant-7R solver family ships its own exact in-limits resolver
+(SRS swivel via ``_swivel_limits`` vs spherical-shoulder q6 via
+``spherical_shoulder`` / ``spherical_shoulder_polished``). The thin-wrapper
+codegen must wire the resolver that *matches the arm's solver* — importing the
+SRS resolver into a spherical-shoulder artifact is a silent no-op (it returns
+``[]`` for a non-SRS chain), so the arm's exact in-limits recovery is dead code
+(the original D1 bug: Franka/FR3 recovered 0 where their own resolver recovers
+10/5).
+
+The structural guard below iterates **every** prebuilt and asserts the wired
+resolver is exactly the one codegen's has-attr rule selects, so this
+mis-wiring class cannot be reintroduced without turning CI red.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from ssik.prebuilt._manifest import load_manifest
+
+# The has-attr derivation codegen uses: a solver family that defines its own
+# ``resolve_in_limits`` owns it; everything else falls back to the SRS resolver.
+_SRS_RESOLVER = "ssik.solvers.seven_r._swivel_limits"
+
+
+def _expected_resolver(solver_name: str):
+    solver_module = importlib.import_module(f"ssik.solvers.{solver_name}")
+    module = solver_module if hasattr(solver_module, "resolve_in_limits") else None
+    if module is None:
+        module = importlib.import_module(_SRS_RESOLVER)
+    return module.resolve_in_limits
+
+
+def _thin_wrapper_prebuilts() -> list[str]:
+    names = []
+    for arm in load_manifest():
+        try:
+            mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+        except Exception:
+            continue
+        # Thin-wrapper artifacts are exactly the ones that emit ``_resolve_in_limits``.
+        if hasattr(mod, "_resolve_in_limits"):
+            names.append(arm)
+    return names
+
+
+_THIN_WRAPPER = _thin_wrapper_prebuilts()
+
+
+@pytest.mark.parametrize("arm", _THIN_WRAPPER)
+def test_prebuilt_wires_solver_matched_resolver(arm: str) -> None:
+    """Structural guard: every thin-wrapper prebuilt imports the in-limits
+    resolver from the module that matches its own solver — never a mismatched
+    no-op (D1). Fails CI the instant a new/renamed solver drifts."""
+    mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+    expected = _expected_resolver(mod.SOLVER_NAME)
+    assert mod._resolve_in_limits is expected, (
+        f"{arm} (solver {mod.SOLVER_NAME}) wired {mod._resolve_in_limits.__module__}."
+        f"resolve_in_limits but its solver family provides "
+        f"{expected.__module__}.resolve_in_limits — the D1 mis-wiring."
+    )
+
+
+@pytest.mark.parametrize(
+    ("arm", "q"),
+    [
+        ("franka_panda_ik", [0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5]),
+        ("fr3_ik", [0.3, -0.4, 0.2, -1.6, 0.1, 1.3, 0.5]),
+        ("xarm7_ik", [0.2, -0.3, 0.5, 1.0, 0.4, 1.0, 0.3]),
+    ],
+)
+def test_spherical_shoulder_in_limits_recovery_is_live(arm: str, q: list[float]) -> None:
+    """Behavioral regression: the spherical-shoulder prebuilts' in-limits
+    resolver actually recovers solutions (it was the SRS no-op returning 0)."""
+    mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+    t = mod.fk(np.asarray(q))
+    sols = mod._resolve_in_limits(mod._KB, t)
+    assert sols, f"{arm}: in-limits resolver recovered nothing (D1 dead-code regression)"
+    worst = max(float(np.max(np.abs(mod.fk(s.q) - t))) for s in sols)
+    assert worst < 1e-9, f"{arm}: in-limits solution FK closure {worst:.2e}"


### PR DESCRIPTION
Part of #389 (architecture audit — D1, first confirmed defect).

## Bug

The thin-wrapper codegen hard-coded `from ssik.solvers.seven_r._swivel_limits import resolve_in_limits` for **every** thin-wrapper arm. That's the *SRS* resolver — on a spherical-shoulder arm (Franka/FR3/xArm7) it classifies the chain as non-SRS and returns `[]`. So the `respect_limits` empty-fallback recovered **0** in-limits solutions on the flagship arms, where their own resolver recovers **10 / 5 / 28**. The `spherical_shoulder` module's headline "exact in-limits, no coverage gaps" guarantee was dead code on the arms it was written for.

Verified: `franka_panda_ik._resolve_in_limits(_KB, T)` → 0 before, 10 after (fr3 5, xarm7 28).

## Fix

Select the resolver per solver, **derived from the solver module itself** (has-attr) rather than a hand-kept map: a solver family that defines `resolve_in_limits` owns it; everything else falls back to the SRS resolver. A future thin-wrapper solver that ships its own resolver is wired automatically — no new registry to keep in sync (which is the whole point of #389).

Regenerated franka/fr3/xarm7 artifacts (one import line each). `import_module` hoisted to a module-level import (was duplicated in two local scopes).

## Guard against recurrence

`tests/test_in_limits_resolver_wiring.py`:
- **Structural guard** — parametrizes over *every* thin-wrapper prebuilt and asserts the wired `_resolve_in_limits is` exactly the resolver the has-attr rule selects. Any future mis-wiring (new arm, renamed solver) turns CI red.
- **Behavioral regression** — Franka/FR3/xArm7 recover in-limits solutions at machine-precision FK (was 0).

Full suite unaffected: snapshot + fixtures green; ruff + mypy clean.