### PR TITLE
Collapse the ~6 parallel solver registries into one SolverSpec (U1)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -33,6 +33,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ssik.core.solver_registry import SOLVERS
+
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from ssik._kinbody import KinBody
     from ssik.core.dispatcher import DispatchPlan
@@ -115,26 +117,6 @@ def emit_artifact(
     )
 
 
-# Maps the dispatcher's solver_name (e.g. ``ikgeo.three_parallel``) onto the
-# fully-qualified Python module path under :mod:`ssik.solvers` that the
-# emitted artifact will import.
-_SOLVER_IMPORT_PATHS: dict[str, str] = {
-    "ikgeo.three_parallel": "ssik.solvers.ikgeo.three_parallel",
-    "ikgeo.spherical_two_parallel": "ssik.solvers.ikgeo.spherical_two_parallel",
-    "ikgeo.spherical_two_intersecting": "ssik.solvers.ikgeo.spherical_two_intersecting",
-    "ikgeo.spherical": "ssik.solvers.ikgeo.spherical",
-    "ikgeo.two_parallel": "ssik.solvers.ikgeo.two_parallel",
-    "ikgeo.two_intersecting": "ssik.solvers.ikgeo.two_intersecting",
-    "ikgeo.general_6r": "ssik.solvers.ikgeo.general_6r",
-    "husty_pfurner.general_6r": "ssik.solvers.husty_pfurner.general_6r",
-    "seven_r.srs": "ssik.solvers.seven_r.srs",
-    "seven_r.srs_polished": "ssik.solvers.seven_r.srs_polished",
-    "seven_r.spherical_shoulder": "ssik.solvers.seven_r.spherical_shoulder",
-    "seven_r.spherical_shoulder_polished": "ssik.solvers.seven_r.spherical_shoulder_polished",
-    "jointlock.seven_r": "ssik.solvers.jointlock.seven_r",
-}
-
-
 def _render(*, kb: KinBody, plan: DispatchPlan, module_name: str, arm_label: str) -> str:
     """Render the artifact source as a single string.
 
@@ -143,7 +125,7 @@ def _render(*, kb: KinBody, plan: DispatchPlan, module_name: str, arm_label: str
     into ssik solver at runtime; #110 Phase 1 default). The specialised
     form is preferred when a per-solver composer is registered.
     """
-    if plan.solver_name in _SPECIALISED_COMPOSERS:
+    if SOLVERS[plan.solver_name].composer is not None:
         return _render_specialised(kb=kb, plan=plan, module_name=module_name, arm_label=arm_label)
     return _render_thin_wrapper(kb=kb, plan=plan, module_name=module_name, arm_label=arm_label)
 
@@ -156,7 +138,7 @@ def _render_thin_wrapper(
     Used for solvers without a registered specialised composer (today:
     every solver except spherical_two_parallel; expand as composers land).
     """
-    solver_module = _SOLVER_IMPORT_PATHS[plan.solver_name]
+    solver_module = SOLVERS[plan.solver_name].module_path
     solver_short = plan.solver_name.split(".")[-1]
 
     buf = StringIO()
@@ -229,15 +211,11 @@ def _render_specialised(
     the algebraic candidates with FK verification + dedup, mirroring
     `verify_candidates`.
     """
-    composer = _SPECIALISED_COMPOSERS[plan.solver_name]
-    composer_module = composer.__module__
-    composer_func_name = composer.__name__
-
-    # Local import to avoid a hard dep cycle.
-
+    composer_module = SOLVERS[plan.solver_name].composer
+    assert composer_module is not None  # _render_specialised is only called when set
     comp_mod = import_module(composer_module)
-    compose = getattr(comp_mod, composer_func_name)
-    render_constants_header = getattr(comp_mod, "render_constants_header")  # noqa: B009
+    compose = comp_mod.compose
+    render_constants_header = comp_mod.render_constants_header
 
     algebraic_body = compose(kb)
 
@@ -296,36 +274,16 @@ def _render_specialised(
     if plan.solver_name == "jointlock.seven_r":
         buf.write(_render_specialised_solve_orchestrator_7r())
     else:
+        _spec = SOLVERS[plan.solver_name]
         buf.write(
             _render_specialised_solve_orchestrator(
-                _SPECIALISED_FK_ATOL_EXPR.get(plan.solver_name, "policy.subproblem_numerical"),
-                force_refine=plan.solver_name in _SPECIALISED_FORCE_REFINE,
+                _spec.fk_atol_expr,
+                force_refine=_spec.force_refine,
             )
         )
     buf.write(_render_fk_alias())
     buf.write(_render_all_export())
     return buf.getvalue()
-
-
-# Per-solver FK-verify gate baked into the specialised artifact's solve(). The
-# default (``policy.subproblem_numerical`` = 1e-5) is what tier-2 RR arms rely on
-# -- their algebraic FK can drift above it and is recovered by refinement. Exact
-# Pieper solvers that can emit a near-singular SP-clip near-miss (~1e-6 FK, no
-# real IK nearby) tighten the gate to drop it (#362); keep in sync with the live
-# solver's own gate.
-_SPECIALISED_FK_ATOL_EXPR: dict[str, str] = {
-    "ikgeo.three_parallel": "1e-7",  # == ssik.solvers.ikgeo.three_parallel._FK_VERIFY_ATOL
-}
-
-# Solvers whose artifact always Newton-polishes near-miss candidates (even when
-# the caller passes ``allow_refinement=False``). At a near-singular pose the
-# closed form only reaches ~1e-6 FK; polish then separates genuine near-singular
-# solutions (converge -> kept, #288) from spurious boundary near-misses (stall ->
-# dropped, #362). Fires only for the rare > fk_atol candidate. Mirrors the live
-# solver's unconditional ``allow_refinement=True``. Not for tier-2 RR arms --
-# their near-misses are common and their default (drop) / opt-in-polish contract
-# is deliberate.
-_SPECIALISED_FORCE_REFINE: frozenset[str] = frozenset({"ikgeo.three_parallel"})
 
 
 def _render_specialised_solve_orchestrator(
@@ -722,7 +680,7 @@ def _render_specialised_solve_orchestrator(
         '''
     ).replace("fk_atol = policy.subproblem_numerical", f"fk_atol = {fk_atol_expr}")
     if force_refine:
-        # Always polish near-misses (see _SPECIALISED_FORCE_REFINE). Only rewrite
+        # Always polish near-misses (see SolverSpec.force_refine). Only rewrite
         # the gate when set, so non-forced artifacts stay byte-identical.
         template = template.replace(
             "if not allow_refinement:", "if not (allow_refinement or True):"
@@ -1137,35 +1095,6 @@ def _render_specialised_solve_orchestrator_7r() -> str:
             return solutions
         '''
     )
-
-
-# Per-solver registered composers. Solvers absent from this map fall back
-# to the thin-wrapper emitter. Add entries as composers land (#112 plan).
-from collections.abc import Callable  # noqa: E402
-
-# ``KinBody`` is in TYPE_CHECKING-only scope at module load; use a string
-# forward reference inside ``Callable``.
-ComposerFn = Callable[["KinBody"], str]
-
-
-def _import_composer(module_path: str, func_name: str) -> ComposerFn:
-
-    fn = getattr(import_module(module_path), func_name)
-    return fn  # type: ignore[no-any-return]
-
-
-_SPECIALISED_COMPOSERS: dict[str, ComposerFn] = {
-    "ikgeo.spherical_two_parallel": _import_composer(
-        "ssik.codegen._compose.spherical_two_parallel", "compose"
-    ),
-    "ikgeo.three_parallel": _import_composer("ssik.codegen._compose.three_parallel", "compose"),
-    "ikgeo.spherical_two_intersecting": _import_composer(
-        "ssik.codegen._compose.spherical_two_intersecting", "compose"
-    ),
-    "ikgeo.spherical": _import_composer("ssik.codegen._compose.spherical", "compose"),
-    "ikgeo.general_6r": _import_composer("ssik.codegen._compose.general_6r", "compose"),
-    "jointlock.seven_r": _import_composer("ssik.codegen._compose.seven_r", "compose"),
-}
 
 
 def _kb_digest(kb: KinBody) -> str:

--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -61,6 +61,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from ssik._kinbody import KinBody
+from ssik.core.solver_registry import SOLVERS
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.predicates import (
     axes_meet_at_common_point,
@@ -109,22 +110,6 @@ class DispatchPlan:
 # Per-solver order-of-magnitude estimates measured on Apple M3 single-thread,
 # Python+numpy, post-#93 speed pass. These are the user-facing "expect ~Xms"
 # numbers; codegen also bakes them into the emitted artifact's docstring.
-_SOLVER_ESTIMATES: dict[str, tuple[int, float, int]] = {
-    # solver_name -> (tier, expected_ms_median, flop_budget)
-    "ikgeo.three_parallel": (0, 1.6, 2_519),
-    "ikgeo.spherical_two_parallel": (0, 1.2, 1_316),
-    "ikgeo.spherical_two_intersecting": (0, 1.3, 1_476),
-    "ikgeo.spherical": (0, 7.5, 10_312),
-    "ikgeo.two_parallel": (1, 261.0, 141_569),
-    "ikgeo.two_intersecting": (1, 1184.0, 2_650_681),
-    "ikgeo.general_6r": (2, 5.0, 30_000_000),
-    "husty_pfurner.general_6r": (2, 120.0, 50_000_000),
-    "seven_r.srs": (0, 8.5, 1_900),  # native SRS-class 7R, full sweep (16 swivel x 8 branches)
-    "seven_r.srs_polished": (0, 56.0, 80_000),  # approximate-SRS + batched LM polish (Gen3 et al.)
-    "seven_r.spherical_shoulder": (0, 17.0, 6_000),  # exact spherical-shoulder 7R (Franka/FR3)
-    "seven_r.spherical_shoulder_polished": (0, 8.0, 40_000),  # near-spherical + LM polish (xArm7)
-    "jointlock.seven_r": (1, 50.0, 30_274),  # 7R wrapper around inner 6R
-}
 
 
 def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) -> DispatchPlan:
@@ -162,7 +147,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "1989 algorithm, parameterised by elbow swivel angle.\n"
                     "Covers KUKA iiwa LBR (canonical strict-SRS)."
                 ),
-                needs_symbolic_precompute=False,
             )
             _LOG.info("dispatch: chose %s (tier 0, native SRS-7R)", plan.solver_name)
             return plan
@@ -185,7 +169,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "Faster than the jointlock sweep, machine precision, no\n"
                     "coverage gaps. Covers Franka Panda / FR3."
                 ),
-                needs_symbolic_precompute=False,
             )
             _LOG.info("dispatch: chose %s (tier 0, spherical-shoulder-7R)", plan.solver_name)
             return plan
@@ -207,7 +190,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "produces excellent seeds; LM polish against the true FK\n"
                     "recovers machine precision. Covers uFactory xArm7."
                 ),
-                needs_symbolic_precompute=False,
             )
             _LOG.info("dispatch: chose %s (tier 0, approx-spherical-7R)", plan.solver_name)
             return plan
@@ -230,7 +212,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "universal jointlock+HP fallback on small-drift arms.\n"
                     "Covers Kinova Gen3 (12 mm / 0.4 mm drift)."
                 ),
-                needs_symbolic_precompute=False,
             )
             _LOG.info("dispatch: chose %s (tier 0, approximate-SRS-7R)", plan.solver_name)
             return plan
@@ -245,7 +226,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                 "Covers Franka Panda, FR3, uFactory xArm7, and any other\n"
                 "non-SRS 7R revolute arm."
             ),
-            needs_symbolic_precompute=False,
         )
         _LOG.info("dispatch: chose %s (tier 1, 7R wrapper)", plan.solver_name)
         return plan
@@ -274,7 +254,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                 "UR-class structure (UR3 / UR5 / UR10).\n"
                 "Closed-form via SP6 (joints 0+4) + SP1 + SP3."
             ),
-            needs_symbolic_precompute=False,
         )
         _LOG.info("dispatch: chose %s (tier 0)", plan.solver_name)
         return plan
@@ -294,7 +273,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "parallel-shoulder solver is preferred for slightly tighter "
                     "elbow conditioning."
                 ),
-                needs_symbolic_precompute=False,
             )
         elif j12_parallel:
             plan = _make_plan(
@@ -305,7 +283,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "Closed-form via SP4 (shoulder) + SP3 (elbow) + SP1 (wrist). "
                     "Covers most industrial 6R arms (Puma, Fanuc LR/CR, KUKA KR)."
                 ),
-                needs_symbolic_precompute=False,
             )
         elif p1_on_axis:
             plan = _make_plan(
@@ -316,7 +293,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "Closed-form via SP3 + SP2 + SP4 + SP1. Compact-base arms "
                     "(IRB120-class, lite6/xArm6 subfamilies)."
                 ),
-                needs_symbolic_precompute=False,
             )
         else:
             plan = _make_plan(
@@ -328,7 +304,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                     "Generic spherical-wrist fallback; rarely matches "
                     "commercial geometry."
                 ),
-                needs_symbolic_precompute=False,
             )
         _LOG.info("dispatch: chose %s (tier 0)", plan.solver_name)
         return plan
@@ -362,26 +337,25 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
             "leftvar selection. Closes the EAIK coverage gap (Kinova JACO 2 "
             "classical, Agilex Piper, custom non-Pieper 6R)." + weak_block
         ),
-        needs_symbolic_precompute=True,
     )
     _LOG.info("dispatch: chose %s (tier 2)", plan.solver_name)
     return plan
 
 
-def _make_plan(solver_name: str, *, reason: str, needs_symbolic_precompute: bool) -> DispatchPlan:
-    """Assemble a :class:`DispatchPlan` from per-solver estimates + caller fields."""
-    tier, ms, flops = _SOLVER_ESTIMATES[solver_name]
+def _make_plan(solver_name: str, *, reason: str) -> DispatchPlan:
+    """Assemble a :class:`DispatchPlan` from the solver's :class:`SolverSpec`."""
+    spec = SOLVERS[solver_name]
     # Symbolic precompute time estimate -- only applies to tier-2 RR currently.
     # 150-300 s on JACO 2 today; report a single midpoint estimate for the
     # build CLI's ETA. Real per-arm time depends on linearity-joint search
     # hits and sympy version; the build pass measures it precisely.
-    precompute_s = 240.0 if needs_symbolic_precompute else None
+    precompute_s = 240.0 if spec.needs_symbolic_precompute else None
     return DispatchPlan(
         solver_name=solver_name,
-        tier=tier,
+        tier=spec.tier,
         reason=reason,
-        expected_ms_median=ms,
-        flop_budget=flops,
-        needs_symbolic_precompute=needs_symbolic_precompute,
+        expected_ms_median=spec.expected_ms,
+        flop_budget=spec.flop_budget,
+        needs_symbolic_precompute=spec.needs_symbolic_precompute,
         estimated_precompute_seconds=precompute_s,
     )

--- a/src/ssik/core/solver_registry.py
+++ b/src/ssik/core/solver_registry.py
@@ -1,0 +1,124 @@
+"""Single source of truth for every analytical solver ssik can dispatch.
+
+Historically the per-solver metadata lived in ~six parallel ``name -> X`` tables
+that had to be edited in lockstep whenever a solver was added or renamed
+(dispatcher estimates, codegen import paths, manipulator module paths, cli
+scaffolds, codegen composers, and the fk-atol / force-refine overrides). Two of
+them were byte-identical and fully derivable (``f"ssik.solvers.{name}"``), and
+nothing guarded keyset consistency, so drift shipped green and surfaced as a
+KeyError in the field.
+
+This module collapses all of that into one :class:`SolverSpec` per solver. Every
+consumer reads :data:`SOLVERS`; nothing else holds per-solver metadata.
+``tests/test_solver_registry.py`` asserts the table is internally consistent and
+that every module/composer path imports with the expected entry point, so a new
+solver is wired everywhere from one row or CI goes red.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["SOLVERS", "SolverSpec"]
+
+
+@dataclass(frozen=True)
+class SolverSpec:
+    """Everything ssik needs to know about one solver, in one place.
+
+    :param name: the dispatch key, e.g. ``"ikgeo.three_parallel"``. It is also
+        the module suffix -- :attr:`module_path` is ``"ssik.solvers." + name`` --
+        so the (formerly duplicated) import-path and module-path tables are just
+        this property.
+    :param tier: 0 (closed-form) / 1 (univariate search) / 2 (numeric RR/HP).
+    :param expected_ms: rough median solve time, for the dispatch plan + CLI ETA.
+    :param flop_budget: rough per-solve FLOP estimate, for the dispatch plan.
+    :param needs_symbolic_precompute: True iff ``ssik build`` runs a sympy
+        derivation for this solver (tier-2 Raghavan-Roth only today).
+    :param composer: dotted module path of the specialised codegen composer
+        (its entry point is ``compose``), or ``None`` for solvers emitted via the
+        thin-wrapper template.
+    :param fk_atol_expr: the FK-closure gate the emitted specialised orchestrator
+        verifies candidates at (a Python expression string). Defaults to the
+        generic subproblem tolerance; tightened per solver where a boundary
+        near-miss would otherwise pass (three_parallel, #362).
+    :param force_refine: whether the emitted artifact always runs the LM polish
+        (independent of the caller's ``allow_refinement``); artifact-only, the
+        live solver still honours the caller.
+    :param auto_dispatch: whether :func:`ssik.core.dispatcher.dispatch` can route
+        an arm here automatically. False for the tier-1 univariate-search solvers,
+        which are documented as explicit-use-only (RR is ~50-200x faster).
+    """
+
+    name: str
+    tier: int
+    expected_ms: float
+    flop_budget: int
+    needs_symbolic_precompute: bool = False
+    composer: str | None = None
+    fk_atol_expr: str = "policy.subproblem_numerical"
+    force_refine: bool = False
+    auto_dispatch: bool = True
+
+    @property
+    def module_path(self) -> str:
+        """Import path of the live solver module (defines ``solve``)."""
+        return f"ssik.solvers.{self.name}"
+
+
+def _spec(name: str, tier: int, ms: float, flops: int, **kw: object) -> SolverSpec:
+    return SolverSpec(name=name, tier=tier, expected_ms=ms, flop_budget=flops, **kw)  # type: ignore[arg-type]
+
+
+_COMPOSE = "ssik.codegen._compose"
+
+SOLVERS: dict[str, SolverSpec] = {
+    s.name: s
+    for s in (
+        # fk_atol_expr / force_refine: this solver can emit a near-singular SP-clip
+        # near-miss (~1e-6 FK, no real IK nearby); the tightened 1e-7 gate drops it
+        # and always-polish separates genuine near-singular solutions (converge ->
+        # kept, #288) from spurious boundary near-misses (stall -> dropped, #362).
+        # 1e-7 == ssik.solvers.ikgeo.three_parallel._FK_VERIFY_ATOL (guard-tested).
+        _spec(
+            "ikgeo.three_parallel",
+            0,
+            1.6,
+            2_519,
+            composer=f"{_COMPOSE}.three_parallel",
+            fk_atol_expr="1e-7",
+            force_refine=True,
+        ),
+        _spec(
+            "ikgeo.spherical_two_parallel",
+            0,
+            1.2,
+            1_316,
+            composer=f"{_COMPOSE}.spherical_two_parallel",
+        ),
+        _spec(
+            "ikgeo.spherical_two_intersecting",
+            0,
+            1.3,
+            1_476,
+            composer=f"{_COMPOSE}.spherical_two_intersecting",
+        ),
+        _spec("ikgeo.spherical", 0, 7.5, 10_312, composer=f"{_COMPOSE}.spherical"),
+        _spec("ikgeo.two_parallel", 1, 261.0, 141_569, auto_dispatch=False),
+        _spec("ikgeo.two_intersecting", 1, 1184.0, 2_650_681, auto_dispatch=False),
+        _spec(
+            "ikgeo.general_6r",
+            2,
+            5.0,
+            30_000_000,
+            needs_symbolic_precompute=True,
+            composer=f"{_COMPOSE}.general_6r",
+        ),
+        _spec("husty_pfurner.general_6r", 2, 120.0, 50_000_000),
+        _spec("seven_r.srs", 0, 8.5, 1_900),
+        _spec("seven_r.srs_polished", 0, 56.0, 80_000),
+        _spec("seven_r.spherical_shoulder", 0, 17.0, 6_000),
+        _spec("seven_r.spherical_shoulder_polished", 0, 8.0, 40_000),
+        _spec("jointlock.seven_r", 1, 50.0, 30_274, composer=f"{_COMPOSE}.seven_r"),
+    )
+}

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -37,6 +37,7 @@ from ssik._kinbody import KinBody
 from ssik.core.diagnostic import Diagnostic
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.core.solution import Solution
+from ssik.core.solver_registry import SOLVERS
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 
@@ -44,26 +45,6 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 __all__ = ["Manipulator"]
-
-
-# Map dispatcher solver names (e.g. "ikgeo.three_parallel") to the dotted
-# module path under :mod:`ssik.solvers`. Centralised so the import-path
-# convention is stated once.
-_SOLVER_MODULE_PATHS: dict[str, str] = {
-    "ikgeo.three_parallel": "ssik.solvers.ikgeo.three_parallel",
-    "ikgeo.spherical_two_parallel": "ssik.solvers.ikgeo.spherical_two_parallel",
-    "ikgeo.spherical_two_intersecting": "ssik.solvers.ikgeo.spherical_two_intersecting",
-    "ikgeo.spherical": "ssik.solvers.ikgeo.spherical",
-    "ikgeo.two_parallel": "ssik.solvers.ikgeo.two_parallel",
-    "ikgeo.two_intersecting": "ssik.solvers.ikgeo.two_intersecting",
-    "ikgeo.general_6r": "ssik.solvers.ikgeo.general_6r",
-    "husty_pfurner.general_6r": "ssik.solvers.husty_pfurner.general_6r",
-    "seven_r.srs": "ssik.solvers.seven_r.srs",
-    "seven_r.srs_polished": "ssik.solvers.seven_r.srs_polished",
-    "seven_r.spherical_shoulder": "ssik.solvers.seven_r.spherical_shoulder",
-    "seven_r.spherical_shoulder_polished": "ssik.solvers.seven_r.spherical_shoulder_polished",
-    "jointlock.seven_r": "ssik.solvers.jointlock.seven_r",
-}
 
 
 class Manipulator:
@@ -98,7 +79,7 @@ class Manipulator:
         self._kb: KinBody = kinbody
         self._plan: DispatchPlan = dispatch(kinbody, policy=policy)
         self._solver_module: ModuleType = importlib.import_module(
-            _SOLVER_MODULE_PATHS[self._plan.solver_name]
+            SOLVERS[self._plan.solver_name].module_path
         )
         # Guards the one-time cold-coverage warning (#328).
         self._warned_cold_coverage: bool = False

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -190,7 +190,7 @@ def solve(
         # UR ~7e-6) directly. Recovering a *genuine* near-singular solution
         # (#288, z1 q4=pi/2 ~1e-6 -> machine precision) needs Newton polish, so
         # the caller opts in via ``allow_refinement`` (the standalone-arm
-        # artifacts force it on -- ``_SPECIALISED_FORCE_REFINE``). We honour the
+        # artifacts force it on -- ``SolverSpec.force_refine``). We honour the
         # caller here so inner-solver users like jointlock keep their own
         # refinement policy (and their machine-precision-or-drop contract).
         allow_refinement=allow_refinement,

--- a/tests/test_solver_registry.py
+++ b/tests/test_solver_registry.py
@@ -1,0 +1,99 @@
+"""Guard the single-source solver registry (U1, #389).
+
+``ssik.core.solver_registry.SOLVERS`` replaced ~six parallel ``name -> X`` tables
+that used to be edited in lockstep (dispatcher estimates, codegen import paths,
+manipulator module paths, codegen composers, fk-atol / force-refine overrides).
+These tests are the structural guard that keeps a new/renamed solver from
+shipping half-wired: every row must import, every composer must exist, the
+dispatcher may not emit a name the table lacks, and the one value still mirrored
+in a live solver (three_parallel's FK gate) must match. Any drift turns CI red
+here instead of KeyError-ing in the field.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+from ssik.core.solver_registry import SOLVERS, SolverSpec
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "ssik"
+
+
+@pytest.mark.parametrize("name", sorted(SOLVERS))
+def test_every_solver_module_imports_and_solves(name: str) -> None:
+    """Each spec's ``module_path`` imports and exposes a callable ``solve``."""
+    spec = SOLVERS[name]
+    assert spec.name == name, "SOLVERS key must equal the spec's name"
+    module = importlib.import_module(spec.module_path)
+    assert callable(getattr(module, "solve", None)), (
+        f"{name}: {spec.module_path} has no callable solve()"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(n for n, s in SOLVERS.items() if s.composer))
+def test_every_composer_imports_with_entry_points(name: str) -> None:
+    """Each specialised solver's ``composer`` module exposes ``compose`` and
+    ``render_constants_header`` (the codegen contract)."""
+    composer = SOLVERS[name].composer
+    assert composer is not None
+    mod = importlib.import_module(composer)
+    assert callable(getattr(mod, "compose", None)), f"{name}: {composer}.compose missing"
+    assert callable(getattr(mod, "render_constants_header", None)), (
+        f"{name}: {composer}.render_constants_header missing"
+    )
+
+
+def test_dispatcher_only_emits_registered_solvers() -> None:
+    """Every solver name the dispatcher can hand to ``_make_plan`` is in SOLVERS.
+
+    Parses the dispatcher source for the string literals passed to ``_make_plan``
+    so a new dispatch branch that references an unregistered solver fails here
+    rather than KeyError-ing at ``dispatch()`` / ``ssik build`` time.
+    """
+    src = (_SRC / "core" / "dispatcher.py").read_text()
+    emitted = set(re.findall(r'_make_plan\(\s*"([^"]+)"', src))
+    assert emitted, "no _make_plan calls found -- regex or dispatcher structure changed"
+    missing = emitted - set(SOLVERS)
+    assert not missing, f"dispatcher emits solvers absent from SOLVERS: {sorted(missing)}"
+
+
+def test_three_parallel_fk_gate_matches_live_solver() -> None:
+    """The FK-verify gate baked into three_parallel's artifact must equal the
+    live solver's constant -- the value the old codegen mirror could silently
+    drift from (#362)."""
+    from ssik.solvers.ikgeo import three_parallel
+
+    # fk_atol_expr is a Python expression string emitted into the artifact;
+    # compare its numeric value (not text) to the live gate.
+    assert float(SOLVERS["ikgeo.three_parallel"].fk_atol_expr) == three_parallel._FK_VERIFY_ATOL
+
+
+def test_every_prebuilt_solver_name_is_registered() -> None:
+    """Every shipped prebuilt artifact's ``SOLVER_NAME`` is a registered solver."""
+    from ssik.prebuilt._manifest import load_manifest
+
+    for arm in load_manifest():
+        try:
+            mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+        except Exception:
+            continue
+        assert mod.SOLVER_NAME in SOLVERS, f"{arm}: SOLVER_NAME {mod.SOLVER_NAME} not in SOLVERS"
+
+
+def test_module_path_is_derived_not_stored() -> None:
+    """``module_path`` is a pure derivation of the name (the property that let us
+    delete the two byte-identical import-path/module-path tables)."""
+    for name, spec in SOLVERS.items():
+        assert spec.module_path == f"ssik.solvers.{name}"
+
+
+def test_spec_is_frozen() -> None:
+    """The registry is immutable -- no runtime mutation of solver metadata."""
+    spec = next(iter(SOLVERS.values()))
+    with pytest.raises((AttributeError, TypeError)):
+        spec.tier = 99  # type: ignore[misc]
+    assert isinstance(spec, SolverSpec)


### PR DESCRIPTION
Part of #389 (architecture audit — U1, the registry single-source-of-truth). Follows #390 (D1).

## Why

Per-solver metadata lived in **six** hand-synced `name -> X` tables:
- `dispatcher._SOLVER_ESTIMATES` (tier/ms/flops)
- `codegen._SOLVER_IMPORT_PATHS` (module path)
- `manipulator._SOLVER_MODULE_PATHS` (module path — **byte-identical** to the above)
- `codegen._SPECIALISED_COMPOSERS` (composer fn)
- `codegen._SPECIALISED_FK_ATOL_EXPR` / `_SPECIALISED_FORCE_REFINE` (overrides)

Adding or renaming a solver meant editing all six in lockstep. Two were fully derivable (`f"ssik.solvers.{name}"`), and **nothing guarded keyset consistency**, so drift shipped green and surfaced as a `KeyError` in the field. This is the recurring pain the audit flagged as the root cause.

## What

One `ssik.core.solver_registry.SolverSpec` per solver, in a single `SOLVERS` table. `module_path` is a derived property (deletes the two identical dicts); everything else is one row per solver. All four consumers rewired to read `SOLVERS`; the six old tables + the `ComposerFn`/`_import_composer` infrastructure are deleted. `needs_symbolic_precompute` moved from an error-prone per-call arg (11 sites) to a spec field.

## Guard against recurrence (the point of #389)

`tests/test_solver_registry.py` makes half-wiring impossible to merge:
- every `module_path` imports and exposes `solve()`
- every `composer` imports and exposes `compose` + `render_constants_header`
- **the dispatcher may not emit a solver name absent from `SOLVERS`** (parsed from dispatcher source — catches a new branch referencing an unregistered solver)
- three_parallel's baked FK gate must equal the live `_FK_VERIFY_ATOL` (closes the old "keep in sync" comment)
- every shipped prebuilt's `SOLVER_NAME` is registered

## Verification

- Artifacts **byte-identical** — snapshot test green with no regen (same emitted values).
- Full suite: **1641 passed, 6 xfailed, 5 xpassed** (all pre-existing). ruff + mypy clean.