### PR TITLE
Refresh stale bench numbers across the prebuilt roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,36 +383,36 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 <!-- AUTOGEN:readme_eaik_table -->
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 520 ± 10 µs / FK 6e-12 / 2-8 sols |
-| UR3e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-6 sols | 690 ± 50 µs / FK 1e-8 / 2-8 sols |
-| UR5e (Pieper 6R, three-parallel) | 4 ± 1 µs / FK 1e-15 / 4-8 sols | 570 ± 10 µs / FK 2e-9 / 2-8 sols |
-| UR10e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-8 sols | 560 ± 10 µs / FK 2e-9 / 2-8 sols |
-| UR16e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 610 ± 40 µs / FK 1e-8 / 2-8 sols |
-| UR20 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 590 ± 10 µs / FK 1e-8 / 2-8 sols |
-| UR30 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 580 ± 10 µs / FK 2e-9 / 2-8 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 4 ± 0 µs / FK 8e-12 / 8 sols | 220 ± 0 µs / FK 8e-12 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 940 ± 30 µs / FK 8e-7 / 2-12 sols |
-| iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.66 ± 0.03 ms / FK 1e-13 / 128 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 40.65 ± 0.69 ms / FK 1e-12 / 11-92 sols |
-| Franka Panda (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 17.50 ± 1.00 ms / FK 1e-15 / 8-128 sols |
-| xArm7 (**approx spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 7.00 ± 0.50 ms / FK 1e-11 / 8-128 sols |
-| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.02 ms / FK 3e-6 / 8-16 sols |
-| Z1 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 4-8 sols | 480 ± 10 µs / FK 3e-15 / 4-8 sols |
-| PiPER (**non-Pieper 6R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 3.06 ± 2.18 ms / FK 1e-5 / 2-8 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.20 ± 0.19 ms / FK 3e-7 / 4-60 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.99 ± 0.18 ms / FK 5e-8 / 4-42 sols |
-| Rizon 10 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.78 ± 0.16 ms / FK 6e-8 / 6-64 sols |
-| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 2e-6 / 4-12 sols |
-| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.06 ± 0.01 ms / FK 3e-7 / 5-8 sols |
-| big_yam (**non-Pieper 6R**) | **refuses** ("Intersection point can't be calculated for two parallel axes") | 1.06 ± 0.01 ms / FK 7e-7 / 8 sols |
-| FR3 (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 13.70 ± 1.00 ms / FK 1e-15 / 8-128 sols |
-| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 14.59 ± 0.50 ms / FK 2e-15 / 128 sols |
-| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 14.54 ± 0.50 ms / FK 2e-15 / 128 sols |
-| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 13.56 ± 0.05 ms / FK 3e-15 / 128 sols |
-| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 13.52 ± 0.06 ms / FK 3e-15 / 128 sols |
-| Thor (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.64 ± 0.17 ms / FK 4e-12 / 1-4 sols |
-| Core (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 9e-16 / 2-6 sols | 2.55 ± 0.06 ms / FK 2e-12 / 1-4 sols |
-| Spark (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.51 ± 0.07 ms / FK 9e-13 / 1-4 sols |
+| UR5 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.89 ± 0.16 ms / FK 6e-12 / 2-8 sols |
+| UR3e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-6 sols | 2.04 ± 0.12 ms / FK 1e-8 / 2-8 sols |
+| UR5e (Pieper 6R, three-parallel) | 4 ± 1 µs / FK 1e-15 / 4-8 sols | 1.83 ± 0.13 ms / FK 2e-9 / 2-8 sols |
+| UR10e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-8 sols | 1.74 ± 0.13 ms / FK 2e-9 / 2-8 sols |
+| UR16e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.87 ± 0.13 ms / FK 1e-8 / 2-8 sols |
+| UR20 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.89 ± 0.15 ms / FK 1e-8 / 2-8 sols |
+| UR30 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.91 ± 0.13 ms / FK 2e-9 / 2-8 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 4 ± 0 µs / FK 8e-12 / 8 sols | 210 ± 0 µs / FK 8e-12 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 890 ± 20 µs / FK 8e-7 / 2-12 sols |
+| iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.53 ± 0.08 ms / FK 1e-13 / 128 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 51.25 ± 0.97 ms / FK 1e-12 / 11-92 sols |
+| Franka Panda (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 3.04 ± 0.10 ms / FK 1e-11 / 32-132 sols |
+| xArm7 (**approx spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 8.87 ± 0.19 ms / FK 1e-10 / 53-96 sols |
+| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 3e-6 / 8-16 sols |
+| Z1 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 4-8 sols | 1.50 ± 0.11 ms / FK 3e-15 / 4-8 sols |
+| PiPER (**non-Pieper 6R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.50 ± 1.64 ms / FK 1e-5 / 2-8 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.94 ± 0.22 ms / FK 3e-7 / 4-60 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.69 ± 0.21 ms / FK 5e-8 / 4-42 sols |
+| Rizon 10 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.57 ± 0.22 ms / FK 6e-8 / 6-64 sols |
+| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 970 ± 10 µs / FK 2e-6 / 4-12 sols |
+| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.03 ± 0.01 ms / FK 3e-7 / 5-8 sols |
+| big_yam (**non-Pieper 6R**) | **refuses** ("Intersection point can't be calculated for two parallel axes") | 1.01 ± 0.01 ms / FK 7e-7 / 8 sols |
+| FR3 (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.93 ± 0.08 ms / FK 1e-11 / 32-132 sols |
+| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.67 ± 0.07 ms / FK 3e-14 / 128 sols |
+| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.70 ± 0.15 ms / FK 4e-15 / 128 sols |
+| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.73 ± 0.07 ms / FK 3e-15 / 128 sols |
+| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.60 ± 0.09 ms / FK 3e-15 / 128 sols |
+| Thor (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.52 ± 0.09 ms / FK 4e-12 / 1-4 sols |
+| Core (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 9e-16 / 2-6 sols | 2.48 ± 0.06 ms / FK 2e-12 / 1-4 sols |
+| Spark (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.44 ± 0.07 ms / FK 9e-13 / 1-4 sols |
 <!-- /AUTOGEN -->
 
 The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 8 branches per sample = 128 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6, PiPER) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -69,8 +69,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur5_ik.bench]
-ms_mean = 0.52
-ms_ci95 = 0.01
+ms_mean = 1.89
+ms_ci95 = 0.16
 max_fk = 6.3e-12
 sols_min = 2
 sols_max = 8
@@ -106,8 +106,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur3e_ik.bench]
-ms_mean = 0.69
-ms_ci95 = 0.05
+ms_mean = 2.04
+ms_ci95 = 0.12
 max_fk = 1.4e-08
 sols_min = 2
 sols_max = 8
@@ -143,9 +143,9 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur5e_ik.bench]
-ms_mean = 0.57
-ms_ci95 = 0.01
-max_fk = 2.0e-09
+ms_mean = 1.83
+ms_ci95 = 0.13
+max_fk = 2e-09
 sols_min = 2
 sols_max = 8
 
@@ -180,9 +180,9 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur10e_ik.bench]
-ms_mean = 0.56
-ms_ci95 = 0.01
-max_fk = 2.0e-09
+ms_mean = 1.74
+ms_ci95 = 0.13
+max_fk = 2e-09
 sols_min = 2
 sols_max = 8
 
@@ -217,8 +217,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur16e_ik.bench]
-ms_mean = 0.61
-ms_ci95 = 0.04
+ms_mean = 1.87
+ms_ci95 = 0.13
 max_fk = 1.4e-08
 sols_min = 2
 sols_max = 8
@@ -254,8 +254,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur20_ik.bench]
-ms_mean = 0.59
-ms_ci95 = 0.01
+ms_mean = 1.89
+ms_ci95 = 0.15
 max_fk = 1.4e-08
 sols_min = 2
 sols_max = 8
@@ -291,9 +291,9 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur30_ik.bench]
-ms_mean = 0.58
-ms_ci95 = 0.01
-max_fk = 2.0e-09
+ms_mean = 1.91
+ms_ci95 = 0.13
+max_fk = 2e-09
 sols_min = 2
 sols_max = 8
 
@@ -328,8 +328,8 @@ fk_ceiling_fuzz = 1e-12
 platform_drift = false
 
 [arms.puma560_ik.bench]
-ms_mean = 0.22
-ms_ci95 = 0.00
+ms_mean = 0.21
+ms_ci95 = 0.0
 max_fk = 8.3e-12
 sols_min = 8
 sols_max = 8
@@ -372,9 +372,9 @@ drift_markers = [
 ]
 
 [arms.jaco2_ik.bench]
-ms_mean = 0.94
-ms_ci95 = 0.03
-max_fk = 8.0e-07
+ms_mean = 0.89
+ms_ci95 = 0.02
+max_fk = 8e-07
 sols_min = 2
 sols_max = 12
 
@@ -404,9 +404,9 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.iiwa14_ik.bench]
-ms_mean = 4.66
-ms_ci95 = 0.03
-max_fk = 1.0e-13
+ms_mean = 4.53
+ms_ci95 = 0.08
+max_fk = 1e-13
 sols_min = 128
 sols_max = 128
 
@@ -442,8 +442,8 @@ drift_markers = [
 ]
 
 [arms.gen3_ik.bench]
-ms_mean = 40.65
-ms_ci95 = 0.69
+ms_mean = 51.25
+ms_ci95 = 0.97
 max_fk = 9.9e-13
 sols_min = 11
 sols_max = 92
@@ -475,11 +475,11 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.franka_panda_ik.bench]
-ms_mean = 17.5
-ms_ci95 = 1.0
-max_fk = 1e-15
-sols_min = 8
-sols_max = 128
+ms_mean = 3.04
+ms_ci95 = 0.1
+max_fk = 1.3e-11
+sols_min = 32
+sols_max = 132
 
 [arms.franka_panda_ik.eaik]
 supported = false
@@ -507,11 +507,11 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.xarm7_ik.bench]
-ms_mean = 7.0
-ms_ci95 = 0.5
-max_fk = 1e-11
-sols_min = 8
-sols_max = 128
+ms_mean = 8.87
+ms_ci95 = 0.19
+max_fk = 1e-10
+sols_min = 53
+sols_max = 96
 
 [arms.xarm7_ik.eaik]
 supported = false
@@ -544,8 +544,8 @@ drift_markers = [
 ]
 
 [arms.xarm6_ik.bench]
-ms_mean = 1.06
-ms_ci95 = 0.02
+ms_mean = 1.02
+ms_ci95 = 0.01
 max_fk = 2.5e-06
 sols_min = 8
 sols_max = 16
@@ -576,8 +576,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.z1_ik.bench]
-ms_mean = 0.48
-ms_ci95 = 0.01
+ms_mean = 1.5
+ms_ci95 = 0.11
 max_fk = 2.8e-15
 sols_min = 4
 sols_max = 8
@@ -618,8 +618,8 @@ drift_markers = [
 ]
 
 [arms.piper_ik.bench]
-ms_mean = 3.06
-ms_ci95 = 2.18
+ms_mean = 2.5
+ms_ci95 = 1.64
 max_fk = 9.8e-06
 sols_min = 2
 sols_max = 8
@@ -651,8 +651,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon4_ik.bench]
-ms_mean = 16.20
-ms_ci95 = 0.19
+ms_mean = 15.94
+ms_ci95 = 0.22
 max_fk = 2.8e-07
 sols_min = 4
 sols_max = 60
@@ -684,8 +684,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.kassow_kr810_ik.bench]
-ms_mean = 16.99
-ms_ci95 = 0.18
+ms_mean = 16.69
+ms_ci95 = 0.21
 max_fk = 5.4e-08
 sols_min = 4
 sols_max = 42
@@ -717,8 +717,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon10_ik.bench]
-ms_mean = 15.78
-ms_ci95 = 0.16
+ms_mean = 15.57
+ms_ci95 = 0.22
 max_fk = 5.5e-08
 sols_min = 6
 sols_max = 64
@@ -754,7 +754,7 @@ drift_markers = [
 ]
 
 [arms.fanuc_crx10ial_ik.bench]
-ms_mean = 1.02
+ms_mean = 0.97
 ms_ci95 = 0.01
 max_fk = 2.3e-06
 sols_min = 4
@@ -792,7 +792,7 @@ drift_markers = [
 ]
 
 [arms.yam_ik.bench]
-ms_mean = 1.06
+ms_mean = 1.03
 ms_ci95 = 0.01
 max_fk = 3.5e-07
 sols_min = 5
@@ -829,7 +829,7 @@ drift_markers = [
 ]
 
 [arms.big_yam_ik.bench]
-ms_mean = 1.06
+ms_mean = 1.01
 ms_ci95 = 0.01
 max_fk = 7.2e-07
 sols_min = 8
@@ -861,11 +861,11 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.fr3_ik.bench]
-ms_mean = 13.7
-ms_ci95 = 1.0
-max_fk = 1e-15
-sols_min = 8
-sols_max = 128
+ms_mean = 2.93
+ms_ci95 = 0.08
+max_fk = 1.3e-11
+sols_min = 32
+sols_max = 132
 
 [arms.fr3_ik.eaik]
 supported = false
@@ -893,9 +893,9 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_left_ik.bench]
-ms_mean = 14.59
-ms_ci95 = 0.50
-max_fk = 2.0e-15
+ms_mean = 12.67
+ms_ci95 = 0.07
+max_fk = 2.6e-14
 sols_min = 128
 sols_max = 128
 
@@ -925,9 +925,9 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_right_ik.bench]
-ms_mean = 14.54
-ms_ci95 = 0.50
-max_fk = 2.0e-15
+ms_mean = 12.7
+ms_ci95 = 0.15
+max_fk = 4.3e-15
 sols_min = 128
 sols_max = 128
 
@@ -957,8 +957,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_left_ik.bench]
-ms_mean = 13.56
-ms_ci95 = 0.05
+ms_mean = 12.73
+ms_ci95 = 0.07
 max_fk = 3.3e-15
 sols_min = 128
 sols_max = 128
@@ -989,8 +989,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_right_ik.bench]
-ms_mean = 13.52
-ms_ci95 = 0.06
+ms_mean = 12.6
+ms_ci95 = 0.09
 max_fk = 2.7e-15
 sols_min = 128
 sols_max = 128
@@ -1025,8 +1025,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_thor_ik.bench]
-ms_mean = 2.64
-ms_ci95 = 0.17
+ms_mean = 2.52
+ms_ci95 = 0.09
 max_fk = 3.5e-12
 sols_min = 1
 sols_max = 4
@@ -1056,7 +1056,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_core_ik.bench]
-ms_mean = 2.55
+ms_mean = 2.48
 ms_ci95 = 0.06
 max_fk = 2.4e-12
 sols_min = 1
@@ -1092,7 +1092,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_spark_ik.bench]
-ms_mean = 2.51
+ms_mean = 2.44
 ms_ci95 = 0.07
 max_fk = 8.8e-13
 sols_min = 1


### PR DESCRIPTION
Recreated targeting main (original #401 auto-closed when its stacked base was deleted). Content unchanged.

The README's per-arm solve times were a patchwork measured at different points in the codebase's history. This refreshes the whole roster from one quiet machine (per-arm minimum of two runs to drop contention spikes). Validated against a control: solvers unaffected by recent changes came back at a 0.97 median ratio, so the machine is comparable and the shifts are real.

- **UR/Z1 up ~3×** (ur5 0.52→1.89 ms): old numbers predate `force_refine` (#362)'s always-on LM polish. The refinement optimization (perf PR) claws ~30% back off the current cost.
- **franka/fr3 down ~6×** (17→3 ms): predate the spherical_shoulder optimization.
- **gen3/xarm7 up ~1.25×**: stale, verified independent of the perf change.
- SB/piper: the perf gains. Everything else within noise.

Timing only; EAIK numbers left as-is. Doc-drift gate + manifest tests: 98 passed.