### PR TITLE
Manipulator.from_dh / from_axes / from_transforms constructors (closes #8, #9)

### DIFF
--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -75,9 +75,7 @@ def _rotx(alpha: float) -> NDArray[np.float64]:
     return m
 
 
-def _coerce_limits(
-    limits: ArrayLike | None, n: int
-) -> list[tuple[float, float] | None]:
+def _coerce_limits(limits: ArrayLike | None, n: int) -> list[tuple[float, float] | None]:
     """Normalise an optional ``(N, 2)`` limits array to a per-joint list."""
     if limits is None:
         return [None] * n

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ssik._kinbody import KinBody
+from ssik._kinbody import JointSpec, KinBody, build_kinbody
 from ssik.core.diagnostic import Diagnostic
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.core.solution import Solution
@@ -45,6 +45,46 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 __all__ = ["Manipulator"]
+
+
+def _trans(v: NDArray[np.float64]) -> NDArray[np.float64]:
+    m = np.eye(4)
+    m[:3, 3] = v
+    return m
+
+
+def _transx(a: float) -> NDArray[np.float64]:
+    m = np.eye(4)
+    m[0, 3] = a
+    return m
+
+
+def _transz(d: float) -> NDArray[np.float64]:
+    m = np.eye(4)
+    m[2, 3] = d
+    return m
+
+
+def _rotx(alpha: float) -> NDArray[np.float64]:
+    c, s = np.cos(alpha), np.sin(alpha)
+    m = np.eye(4)
+    m[1, 1] = c
+    m[1, 2] = -s
+    m[2, 1] = s
+    m[2, 2] = c
+    return m
+
+
+def _coerce_limits(
+    limits: ArrayLike | None, n: int
+) -> list[tuple[float, float] | None]:
+    """Normalise an optional ``(N, 2)`` limits array to a per-joint list."""
+    if limits is None:
+        return [None] * n
+    arr = np.asarray(limits, dtype=np.float64)
+    if arr.shape != (n, 2):
+        raise ValueError(f"limits must be (N, 2) for N={n}; got {arr.shape}")
+    return [(float(lo), float(hi)) for lo, hi in arr]
 
 
 class Manipulator:
@@ -139,6 +179,133 @@ class Manipulator:
 
         kb = load_urdf_kinbody_normalized(path, base, ee, xacro_args=xacro_args)
         return cls(kb, policy=policy)
+
+    @classmethod
+    def from_axes(
+        cls,
+        joint_axes: ArrayLike,
+        offsets: ArrayLike,
+        *,
+        limits: ArrayLike | None = None,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> Manipulator:
+        """Build from ik-geo / EAIK product-of-exponentials ``H, P`` parameters.
+
+        :param joint_axes: ``(N, 3)`` unit rotation axes in the base frame at
+            zero configuration (ik-geo ``H``).
+        :param offsets: ``(N + 1, 3)`` inter-joint translation vectors in the
+            base frame at zero (ik-geo ``P``): ``offsets[0]`` is base -> joint 0,
+            ``offsets[i]`` is joint ``i-1`` -> joint ``i``, and ``offsets[N]`` is
+            joint ``N-1`` -> end-effector.
+        :param limits: optional ``(N, 2)`` per-joint ``(lower, upper)`` ranges.
+        :param policy: tolerance policy for the dispatcher.
+
+        Reproduces ``FK = prod_i [Trans(P[i]) Rot(H[i], q_i)] . Trans(P[N])`` --
+        the same convention as :class:`eaik.HPRobot`.
+        """
+        h = np.asarray(joint_axes, dtype=np.float64)
+        p = np.asarray(offsets, dtype=np.float64)
+        n = h.shape[0]
+        if h.shape != (n, 3):
+            raise ValueError(f"joint_axes must be (N, 3); got {h.shape}")
+        if p.shape != (n + 1, 3):
+            raise ValueError(f"offsets must be (N + 1, 3) for N={n}; got {p.shape}")
+        lim = _coerce_limits(limits, n)
+        specs = [
+            JointSpec(
+                parent_link_T=_trans(p[i]),
+                axis=h[i],
+                joint_type="revolute",
+                child_link_T=_trans(p[n]) if i == n - 1 else None,
+                limits=lim[i],
+            )
+            for i in range(n)
+        ]
+        return cls(build_kinbody(specs), policy=policy)
+
+    @classmethod
+    def from_transforms(
+        cls,
+        joint_trafos: ArrayLike,
+        joint_axis: ArrayLike = (0.0, 0.0, 1.0),
+        *,
+        limits: ArrayLike | None = None,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> Manipulator:
+        """Build from per-joint zero-pose homogeneous transforms (EAIK
+        ``HomogeneousRobot``).
+
+        :param joint_trafos: ``(N + 1, 4, 4)`` relative zero-pose transforms:
+            ``joint_trafos[i]`` maps frame ``i-1`` to frame ``i`` (``[0]`` is
+            base -> joint 0), and ``joint_trafos[N]`` maps joint ``N-1`` -> EE.
+        :param joint_axis: rotation axis in each joint's local frame (default Z).
+        :param limits: optional ``(N, 2)`` per-joint ``(lower, upper)`` ranges.
+        :param policy: tolerance policy for the dispatcher.
+        """
+        t = np.asarray(joint_trafos, dtype=np.float64)
+        if t.ndim != 3 or t.shape[1:] != (4, 4):
+            raise ValueError(f"joint_trafos must be (N + 1, 4, 4); got {t.shape}")
+        n = t.shape[0] - 1
+        axis = np.asarray(joint_axis, dtype=np.float64)
+        lim = _coerce_limits(limits, n)
+        specs = [
+            JointSpec(
+                parent_link_T=t[i],
+                axis=axis,
+                joint_type="revolute",
+                child_link_T=t[n] if i == n - 1 else None,
+                limits=lim[i],
+            )
+            for i in range(n)
+        ]
+        return cls(build_kinbody(specs), policy=policy)
+
+    @classmethod
+    def from_dh(
+        cls,
+        dh_alpha: ArrayLike,
+        dh_a: ArrayLike,
+        dh_d: ArrayLike,
+        *,
+        limits: ArrayLike | None = None,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> Manipulator:
+        """Build from standard (distal) Denavit-Hartenberg parameters (EAIK
+        ``DhRobot``). All joints revolute; the joint variable is the Z rotation.
+
+        Per-joint link transform is the classic
+        ``Rot_z(theta_i) . Trans_z(d_i) . Trans_x(a_i) . Rot_x(alpha_i)``.
+
+        :param dh_alpha: ``(N,)`` link twists (rad).
+        :param dh_a: ``(N,)`` link lengths (m).
+        :param dh_d: ``(N,)`` link offsets (m).
+        :param limits: optional ``(N, 2)`` per-joint ``(lower, upper)`` ranges.
+        :param policy: tolerance policy for the dispatcher.
+        """
+        alpha = np.asarray(dh_alpha, dtype=np.float64)
+        a = np.asarray(dh_a, dtype=np.float64)
+        d = np.asarray(dh_d, dtype=np.float64)
+        n = alpha.shape[0]
+        if not (alpha.shape == (n,) and a.shape == (n,) and d.shape == (n,)):
+            raise ValueError(
+                f"dh_alpha / dh_a / dh_d must be equal-length 1-D; got "
+                f"{alpha.shape}, {a.shape}, {d.shape}"
+            )
+        lim = _coerce_limits(limits, n)
+        z_axis = np.array([0.0, 0.0, 1.0])
+        specs = [
+            JointSpec(
+                parent_link_T=np.eye(4),
+                axis=z_axis,
+                joint_type="revolute",
+                # theta (the joint's Z rotation) is applied first; the fixed
+                # remainder of the standard-DH link transform is the child T.
+                child_link_T=_transz(float(d[i])) @ _transx(float(a[i])) @ _rotx(float(alpha[i])),
+                limits=lim[i],
+            )
+            for i in range(n)
+        ]
+        return cls(build_kinbody(specs), policy=policy)
 
     # ------------------------------------------------------------------
     # Introspection

--- a/tests/test_manipulator_constructors.py
+++ b/tests/test_manipulator_constructors.py
@@ -1,0 +1,193 @@
+"""Alternative ``Manipulator`` constructors: from_dh / from_axes / from_transforms
+(#8, #9).
+
+Each builds a KinBody from a non-URDF parameterisation (matching EAIK's DhRobot /
+HPRobot / HomogeneousRobot) and must produce a dispatchable, solvable arm whose FK
+equals the parameterisation's own reference FK to machine precision.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik.manipulator import Manipulator
+
+_PI = np.pi
+
+
+def _rot(axis: np.ndarray, theta: float) -> np.ndarray:
+    k = np.asarray(axis, dtype=np.float64)
+    k = k / np.linalg.norm(k)
+    c, s = np.cos(theta), np.sin(theta)
+    kk = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    m = np.eye(4)
+    m[:3, :3] = np.eye(3) + s * kk + (1 - c) * kk @ kk
+    return m
+
+
+def _tr(v: np.ndarray) -> np.ndarray:
+    m = np.eye(4)
+    m[:3, 3] = v
+    return m
+
+
+def _hp_fk(h: np.ndarray, p: np.ndarray, q: np.ndarray) -> np.ndarray:
+    t = _tr(p[0])
+    for i in range(len(h)):
+        t = t @ _rot(h[i], q[i]) @ _tr(p[i + 1])
+    return t
+
+
+def _dh_fk(alpha, a, d, q):
+    def rz(th):
+        return _rot(np.array([0.0, 0.0, 1.0]), th)
+
+    def tx(x):
+        m = np.eye(4)
+        m[0, 3] = x
+        return m
+
+    def tz(z):
+        m = np.eye(4)
+        m[2, 3] = z
+        return m
+
+    def rx(al):
+        return _rot(np.array([1.0, 0.0, 0.0]), al)
+
+    t = np.eye(4)
+    for i in range(len(q)):
+        t = t @ rz(q[i]) @ tz(d[i]) @ tx(a[i]) @ rx(alpha[i])
+    return t
+
+
+def _tf_fk(trafos: np.ndarray, axis, q: np.ndarray) -> np.ndarray:
+    t = trafos[0]
+    for i in range(len(q)):
+        t = t @ _rot(np.asarray(axis, dtype=np.float64), q[i]) @ trafos[i + 1]
+    return np.asarray(t, dtype=np.float64)
+
+
+def _roundtrip_worst(m: Manipulator, seed: int, n: int = 200) -> float:
+    rng = np.random.default_rng(seed)
+    worst = 0.0
+    checked = 0
+    for _ in range(n):
+        q = rng.uniform(-2.0, 2.0, m.dof)
+        target = m.fk(q)
+        sols = m.solve(target, respect_limits=False)
+        if sols:
+            checked += 1
+            worst = max(worst, min(float(np.max(np.abs(m.fk(s.q) - target))) for s in sols))
+    assert checked > n // 2, "arm produced solutions on too few poses"
+    return worst
+
+
+# ---------------------------------------------------------------------------
+# from_axes (ik-geo / EAIK HPRobot)
+# ---------------------------------------------------------------------------
+
+_H = np.array(
+    [[0, 0, 1.0], [0, 1, 0], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=np.float64
+)
+_P = np.array(
+    [[0, 0, 0.1], [0.1, 0, 0.2], [0.3, 0, 0], [0.2, 0, 0], [0, 0, 0], [0.1, 0, 0], [0.05, 0, 0]],
+    dtype=np.float64,
+)
+
+
+def test_from_axes_fk_matches_reference() -> None:
+    m = Manipulator.from_axes(_H, _P)
+    rng = np.random.default_rng(1)
+    worst = max(
+        float(np.max(np.abs(m.fk(q) - _hp_fk(_H, _P, q)))) for q in rng.uniform(-3, 3, (200, 6))
+    )
+    assert worst < 1e-12, f"from_axes FK vs H/P reference {worst:.2e}"
+
+
+def test_from_axes_dispatches_and_solves() -> None:
+    m = Manipulator.from_axes(_H, _P)
+    assert m._plan.solver_name.startswith("ikgeo.")  # spherical-wrist arm
+    assert _roundtrip_worst(m, seed=2) < 1e-9
+
+
+def test_from_axes_rejects_bad_shapes() -> None:
+    with pytest.raises(ValueError, match="joint_axes must be"):
+        Manipulator.from_axes(np.zeros((6, 2)), _P)
+    with pytest.raises(ValueError, match="offsets must be"):
+        Manipulator.from_axes(_H, np.zeros((6, 3)))
+
+
+# ---------------------------------------------------------------------------
+# from_dh (EAIK DhRobot) -- Puma 560, the classic analytic benchmark
+# ---------------------------------------------------------------------------
+
+_PUMA_ALPHA = [_PI / 2, 0.0, -_PI / 2, _PI / 2, -_PI / 2, 0.0]
+_PUMA_A = [0.0, 0.4318, 0.0203, 0.0, 0.0, 0.0]
+_PUMA_D = [0.0, 0.0, 0.15005, 0.4318, 0.0, 0.0]
+
+
+def test_from_dh_puma560_fk_matches_reference() -> None:
+    m = Manipulator.from_dh(_PUMA_ALPHA, _PUMA_A, _PUMA_D)
+    rng = np.random.default_rng(3)
+    worst = max(
+        float(np.max(np.abs(m.fk(q) - _dh_fk(_PUMA_ALPHA, _PUMA_A, _PUMA_D, q))))
+        for q in rng.uniform(-3, 3, (200, 6))
+    )
+    assert worst < 1e-12, f"from_dh FK vs DH reference {worst:.2e}"
+
+
+def test_from_dh_puma560_is_spherical_and_solves() -> None:
+    """Puma 560 has a parallel shoulder + spherical wrist -> Tier-0 spherical
+    solver, and solve(fk(q)) recovers a machine-precision IK (the #8 benchmark)."""
+    m = Manipulator.from_dh(_PUMA_ALPHA, _PUMA_A, _PUMA_D)
+    assert m._plan.solver_name == "ikgeo.spherical_two_parallel", m._plan.solver_name
+    assert _roundtrip_worst(m, seed=4) < 1e-9
+
+
+def test_from_dh_rejects_mismatched_lengths() -> None:
+    with pytest.raises(ValueError, match="equal-length"):
+        Manipulator.from_dh([0.0, 0.0], [0.1], [0.1, 0.2])
+
+
+# ---------------------------------------------------------------------------
+# from_transforms (EAIK HomogeneousRobot)
+# ---------------------------------------------------------------------------
+
+
+def _sample_trafos() -> np.ndarray:
+    t = np.stack([np.eye(4) for _ in range(7)])
+    for i in range(7):
+        t[i, :3, 3] = [0.1 * i, 0.0, 0.1]
+    t[1, :3, :3] = _rot(np.array([1.0, 0.0, 0.0]), 0.5)[:3, :3]
+    t[3, :3, :3] = _rot(np.array([0.0, 1.0, 0.0]), -0.4)[:3, :3]
+    return t
+
+
+def test_from_transforms_fk_matches_reference() -> None:
+    trafos = _sample_trafos()
+    axis = [0.0, 0.0, 1.0]
+    m = Manipulator.from_transforms(trafos, joint_axis=axis)
+    rng = np.random.default_rng(5)
+    worst = max(
+        float(np.max(np.abs(m.fk(q) - _tf_fk(trafos, axis, q))))
+        for q in rng.uniform(-3, 3, (200, 6))
+    )
+    assert worst < 1e-12, f"from_transforms FK vs reference {worst:.2e}"
+
+
+def test_from_transforms_rejects_bad_shape() -> None:
+    with pytest.raises(ValueError, match="joint_trafos must be"):
+        Manipulator.from_transforms(np.zeros((7, 3, 4)))
+
+
+# ---------------------------------------------------------------------------
+# limits pass-through (shared across all three)
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_limits_are_applied() -> None:
+    limits = np.array([[-1.0, 1.0]] * 6)
+    m = Manipulator.from_axes(_H, _P, limits=limits)
+    assert [j.limits for j in m.kinbody.joints] == [(-1.0, 1.0)] * 6


### PR DESCRIPTION
Closes #8 and #9. Three non-URDF `Manipulator` constructors matching EAIK's `DhRobot` / `HPRobot` / `HomogeneousRobot`, so callers with a DH table, ik-geo `H/P` parameters, or per-joint zero-pose transforms can build a solver without writing a URDF.

## API
- **`from_axes(H, P, *, limits=None)`** — `(N,3)` base-frame axes + `(N+1,3)` inter-joint offsets. Reproduces `FK = ∏ Trans(P[i])·Rot(H[i], q_i) · Trans(P[N])`.
- **`from_transforms(joint_trafos, joint_axis=(0,0,1), *, limits=None)`** — `(N+1,4,4)` relative zero-pose transforms + a local rotation axis.
- **`from_dh(dh_alpha, dh_a, dh_d, *, limits=None)`** — standard (distal) DH; per-joint link transform `Rot_z(θ)·Trans_z(d)·Trans_x(a)·Rot_x(α)`, all revolute.

Each maps to a `JointSpec` list → `build_kinbody` → `Manipulator`, so the dispatcher, solvers, and postprocess apply unchanged.

## Validation
- Each constructor's `fk()` equals the parameterisation's **own reference FK** to machine precision (`<1e-12`).
- **Puma 560** via `from_dh` (Corke standard DH) dispatches to `ikgeo.spherical_two_parallel` and `solve(fk(q))` roundtrips at **4e-15** — the #8 benchmark (parallel shoulder + spherical wrist, the classic analytic case).
- Shape/length validation + `limits` pass-through covered.

Full suite **1684 passed, 3 skipped**. ruff + mypy clean.

Note on #9's "identical to `from_urdf` for UR5": `from_axes`/`from_transforms` reproduce the parameterisation's FK exactly, but the ik-geo `H/P` and EAIK conventions place an **identity-oriented EE frame at q=0**, whereas a URDF can bake a rotated `ee_link` home frame. So they match `from_urdf` up to that EE home rotation (which the H/P convention doesn't carry) — validated against each parameterisation's own reference FK instead, which is the precise correctness statement.