### PR TITLE
Factor the shared post-processing pipeline into finalize_solutions (U2b)

### DIFF
--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -148,12 +148,7 @@ def _render_thin_wrapper(
     buf.write("from ssik._kinbody import Joint, KinBody, Link\n")
     buf.write("from ssik.core.solution import Solution\n")
     buf.write("from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy\n")
-    buf.write("from ssik.postprocess import (\n")
-    buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
-    buf.write("    respect_limits as _ps_respect_limits,\n")
-    buf.write("    within_seed_tolerance as _ps_within_seed_tolerance,\n")
-    buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
-    buf.write(")\n")
+    buf.write("from ssik.postprocess import finalize_solutions as _ps_finalize\n")
     # Bulletproof rescue fallback (#319 / #358): thin-wrapper solvers (the
     # SRS family -- seven_r.srs / srs_polished) get the same T-perturbation
     # rescue the specialised orchestrators have, so a reachable-but-degenerate
@@ -245,12 +240,7 @@ def _render_specialised(
         "from ssik.refinement.rescue import "
         "rescue_via_T_perturbation as _rescue_via_T_perturbation\n"
     )
-    buf.write("from ssik.postprocess import (\n")
-    buf.write("    nearest_to_seed as _ps_nearest_to_seed,\n")
-    buf.write("    respect_limits as _ps_respect_limits,\n")
-    buf.write("    within_seed_tolerance as _ps_within_seed_tolerance,\n")
-    buf.write("    wrap_to_limits as _ps_wrap_to_limits,\n")
-    buf.write(")\n")
+    buf.write("from ssik.postprocess import finalize_solutions as _ps_finalize\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -661,22 +651,17 @@ def _render_specialised_solve_orchestrator(
                         jacobian_fn=_spatial_jacobian,
                     )
 
-            # Post-processing pass (#238 item 4). Order matters:
-            #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-            #      candidates into the URDF's limit range
-            #   2. respect_limits drops anything still outside
-            #   3. nearest_to_seed sorts by distance to q_seed (if given)
-            #   4. max_solutions truncates to the first k
-            if respect_limits:
-                solutions = _ps_wrap_to_limits(solutions, _KB)
-                solutions = _ps_respect_limits(solutions, _KB)
-            if q_seed is not None:
-                if seed_tolerance is not None:
-                    solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-            if max_solutions is not None and len(solutions) > max_solutions:
-                solutions = solutions[:max_solutions]
-            return solutions
+            # Shared post-processing pipeline (limits -> seed -> truncate); the
+            # one definition lives in ssik.postprocess.finalize_solutions.
+            return _ps_finalize(
+                solutions,
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=max_solutions,
+            )
         '''
     ).replace("fk_atol = policy.subproblem_numerical", f"fk_atol = {fk_atol_expr}")
     if force_refine:
@@ -1064,35 +1049,33 @@ def _render_specialised_solve_orchestrator_7r() -> str:
                         T,
                         jacobian_fn=_spatial_jacobian,
                     )
-                    if respect_limits:
-                        solutions = _ps_wrap_to_limits(solutions, _KB)
-                        solutions = _ps_respect_limits(solutions, _KB)
-                    if q_seed is not None:
-                        if seed_tolerance is not None:
-                            solutions = _ps_within_seed_tolerance(
-                                solutions, q_seed, seed_tolerance
-                            )
-                        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
+                    # Rescued candidates were not limit-filtered; run the shared
+                    # pipeline (limits + seed) over them.
+                    solutions = _ps_finalize(
+                        solutions,
+                        _KB,
+                        respect_limits=respect_limits,
+                        q_seed=q_seed,
+                        seed_metric=seed_metric,
+                        seed_tolerance=seed_tolerance,
+                    )
 
-            # No orchestrator-level respect_limits pass on the analytical
-            # result: the inner ``_solve_algebraic`` already filtered in-flight
-            # when respect_limits=True, so candidates here are guaranteed
-            # in-limits.
-            #
-            # Seeded ranking (#331): the lock-sweep returns candidates from the
-            # window of lock samples nearest ``q_seed[lock_idx]`` (in seed
-            # order), but the genuinely-nearest config -- and the
-            # branch-continuous one for tracking -- needs an explicit rank by
-            # ``seed_metric`` (default L-infinity) over that window before the
-            # cap. Without this the cap would keep the nearest *lock samples*,
-            # not the nearest *configs*.
-            if q_seed is not None:
-                if seed_tolerance is not None:
-                    solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-                solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-            if max_solutions is not None and len(solutions) > max_solutions:
-                solutions = solutions[:max_solutions]
-            return solutions
+            # No orchestrator-level respect_limits pass on the analytical result:
+            # the inner ``_solve_algebraic`` already filtered in-flight when
+            # respect_limits=True (hence respect_limits=False here). Seeded
+            # ranking (#331) still needs an explicit rank by ``seed_metric`` over
+            # the lock-sample window before the cap, so the cap keeps the nearest
+            # *configs*, not the nearest *lock samples*. Shared pipeline again;
+            # the seed re-rank is idempotent for the already-ranked rescue set.
+            return _ps_finalize(
+                solutions,
+                _KB,
+                respect_limits=False,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=max_solutions,
+            )
         '''
     )
 
@@ -1391,13 +1374,20 @@ def _render_solve_function(solver_short: str) -> str:
                     np.asarray(T_target, dtype=np.float64),
                 )
                 if _tracked is not None:
-                    _fast = [_tracked]
-                    if respect_limits:
-                        _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-                    if _fast and seed_tolerance is not None:
-                        _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+                    # Same post-processing as the full path (no in-limits
+                    # fallback: a tracked seed that fails limits/tolerance falls
+                    # through to the full analytical solve below).
+                    _fast = _ps_finalize(
+                        [_tracked],
+                        _KB,
+                        respect_limits=respect_limits,
+                        q_seed=q_seed,
+                        seed_metric=seed_metric,
+                        seed_tolerance=seed_tolerance,
+                        max_solutions=1,
+                    )
                     if _fast:
-                        return _fast[:1]
+                        return _fast
             sols, _is_ls = _solver_solve(
                 _KB,
                 T_target,
@@ -1430,23 +1420,21 @@ def _render_solve_function(solver_short: str) -> str:
                         _T,
                         jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
                     )
-            if respect_limits:
-                sols = _ps_wrap_to_limits(sols, _KB)
-                sols = _ps_respect_limits(sols, _KB)
-                if not sols:
-                    # #359: the blind swivel sweep sampled no in-limits candidate
-                    # even though a reachable in-limits solution exists (the
-                    # in-limits swivel arc was narrower than the sampling). The
-                    # feasible-swivel resolver computes the in-limits arcs exactly
-                    # and returns solutions directly (no-op for non-SRS chains).
-                    sols = _resolve_in_limits(_KB, T_target, policy=policy)
-            if q_seed is not None:
-                if seed_tolerance is not None:
-                    sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-                sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-            if max_solutions is not None and len(sols) > max_solutions:
-                sols = sols[:max_solutions]
-            return sols
+            # Shared post-processing pipeline (limits -> seed -> truncate); the
+            # one definition lives in ssik.postprocess.finalize_solutions. The
+            # in-limits fallback (#359) recovers a reachable in-limits solution
+            # the coarse sweep missed via the solver-matched exact resolver
+            # (no-op for non-redundant chains).
+            return _ps_finalize(
+                sols,
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=max_solutions,
+                in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+            )
         """
     )
 

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -321,10 +321,7 @@ class Manipulator:
         :raises ValueError: if ``T_target.shape != (4, 4)`` or
             ``len(q_seed) != dof`` when ``q_seed`` is given.
         """
-        from ssik.postprocess import nearest_to_seed as _ps_nearest_to_seed
-        from ssik.postprocess import respect_limits as _ps_respect_limits
-        from ssik.postprocess import within_seed_tolerance as _ps_within_seed_tolerance
-        from ssik.postprocess import wrap_to_limits as _ps_wrap_to_limits
+        from ssik.postprocess import finalize_solutions as _ps_finalize
 
         T = np.asarray(T_target, dtype=np.float64)
         if T.shape != (4, 4):
@@ -412,30 +409,23 @@ class Manipulator:
 
         raw_candidate_count = len(sols)
 
-        # Cross-arm postprocess pass: solvers that didn't honour kwargs
-        # natively get them applied here so the public API is uniform.
-        # Order: wrap_to_limits first (try +/- 2pi shift to bring branches
-        # into the URDF range), THEN respect_limits (drop anything still
-        # outside). Without the shift, IKs returned in [-2pi, 0] would
-        # erroneously be filtered on arms with limits in [0, 2pi]
-        # (the JACO 2 case).
-        if respect_limits:
-            sols = _ps_wrap_to_limits(sols, self._kb)
-            pre_limit_count = len(sols)
-            sols = _ps_respect_limits(sols, self._kb)
-            dropped_by_limits = pre_limit_count - len(sols)
-        else:
-            dropped_by_limits = 0
-        if q_seed_arr is not None:
-            if seed_tolerance is not None:
-                sols = _ps_within_seed_tolerance(sols, q_seed_arr, seed_tolerance)
-            sols = _ps_nearest_to_seed(sols, q_seed_arr, metric=seed_metric)
-        if max_solutions is not None and len(sols) > max_solutions:
-            dropped_by_max_solutions = len(sols) - max_solutions
-            sols = sols[:max_solutions]
-        else:
-            dropped_by_max_solutions = 0
-        result: list[Solution] = sols
+        # Cross-arm postprocess pass (the one shared pipeline -- see
+        # ssik.postprocess.finalize_solutions): solvers that didn't honour kwargs
+        # natively get limits + seed + truncate applied here so the public API is
+        # uniform. ``counts`` feeds the Diagnostic below.
+        counts = {"dropped_by_limits": 0, "dropped_by_max_solutions": 0}
+        result: list[Solution] = _ps_finalize(
+            sols,
+            self._kb,
+            respect_limits=respect_limits,
+            q_seed=q_seed_arr,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            counts=counts,
+        )
+        dropped_by_limits = counts["dropped_by_limits"]
+        dropped_by_max_solutions = counts["dropped_by_max_solutions"]
         if not explain:
             return result
 

--- a/src/ssik/postprocess.py
+++ b/src/ssik/postprocess.py
@@ -47,6 +47,7 @@ in Phase 4 (no per-arm specialisation, no symbolic precompute).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
 
 import numpy as np
@@ -56,6 +57,7 @@ from ssik._kinbody import KinBody
 from ssik.core.solution import Solution
 
 __all__ = [
+    "finalize_solutions",
     "nearest_to_seed",
     "respect_limits",
     "take_first",
@@ -242,3 +244,58 @@ def take_first(sols: list[Solution], k: int) -> list[Solution]:
     :returns: ``sols[:max(k, 0)]``.
     """
     return list(sols[: max(k, 0)])
+
+
+# The ``respect_limits`` function is shadowed by the boolean parameter of the
+# same name inside :func:`finalize_solutions`; alias it so the pipeline can still
+# call it. (The kwarg name matches the public ``solve()`` API and shouldn't move.)
+_apply_limits = respect_limits
+
+
+def finalize_solutions(
+    sols: list[Solution],
+    kb: KinBody,
+    *,
+    respect_limits: bool = True,
+    q_seed: NDArray[np.float64] | None = None,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+    max_solutions: int | None = None,
+    in_limits_fallback: Callable[[], list[Solution]] | None = None,
+    counts: dict[str, int] | None = None,
+) -> list[Solution]:
+    """The shared IK post-processing pipeline: limits -> seed -> truncate.
+
+    This is the one definition of the tail that ``Manipulator.solve`` and every
+    emitted artifact ``solve()`` used to hand-duplicate (four copies, already
+    drifted). Order matters and is fixed: ``wrap_to_limits`` (try +/-2pi to bring
+    branches into range) then ``respect_limits`` (drop the rest); then, if a seed
+    is given, ``within_seed_tolerance`` (hard bound) then ``nearest_to_seed``
+    (rank); then truncate to ``max_solutions``.
+
+    :param respect_limits: when ``True`` apply the wrap+drop limit pass.
+    :param in_limits_fallback: optional zero-arg callable invoked when the limit
+        pass empties the set -- the redundant-7R exact in-limits resolver (#359),
+        which recovers a narrow in-limits arc the coarse sweep missed. ``None``
+        for callers without one (e.g. ``Manipulator``).
+    :param counts: optional dict; when given, populated with ``dropped_by_limits``
+        and ``dropped_by_max_solutions`` for the caller's diagnostics.
+    :returns: the post-processed solution list.
+    """
+    if respect_limits:
+        sols = wrap_to_limits(sols, kb)
+        pre_limit = len(sols)
+        sols = _apply_limits(sols, kb)
+        if counts is not None:
+            counts["dropped_by_limits"] = pre_limit - len(sols)
+        if not sols and in_limits_fallback is not None:
+            sols = in_limits_fallback()
+    if q_seed is not None:
+        if seed_tolerance is not None:
+            sols = within_seed_tolerance(sols, q_seed, seed_tolerance)
+        sols = nearest_to_seed(sols, q_seed, metric=seed_metric)
+    if max_solutions is not None and len(sols) > max_solutions:
+        if counts is not None:
+            counts["dropped_by_max_solutions"] = len(sols) - max_solutions
+        sols = sols[:max_solutions]
+    return sols

--- a/src/ssik/prebuilt/big_yam_ik.py
+++ b/src/ssik/prebuilt/big_yam_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1102,22 +1097,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/fanuc_crx10ial_ik.py
+++ b/src/ssik/prebuilt/fanuc_crx10ial_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1059,22 +1054,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/fr3_ik.py
+++ b/src/ssik/prebuilt/fr3_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/franka_panda_ik.py
+++ b/src/ssik/prebuilt/franka_panda_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/gen3_ik.py
+++ b/src/ssik/prebuilt/gen3_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/iiwa14_ik.py
+++ b/src/ssik/prebuilt/iiwa14_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/jaco2_ik.py
+++ b/src/ssik/prebuilt/jaco2_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1027,22 +1022,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/openarm_left_ik.py
+++ b/src/ssik/prebuilt/openarm_left_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/openarm_right_ik.py
+++ b/src/ssik/prebuilt/openarm_right_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/piper_ik.py
+++ b/src/ssik/prebuilt/piper_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1076,22 +1071,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/puma560_ik.py
+++ b/src/ssik/prebuilt/puma560_ik.py
@@ -52,12 +52,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -682,22 +677,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/r1pro_left_ik.py
+++ b/src/ssik/prebuilt/r1pro_left_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/r1pro_right_ik.py
+++ b/src/ssik/prebuilt/r1pro_right_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/ur10e_ik.py
+++ b/src/ssik/prebuilt/ur10e_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur16e_ik.py
+++ b/src/ssik/prebuilt/ur16e_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur20_ik.py
+++ b/src/ssik/prebuilt/ur20_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur30_ik.py
+++ b/src/ssik/prebuilt/ur30_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur3e_ik.py
+++ b/src/ssik/prebuilt/ur3e_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur5_ik.py
+++ b/src/ssik/prebuilt/ur5_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -619,22 +614,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/ur5e_ik.py
+++ b/src/ssik/prebuilt/ur5e_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -661,22 +656,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/xarm6_ik.py
+++ b/src/ssik/prebuilt/xarm6_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1071,22 +1066,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/xarm7_ik.py
+++ b/src/ssik/prebuilt/xarm7_ik.py
@@ -43,12 +43,7 @@ import numpy as np
 from ssik._kinbody import Joint, KinBody, Link
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 import functools as _functools
 from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
 from ssik.refinement import seeded_track as _seeded_track
@@ -234,13 +229,20 @@ def solve(
             np.asarray(T_target, dtype=np.float64),
         )
         if _tracked is not None:
-            _fast = [_tracked]
-            if respect_limits:
-                _fast = _ps_respect_limits(_ps_wrap_to_limits(_fast, _KB), _KB)
-            if _fast and seed_tolerance is not None:
-                _fast = _ps_within_seed_tolerance(_fast, q_seed, seed_tolerance)
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
             if _fast:
-                return _fast[:1]
+                return _fast
     sols, _is_ls = _solver_solve(
         _KB,
         T_target,
@@ -273,23 +275,21 @@ def solve(
                 _T,
                 jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
             )
-    if respect_limits:
-        sols = _ps_wrap_to_limits(sols, _KB)
-        sols = _ps_respect_limits(sols, _KB)
-        if not sols:
-            # #359: the blind swivel sweep sampled no in-limits candidate
-            # even though a reachable in-limits solution exists (the
-            # in-limits swivel arc was narrower than the sampling). The
-            # feasible-swivel resolver computes the in-limits arcs exactly
-            # and returns solutions directly (no-op for non-SRS chains).
-            sols = _resolve_in_limits(_KB, T_target, policy=policy)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            sols = _ps_within_seed_tolerance(sols, q_seed, seed_tolerance)
-        sols = _ps_nearest_to_seed(sols, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(sols) > max_solutions:
-        sols = sols[:max_solutions]
-    return sols
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
 

--- a/src/ssik/prebuilt/yam_ik.py
+++ b/src/ssik/prebuilt/yam_ik.py
@@ -57,12 +57,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.general_6r"
@@ -1159,22 +1154,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/src/ssik/prebuilt/z1_ik.py
+++ b/src/ssik/prebuilt/z1_ik.py
@@ -53,12 +53,7 @@ from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
-from ssik.postprocess import (
-    nearest_to_seed as _ps_nearest_to_seed,
-    respect_limits as _ps_respect_limits,
-    within_seed_tolerance as _ps_within_seed_tolerance,
-    wrap_to_limits as _ps_wrap_to_limits,
-)
+from ssik.postprocess import finalize_solutions as _ps_finalize
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -609,22 +604,17 @@ def solve(
                 jacobian_fn=_spatial_jacobian,
             )
 
-    # Post-processing pass (#238 item 4). Order matters:
-    #   1. wrap_to_limits tries q +/- 2*pi per joint to bring
-    #      candidates into the URDF's limit range
-    #   2. respect_limits drops anything still outside
-    #   3. nearest_to_seed sorts by distance to q_seed (if given)
-    #   4. max_solutions truncates to the first k
-    if respect_limits:
-        solutions = _ps_wrap_to_limits(solutions, _KB)
-        solutions = _ps_respect_limits(solutions, _KB)
-    if q_seed is not None:
-        if seed_tolerance is not None:
-            solutions = _ps_within_seed_tolerance(solutions, q_seed, seed_tolerance)
-        solutions = _ps_nearest_to_seed(solutions, q_seed, metric=seed_metric)
-    if max_solutions is not None and len(solutions) > max_solutions:
-        solutions = solutions[:max_solutions]
-    return solutions
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    return _ps_finalize(
+        solutions,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+    )
 
 fk = _fk
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -472,7 +472,9 @@ def test_no_prebuilt_reinlines_the_pipeline() -> None:
 
     from ssik.prebuilt._manifest import load_manifest
 
-    prebuilt_dir = Path(importlib.import_module("ssik.prebuilt").__file__).parent
+    prebuilt_init = importlib.import_module("ssik.prebuilt").__file__
+    assert prebuilt_init is not None
+    prebuilt_dir = Path(prebuilt_init).parent
     checked = 0
     for arm in load_manifest():
         src_path = prebuilt_dir / f"{arm}.py"

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -22,6 +22,7 @@ import pytest
 from ssik._kinbody import JointSpec, KinBody, build_kinbody
 from ssik.core.solution import Solution
 from ssik.postprocess import (
+    finalize_solutions,
     nearest_to_seed,
     respect_limits,
     take_first,
@@ -401,3 +402,87 @@ def test_franka_pipeline_real_ik_output() -> None:
     # Truncate to top-1.
     sols = take_first(sols, k=1)
     assert len(sols) == 1
+
+
+# ---------------------------------------------------------------------------
+# finalize_solutions: the single shared post-processing pipeline (U2, #389)
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_equals_manual_pipeline() -> None:
+    """finalize_solutions is exactly the hand-written limits->seed->truncate
+    pipeline it replaced across Manipulator + every emitted artifact."""
+    kb = _kb_with_limits([(-1.0, 1.0), (-1.0, 1.0)])
+    sols = [_sol([0.9, 0.1]), _sol([2.0, 0.0]), _sol([-0.5, 0.5]), _sol([0.2, -0.2])]
+    seed = np.array([0.0, 0.0])
+
+    manual = wrap_to_limits(sols, kb)
+    manual = respect_limits(manual, kb)
+    manual = nearest_to_seed(manual, seed, metric="wrap_linf")
+    manual = manual[:2]
+
+    got = finalize_solutions(
+        sols, kb, respect_limits=True, q_seed=seed, seed_metric="wrap_linf", max_solutions=2
+    )
+    assert [s.q.tolist() for s in got] == [s.q.tolist() for s in manual]
+
+
+def test_finalize_respect_limits_false_skips_limit_pass() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sols = [_sol([5.0]), _sol([0.0])]
+    got = finalize_solutions(sols, kb, respect_limits=False)
+    assert len(got) == 2  # nothing dropped
+
+
+def test_finalize_in_limits_fallback_fires_when_empty() -> None:
+    """When the limit pass empties the set, the fallback recovers it (the #359
+    in-limits resolver hook)."""
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sols = [_sol([5.0])]  # out of range -> dropped
+    recovered = [_sol([0.5])]
+    got = finalize_solutions(sols, kb, respect_limits=True, in_limits_fallback=lambda: recovered)
+    assert [s.q.tolist() for s in got] == [[0.5]]
+
+
+def test_finalize_no_fallback_when_nonempty() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sentinel = [_sol([0.5])]
+    got = finalize_solutions(
+        [_sol([0.2])], kb, respect_limits=True, in_limits_fallback=lambda: sentinel
+    )
+    assert [s.q.tolist() for s in got] == [[0.2]]  # fallback not used
+
+
+def test_finalize_populates_counts() -> None:
+    kb = _kb_with_limits([(-1.0, 1.0)])
+    sols = [_sol([0.1]), _sol([5.0]), _sol([0.3]), _sol([-0.2])]  # one out of range
+    counts: dict[str, int] = {}
+    got = finalize_solutions(sols, kb, respect_limits=True, max_solutions=1, counts=counts)
+    assert len(got) == 1
+    assert counts["dropped_by_limits"] == 1
+    assert counts["dropped_by_max_solutions"] == 2  # 3 in-limits -> truncate to 1
+
+
+def test_no_prebuilt_reinlines_the_pipeline() -> None:
+    """Structural guard (U2, #389): every emitted artifact routes post-processing
+    through finalize_solutions and must NOT hand-inline the raw
+    wrap->respect->nearest sequence, so the pipeline can't drift back into N copies."""
+    import importlib
+    from pathlib import Path
+
+    from ssik.prebuilt._manifest import load_manifest
+
+    prebuilt_dir = Path(importlib.import_module("ssik.prebuilt").__file__).parent
+    checked = 0
+    for arm in load_manifest():
+        src_path = prebuilt_dir / f"{arm}.py"
+        if not src_path.exists():
+            continue
+        src = src_path.read_text()
+        if "_ps_finalize" not in src and "finalize_solutions" not in src:
+            continue  # arm with no post-processing (none today, but be lenient)
+        checked += 1
+        # The old inlined pipeline calls must not reappear in emitted artifacts.
+        assert "_ps_wrap_to_limits(" not in src, f"{arm}: re-inlined wrap_to_limits"
+        assert "_ps_nearest_to_seed(" not in src, f"{arm}: re-inlined nearest_to_seed"
+    assert checked > 0, "no prebuilt artifacts found to check"


### PR DESCRIPTION
Part of #389 (architecture audit — U2b). Follows #390 (D1), #391 (U1), #392 (parity test).

## Why

The `limits → seed → truncate` post-processing tail was hand-duplicated in **four** places that had already drifted:
- `Manipulator.solve`
- codegen thin-wrapper template
- codegen specialised-6R orchestrator
- codegen jointlock-7R orchestrator (two copies — rescue branch + main tail)

## What

New `ssik.postprocess.finalize_solutions` is the single definition; every site calls it. The per-caller variation stays parameterised, not re-inlined:
- `in_limits_fallback` — the #359 exact in-limits resolver hook (thin-wrapper redundant-7R arms; `None` elsewhere).
- `counts` — optional dict populated with `dropped_by_limits` / `dropped_by_max_solutions` for `Manipulator`'s `Diagnostic`.

codegen now emits a single `_ps_finalize(...)` call from every orchestrator (including the #380 seeded fast path), and the four individual postprocess imports collapse to one. **Net −150 lines across 24 regenerated artifacts.**

## Guards against recurrence

- `finalize_solutions` unit tests: equals-the-manual-pipeline, in-limits fallback fires/doesn't, `respect_limits=False` skip, drop counts.
- **Structural guard**: no prebuilt artifact re-inlines the raw `wrap_to_limits`/`nearest_to_seed` calls — the pipeline can't drift back into N copies.
- The merged **artifact↔live parity test (#392)** confirms the emitted `finalize` behaves identically to the live path (this is what makes the template surgery safe).

## Verification

Full suite **1665 passed, 3 skipped, 6 xfailed, 5 xpassed** (all pre-existing). Parity + snapshot green. ruff + mypy clean.