### PR TITLE
Efficiency: scalarize rotate() + cache solver signature (E2/E6)

### DIFF
--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -61,7 +61,7 @@ class Manipulator:
         loader). Most users should use :meth:`from_urdf` instead.
     """
 
-    __slots__ = ("_kb", "_plan", "_solver_module", "_warned_cold_coverage")
+    __slots__ = ("_kb", "_plan", "_solver_module", "_solver_params", "_warned_cold_coverage")
 
     def __init__(
         self,
@@ -80,6 +80,11 @@ class Manipulator:
         self._plan: DispatchPlan = dispatch(kinbody, policy=policy)
         self._solver_module: ModuleType = importlib.import_module(
             SOLVERS[self._plan.solver_name].module_path
+        )
+        # The dispatched solver is fixed here, so its parameter set never changes;
+        # cache it once instead of re-inspecting the signature on every solve().
+        self._solver_params: frozenset[str] = frozenset(
+            inspect.signature(self._solver_module.solve).parameters
         )
         # Guards the one-time cold-coverage warning (#328).
         self._warned_cold_coverage: bool = False
@@ -338,11 +343,9 @@ class Manipulator:
 
         # Filter kwargs by the dispatched solver's signature so callers can
         # pass q_seed (or any other not-universally-supported kwarg) without
-        # tripping TypeError on solvers that don't accept it. The dispatch
-        # is determined at __init__ time, so the signature lookup is per-IK
-        # but cheap (~5 us).
-        sig = inspect.signature(self._solver_module.solve)
-        params = sig.parameters
+        # tripping TypeError on solvers that don't accept it. Cached at __init__
+        # (the dispatched solver is fixed there), so this is a set lookup per IK.
+        params = self._solver_params
         kwargs: dict[str, Any] = {"policy": policy}
         if "allow_refinement" in params:
             kwargs["allow_refinement"] = allow_refinement

--- a/src/ssik/subproblems/_rotation.py
+++ b/src/ssik/subproblems/_rotation.py
@@ -42,12 +42,24 @@ def rotate(k: NDArray[np.float64], theta: float, v: NDArray[np.float64]) -> NDAr
 
     ``rotate(k, theta, v) = v cos(theta) + (k x v) sin(theta) + k (k . v) (1 - cos(theta))``
     """
+    # Scalarized Rodrigues (like ``rotation_matrix``): builds the 3-vector from
+    # float ops in a single allocation instead of ~5 numpy temporaries
+    # (``_cross3`` array + four element-wise products/sums). ``rotate`` is one of
+    # the hottest calls in the SP5/SP6 refine loops, so the per-call heap churn
+    # matters. Element order matches the vectorized form exactly (bit-identical).
     c = math.cos(theta)
     s = math.sin(theta)
-    kv = _dot3(k, v)
-    one_minus_c = 1.0 - c
-    out: NDArray[np.float64] = v * c + _cross3(k, v) * s + k * (kv * one_minus_c)
-    return out
+    kx, ky, kz = float(k[0]), float(k[1]), float(k[2])
+    vx, vy, vz = float(v[0]), float(v[1]), float(v[2])
+    m = (1.0 - c) * (kx * vx + ky * vy + kz * vz)
+    return np.array(
+        [
+            vx * c + (ky * vz - kz * vy) * s + kx * m,
+            vy * c + (kz * vx - kx * vz) * s + ky * m,
+            vz * c + (kx * vy - ky * vx) * s + kz * m,
+        ],
+        dtype=np.float64,
+    )
 
 
 @cython.ccall


### PR DESCRIPTION
Part of #389 (architecture audit — efficiency batch). Follows #390–#395.

Two per-call hot-path wins, both behaviour-preserving:

## E2 — scalarize `rotate()`
`rotate()` (Rodrigues) built its result via ~5 numpy temporaries every call (a `_cross3` array + four element-wise product/sum arrays). It's one of the hottest calls in the SP5/SP6 refine loops (~21% of solve per the audit profile). Scalarized to a single `np.array` from float ops, matching how `rotation_matrix` is already written.

**Bit-identical**: element order matches the vectorized form exactly — verified `worst |old − new| = 0.0` over 100k random inputs.

## E6 — cache the solver signature
`Manipulator.solve` re-ran `inspect.signature(solver.solve)` on **every** IK to decide which kwargs the dispatched solver accepts. The solver is fixed at `__init__`, so the parameter set is cached there (frozenset) and it's a set lookup per call now. (Also added `_solver_params` to `__slots__`.)

## Verification
Full suite **1675 passed, 3 skipped** (all pre-existing). ruff + mypy clean.

Deferred from the efficiency audit (more involved, separate follow-ups): `poe_fk` identity-`T_right` skip (E4), `_bake`/`canonicalize_spherical_wrist` per-IK caching (E1), `lm_refine_batch` single-chain-walk (E5). The SE(3)-inverse win (E3) already landed with D2 (#394).