### PR TITLE
Bulletproof solver construction against axis representation gauges (sign + length)

### DIFF
--- a/src/ssik/_kinbody.py
+++ b/src/ssik/_kinbody.py
@@ -51,7 +51,38 @@ __all__ = [
 # offset is treated as zero (a genuine spherical wrist meets to ~1e-15).
 _WRIST_PERP_ATOL = 1e-9
 
+# An axis vector shorter than this carries no usable direction (degenerate).
+_AXIS_MIN_NORM = 1e-9
+# An axis already this close to unit length is passed through unchanged, so a
+# clean (already-normalized) chain -- e.g. every URDF axis, which urchin unitizes
+# on load -- keeps its exact bytes and baked artifacts don't drift. Only a
+# meaningfully non-unit axis (a hand-built JointSpec / from_axes row) is scaled.
+_AXIS_UNIT_TOL = 1e-9
+
 JointType = Literal["revolute", "prismatic"]
+
+
+def _unit_axis(axis: NDArray[np.float64], i: int) -> NDArray[np.float64]:
+    """Return ``axis`` scaled to unit length.
+
+    A joint axis denotes only a *direction*: its magnitude is physically
+    meaningless, but the Rodrigues kernel (``rotate`` / ``rotation_matrix``) and
+    every predicate assume ``|axis| == 1`` (``predicates`` documents that a
+    non-unit axis silently misbehaves rather than raising). The URDF loader gets
+    unit axes for free from ``urchin``, but the direct constructors
+    (``from_axes`` / ``from_dh`` / ``from_transforms`` / raw ``JointSpec``) trust
+    the caller, so we normalize here -- the one construction chokepoint -- to
+    make all paths robust to the axis-length gauge. A near-zero axis has no
+    direction and is a construction error.
+    """
+    n = float(np.linalg.norm(axis))
+    if n < _AXIS_MIN_NORM:
+        raise ValueError(f"joint {i} axis is degenerate (norm {n:.2e}); it has no direction")
+    if abs(n - 1.0) <= _AXIS_UNIT_TOL:
+        # Already unit -- return the exact input (no float division), so a
+        # normalized chain stays bit-identical and baked artifacts don't shift.
+        return axis
+    return axis / n
 
 
 @dataclass(frozen=True)
@@ -293,6 +324,9 @@ def build_kinbody(
         axis_local = np.ascontiguousarray(spec.axis, dtype=np.float64)
         if axis_local.shape != (3,):
             raise ValueError(f"spec[{i}].axis must be shape (3,), got {axis_local.shape}")
+        # Normalize to unit -- the Rodrigues kernel + predicates assume |axis|=1.
+        # R_cum below is a rotation (norm-preserving), so axis_world stays unit.
+        axis_local = _unit_axis(axis_local, i)
 
         # Advance through T_left's rotation + translation.
         pos_cum = pos_cum + R_cum @ T_left[:3, 3]
@@ -383,6 +417,9 @@ def build_poe_kinbody(
     links = [Link(name=name) for name in link_names]
     joints: list[Joint] = []
     for i, (name, joint_type, axis_base, p_offset, limits) in enumerate(records):
+        # Normalize to unit (urchin already does for URDF; belt-and-suspenders
+        # for any other record source). Rodrigues + predicates assume |axis|=1.
+        axis_base = _unit_axis(np.ascontiguousarray(axis_base, dtype=np.float64), i)
         t_left = np.eye(4, dtype=np.float64)
         t_left[:3, 3] = p_offset
         t_right = final_t_right if i == n - 1 else np.eye(4, dtype=np.float64)

--- a/src/ssik/solvers/ikgeo/three_parallel.py
+++ b/src/ssik/solvers/ikgeo/three_parallel.py
@@ -110,6 +110,23 @@ def solve(
     p = [kb.joints[i].T_left[:3, 3].copy() for i in range(6)]
     p.append(kb.joints[-1].T_right[:3, 3].copy())
 
+    # Parallel-trio sign normalization. The elbow algebra below collapses the
+    # trio (1, 2, 3) onto the single direction ``axes[1]`` -- it solves each
+    # trio angle *about axes[1]* and uses the signed total theta14 = q1+q2+q3+q4.
+    # A URDF may orient a trio joint's axis anti-parallel to axes[1] (both are
+    # "parallel" to the predicate, since +/-a are geometrically parallel); its
+    # angle then comes out in the axes[1] frame, negated from the physical joint.
+    # Flipping a revolute axis is a gauge freedom (R(-a, q) = R(a, -q)), so we
+    # recover the physical trio angles by negating the anti-parallel ones on the
+    # composed candidate. Without this an anti-parallel j2/j3 (e.g. Standard Bots
+    # core/spark) yields FK-failing candidates. See the axis-sign robustness test.
+    trio_flip = np.array(
+        [1.0, 1.0]
+        + [1.0 if float(np.dot(axes[i], axes[1])) >= 0.0 else -1.0 for i in (2, 3)]
+        + [1.0, 1.0],
+        dtype=np.float64,
+    )
+
     # Our POE's T_right[5] encodes a home-pose rotation after joint 5, so
     # FK(q) = [R_joints @ R_home, p; 0, 1]. IK-Geo's formulas assume the final
     # frame has identity home rotation (pure translation), so we strip
@@ -171,7 +188,9 @@ def solve(
             p2_rotated = p[2] + rotate(axes[1], q3, p[3])
             q2, _ = sp1.solve(axes[1], p2_rotated, d_inner, policy)
             q4 = _wrap_to_pi(theta14 - q2 - q3)
-            candidates.append(np.array([q1, q2, q3, q4, q5, q6]))
+            # Negate any anti-parallel trio joint back to its physical convention
+            # (see trio_flip above) before FK-verify on the original chain.
+            candidates.append(np.array([q1, q2, q3, q4, q5, q6]) * trio_flip)
 
     # Post-verify and dedup. SP6 has pre-sorted candidates by pre-GN
     # residual (cleanest Bezout-cluster representative first); the

--- a/tests/test_axis_sign_robustness.py
+++ b/tests/test_axis_sign_robustness.py
@@ -1,0 +1,132 @@
+"""Axis-sign (gauge) robustness of the analytic solvers.
+
+A revolute joint's axis direction is a gauge freedom: flipping ``a -> -a`` and
+negating the joint angle ``q -> -q`` leaves FK unchanged, because
+``R(-a, q) == R(a, -q)``. A URDF author is free to point any joint axis either
+way, so an authored ``-a`` must solve exactly as well as ``+a``.
+
+Every solver must therefore be *sign-robust*: for any single joint whose axis is
+negated (a distinct-but-valid arm), ``solve(fk(q))`` must still round-trip to
+machine precision. A parallel/intersecting predicate treats ``±a`` as parallel/
+concurrent, so a negated axis re-dispatches to the *same* solver -- the solver
+cannot lean on an axis-sign it never enforced.
+
+``ikgeo.three_parallel`` violated this: it collapses the parallel trio (joints
+1, 2, 3) onto ``axes[1]`` and uses the signed total ``theta14 = q1+q2+q3+q4``, so
+a trio joint authored anti-parallel to ``axes[1]`` produced candidates in the
+wrong sign convention and FK-failed (Standard Bots core/spark, 0 solutions). The
+fix normalizes each anti-parallel trio joint back to its physical convention.
+The wider audit (SRS, spherical_two_parallel/intersecting, general_6r,
+spherical_shoulder 7R) found every other family already robust; these tests pin
+the property so it cannot silently regress.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import JointSpec, build_kinbody
+from ssik.core.dispatcher import dispatch
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.manipulator import Manipulator
+
+_Z = np.array([0.0, 0.0, 1.0])
+_Y = np.array([0.0, 1.0, 0.0])
+_X = np.array([1.0, 0.0, 0.0])
+
+
+def _trans(x: float, y: float, z: float) -> np.ndarray:
+    m = np.eye(4)
+    m[:3, 3] = (x, y, z)
+    return m
+
+
+# A UR-style 6R: base ``z``, then the parallel shoulder/elbow/wrist-1 trio
+# (joints 1, 2, 3 about ``y``), then wrist-2 ``z`` and wrist-3 ``y`` --
+# the ``ikgeo.three_parallel`` class.
+_THREE_PARALLEL = [
+    JointSpec(parent_link_T=_trans(0, 0, 0.1), axis=_Z, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0.1, 0.1), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0.4, 0, 0), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0.4, 0, 0), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0.1, 0), axis=_Z, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0, 0.1), axis=_Y, joint_type="revolute"),
+]
+
+# An anthropomorphic arm with a parallel shoulder/elbow pair and a spherical
+# wrist -- the ``ikgeo.spherical_two_parallel`` class (mirrors the #377 test).
+_TWO_PARALLEL = [
+    JointSpec(parent_link_T=_trans(0, 0, 0), axis=_Z, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0, 0.5), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0.5, 0, 0), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0.5, 0, 0), axis=_X, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0, 0), axis=_Y, joint_type="revolute"),
+    JointSpec(parent_link_T=_trans(0, 0, 0), axis=_X, joint_type="revolute"),
+]
+
+
+def _flip_axis(specs: list[JointSpec], i: int) -> list[JointSpec]:
+    """Return a copy of ``specs`` with joint ``i``'s axis negated."""
+    return [
+        JointSpec(
+            parent_link_T=s.parent_link_T,
+            axis=(-s.axis if j == i else s.axis),
+            joint_type=s.joint_type,
+        )
+        for j, s in enumerate(specs)
+    ]
+
+
+def _worst_roundtrip(kb, seed: int, n: int = 100) -> tuple[int, float]:
+    """``solve(fk(q))`` over ``n`` random poses; return (solved, worst FK error)."""
+    m = Manipulator(kb)
+    rng = np.random.default_rng(seed)
+    solved = 0
+    worst = 0.0
+    for _ in range(n):
+        q = rng.uniform(-2.0, 2.0, size=len(kb.joints))
+        t = poe_forward_kinematics(kb, q)
+        sols = m.solve(t, respect_limits=False)
+        if sols:
+            solved += 1
+            worst = max(
+                worst,
+                min(float(np.max(np.abs(poe_forward_kinematics(kb, s.q) - t))) for s in sols),
+            )
+    return solved, worst
+
+
+@pytest.mark.parametrize("flip", range(6))
+def test_three_parallel_is_sign_robust(flip: int) -> None:
+    """Negating *any* joint axis (notably a parallel-trio joint 1/2/3, the bug
+    case) keeps the arm on ``three_parallel`` and solving at machine precision."""
+    kb = build_kinbody(_flip_axis(_THREE_PARALLEL, flip))
+    assert dispatch(kb).solver_name == "ikgeo.three_parallel"
+    solved, worst = _worst_roundtrip(kb, seed=100 + flip)
+    assert solved == 100, f"flip j{flip}: only solved {solved}/100"
+    assert worst < 1e-9, f"flip j{flip}: worst FK closure {worst:.2e}"
+
+
+def test_three_parallel_anti_parallel_trio_regression() -> None:
+    """The exact failure mode: joints 2 and 3 authored anti-parallel to the trio
+    reference axis (Standard Bots core/spark). Pre-fix this returned 0 solutions;
+    it must now round-trip at machine precision."""
+    specs = _flip_axis(_flip_axis(_THREE_PARALLEL, 2), 3)
+    kb = build_kinbody(specs)
+    assert dispatch(kb).solver_name == "ikgeo.three_parallel"
+    solved, worst = _worst_roundtrip(kb, seed=7)
+    assert solved == 100, f"anti-parallel trio: only solved {solved}/100"
+    assert worst < 1e-9, f"anti-parallel trio: worst FK closure {worst:.2e}"
+
+
+@pytest.mark.parametrize("flip", range(6))
+def test_spherical_two_parallel_is_sign_robust(flip: int) -> None:
+    """A representative already-robust family stays robust under any axis flip --
+    guards against a future same-sign assumption creeping into the SP-per-joint
+    solvers (the audit found these use actual per-joint axes, not a signed sum)."""
+    kb = build_kinbody(_flip_axis(_TWO_PARALLEL, flip))
+    assert dispatch(kb).solver_name == "ikgeo.spherical_two_parallel"
+    solved, worst = _worst_roundtrip(kb, seed=200 + flip)
+    assert solved == 100, f"flip j{flip}: only solved {solved}/100"
+    assert worst < 1e-9, f"flip j{flip}: worst FK closure {worst:.2e}"

--- a/tests/test_manipulator_constructors.py
+++ b/tests/test_manipulator_constructors.py
@@ -191,3 +191,35 @@ def test_constructor_limits_are_applied() -> None:
     limits = np.array([[-1.0, 1.0]] * 6)
     m = Manipulator.from_axes(_H, _P, limits=limits)
     assert [j.limits for j in m.kinbody.joints] == [(-1.0, 1.0)] * 6
+
+
+# ---------------------------------------------------------------------------
+# axis-length gauge: a joint axis denotes only a direction, so a non-unit axis
+# must build the identical arm (the Rodrigues kernel + predicates assume unit
+# length; the URDF loader normalizes for free, the direct constructors must too)
+# ---------------------------------------------------------------------------
+
+
+def test_non_unit_axis_is_normalized_and_fk_identical() -> None:
+    """Scaling any ``from_axes`` H-row (a non-unit axis) must yield an arm that
+    is FK-identical to the unit version -- not a silently different robot."""
+    m_unit = Manipulator.from_axes(_H, _P)
+    h_scaled = _H.copy()
+    h_scaled[1] *= 2.0
+    h_scaled[3] *= 0.5
+    m_scaled = Manipulator.from_axes(h_scaled, _P)
+    rng = np.random.default_rng(11)
+    worst = max(
+        float(np.max(np.abs(m_unit.fk(q) - m_scaled.fk(q)))) for q in rng.uniform(-3, 3, (200, 6))
+    )
+    assert worst == 0.0, f"non-unit axis changed FK by {worst:.2e} (not normalized)"
+    # And the scaled-axis arm still solves against itself at machine precision.
+    assert _roundtrip_worst(m_scaled, seed=12) < 1e-9
+
+
+def test_degenerate_axis_is_rejected() -> None:
+    """A near-zero axis carries no direction and is a construction error."""
+    h_bad = _H.copy()
+    h_bad[2] = 0.0
+    with pytest.raises(ValueError, match="degenerate"):
+        Manipulator.from_axes(h_bad, _P)


### PR DESCRIPTION
Makes the construction/dispatch boundary robust to two **axis representation freedoms** that solver kernels silently assumed away. Both are instances of one bug class: *a construction boundary accepts a representation the solver can't handle, producing silent wrong answers rather than a raise.*

## 1. Axis **sign** — the three_parallel gauge bug (root cause)

`ikgeo.three_parallel` collapses the parallel trio (joints 1, 2, 3) onto the single direction `axes[1]` and uses the signed total `theta14 = q1+q2+q3+q4`. A URDF may author a trio joint's axis **anti-parallel** to `axes[1]` — still "parallel" to the predicate, since ±a are geometrically parallel — so that joint's angle comes out negated from the physical joint and **every candidate FK-fails**. Standard Bots **core**/**spark** dispatched correctly but returned **0 solutions**.

Fix: axis flip is a gauge freedom (`R(-a,q)=R(a,-q)`), so negate the anti-parallel trio joints (`trio_flip`) on each candidate before FK-verify. Same-sign arms (UR5/Z1) are unchanged.

## 2. Axis **length** — non-unit axes in the direct constructors

A joint axis denotes only a *direction*, but the Rodrigues kernel + every predicate assume `|axis| == 1` (`predicates.py:16` documents this as a silent-failure surface with no runtime check). The URDF path is safe (urchin unitizes on load), but the `from_axes`/`from_dh`/`from_transforms`/`JointSpec` constructors (#8/#9) trusted the caller — an EAIK-style `from_axes(H, P)` with a non-unit H-row silently built a *different* robot (FK off by 0.36, 0/100 self-round-trip).

Fix: normalize at the two construction chokepoints (`_unit_axis`), raising on a degenerate near-zero axis. It's a **bit-exact no-op** for already-unit axes (`|n-1| ≤ 1e-9`), so URDF chains keep their exact bytes and baked artifacts don't drift.

## Audit — is this a wider bug class?

A parallel structural survey of every solver (`three_parallel`, `spherical_two_parallel`/`_intersecting`/`spherical`, `general_6r`, SRS 7R, `spherical_shoulder` 7R, jointlock) plus per-family axis-flip round-trips. **Only these two freedoms were unguarded.** Everything else is provably safe:

| Freedom / assumption | Status |
|---|---|
| Axis **sign** (±a) | ❌→✅ fixed here (three_parallel; all other families use per-joint SP axes and are robust) |
| Axis **length** (‖a‖) | ❌→✅ fixed here (constructors; URDF safe via urchin) |
| Hardcoded joint **indices** (trio=1,2,3; wrist=3,4,5) | ✅ every solver re-asserts its predicate on entry + raises; dispatcher routes only matching inputs; non-canonical structure falls through to `general_6r` |
| **Home-rotation** gauge (R_home) | ✅ stripped/bridged in every solver (ikgeo strip, general_6r DH bridge, SRS/7R via R_post_wrist) |
| Coincident-origin / wrist consolidation | ✅ guarded by strict predicate + `canonicalize_spherical_wrist` |
| `spherical.py` shoulder-not-parallel | ✅ degrades to empty set (not wrong answer), guarded by dispatcher ordering |

## Test plan

- **`tests/test_axis_sign_robustness.py`** (new) — negating *any* single joint axis on a `three_parallel` arm keeps it dispatched and round-tripping at machine precision (all 6 joints), the exact anti-parallel-trio regression, and a representative already-robust family (`spherical_two_parallel`) under every flip. Confirmed the guard **bites**: reverting the sign fix fails 4 of these.
- **`tests/test_manipulator_constructors.py`** (extended) — a scaled-axis arm is FK-identical to the unit version and self-round-trips; a degenerate axis raises.
- thor/core/spark now solve 200/200 at ≈1e-14 (were 0/200); non-unit `from_axes` now bit-identical to unit (was 0.36 FK error).
- Full suite: **1697 passed** (pre-length-fix run); re-running after the axis-length commit. gen3/xarm7 artifact snapshots confirmed **unchanged** (the no-op guard).

Unblocks onboarding the Standard Bots arms.