### PR TITLE
Guard against benchmarking uncompiled Cython extensions + correct the numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,36 +383,36 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 <!-- AUTOGEN:readme_eaik_table -->
 | Arm (class) | EAIK | ssik |
 |---|---|---|
-| UR5 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.89 ± 0.16 ms / FK 6e-12 / 2-8 sols |
-| UR3e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-6 sols | 2.04 ± 0.12 ms / FK 1e-8 / 2-8 sols |
-| UR5e (Pieper 6R, three-parallel) | 4 ± 1 µs / FK 1e-15 / 4-8 sols | 1.83 ± 0.13 ms / FK 2e-9 / 2-8 sols |
+| UR5 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.77 ± 0.13 ms / FK 6e-12 / 2-8 sols |
+| UR3e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-6 sols | 2.03 ± 0.11 ms / FK 1e-8 / 2-8 sols |
+| UR5e (Pieper 6R, three-parallel) | 4 ± 1 µs / FK 1e-15 / 4-8 sols | 1.85 ± 0.13 ms / FK 2e-9 / 2-8 sols |
 | UR10e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 2-8 sols | 1.74 ± 0.13 ms / FK 2e-9 / 2-8 sols |
-| UR16e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.87 ± 0.13 ms / FK 1e-8 / 2-8 sols |
-| UR20 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.89 ± 0.15 ms / FK 1e-8 / 2-8 sols |
-| UR30 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.91 ± 0.13 ms / FK 2e-9 / 2-8 sols |
-| Puma 560 (Pieper 6R, spherical wrist) | 4 ± 0 µs / FK 8e-12 / 8 sols | 210 ± 0 µs / FK 8e-12 / 8 sols |
-| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 890 ± 20 µs / FK 8e-7 / 2-12 sols |
-| iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.53 ± 0.08 ms / FK 1e-13 / 128 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 51.25 ± 0.97 ms / FK 1e-12 / 11-92 sols |
-| Franka Panda (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 3.04 ± 0.10 ms / FK 1e-11 / 32-132 sols |
-| xArm7 (**approx spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 8.87 ± 0.19 ms / FK 1e-10 / 53-96 sols |
-| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 3e-6 / 8-16 sols |
-| Z1 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 4-8 sols | 1.50 ± 0.11 ms / FK 3e-15 / 4-8 sols |
-| PiPER (**non-Pieper 6R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.50 ± 1.64 ms / FK 1e-5 / 2-8 sols |
-| Rizon 4 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.94 ± 0.22 ms / FK 3e-7 / 4-60 sols |
-| Kassow KR810 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.69 ± 0.21 ms / FK 5e-8 / 4-42 sols |
-| Rizon 10 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.57 ± 0.22 ms / FK 6e-8 / 6-64 sols |
-| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 970 ± 10 µs / FK 2e-6 / 4-12 sols |
-| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.03 ± 0.01 ms / FK 3e-7 / 5-8 sols |
+| UR16e (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.89 ± 0.13 ms / FK 1e-8 / 2-8 sols |
+| UR20 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 1e-15 / 4-8 sols | 1.80 ± 0.13 ms / FK 1e-8 / 2-8 sols |
+| UR30 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 2-8 sols | 1.93 ± 0.13 ms / FK 2e-9 / 2-8 sols |
+| Puma 560 (Pieper 6R, spherical wrist) | 4 ± 0 µs / FK 8e-12 / 8 sols | 220 ± 0 µs / FK 8e-12 / 8 sols |
+| JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 870 ± 20 µs / FK 8e-7 / 2-12 sols |
+| iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.84 ± 0.02 ms / FK 1e-13 / 128 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 40.75 ± 0.91 ms / FK 1e-12 / 11-92 sols |
+| Franka Panda (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 3.00 ± 0.11 ms / FK 1e-11 / 32-132 sols |
+| xArm7 (**approx spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 6.87 ± 0.15 ms / FK 1e-10 / 53-96 sols |
+| xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.04 ± 0.02 ms / FK 3e-6 / 8-16 sols |
+| Z1 (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 2e-15 / 4-8 sols | 1.52 ± 0.11 ms / FK 3e-15 / 4-8 sols |
+| PiPER (**non-Pieper 6R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.01 ± 1.01 ms / FK 1e-5 / 2-8 sols |
+| Rizon 4 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.55 ± 0.55 ms / FK 3e-7 / 4-60 sols |
+| Kassow KR810 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 16.52 ± 0.23 ms / FK 5e-8 / 4-42 sols |
+| Rizon 10 (**non-SRS 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 15.13 ± 0.20 ms / FK 6e-8 / 6-64 sols |
+| CRX-10iA/L (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 960 ± 10 µs / FK 2e-6 / 4-12 sols |
+| YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 3e-7 / 5-8 sols |
 | big_yam (**non-Pieper 6R**) | **refuses** ("Intersection point can't be calculated for two parallel axes") | 1.01 ± 0.01 ms / FK 7e-7 / 8 sols |
-| FR3 (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.93 ± 0.08 ms / FK 1e-11 / 32-132 sols |
-| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.67 ± 0.07 ms / FK 3e-14 / 128 sols |
-| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.70 ± 0.15 ms / FK 4e-15 / 128 sols |
-| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.73 ± 0.07 ms / FK 3e-15 / 128 sols |
-| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.60 ± 0.09 ms / FK 3e-15 / 128 sols |
-| Thor (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.52 ± 0.09 ms / FK 4e-12 / 1-4 sols |
-| Core (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 9e-16 / 2-6 sols | 2.48 ± 0.06 ms / FK 2e-12 / 1-4 sols |
-| Spark (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.44 ± 0.07 ms / FK 9e-13 / 1-4 sols |
+| FR3 (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.83 ± 0.08 ms / FK 1e-11 / 32-132 sols |
+| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.97 ± 0.11 ms / FK 3e-14 / 128 sols |
+| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.96 ± 0.12 ms / FK 4e-15 / 128 sols |
+| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.94 ± 0.25 ms / FK 3e-15 / 128 sols |
+| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.92 ± 0.11 ms / FK 3e-15 / 128 sols |
+| Thor (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.44 ± 0.06 ms / FK 4e-12 / 1-4 sols |
+| Core (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 9e-16 / 2-6 sols | 2.47 ± 0.06 ms / FK 2e-12 / 1-4 sols |
+| Spark (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.46 ± 0.06 ms / FK 9e-13 / 1-4 sols |
 <!-- /AUTOGEN -->
 
 The "sols" column shows the **range of branch counts across the 100 reachable poses**. For Pieper-class arms (Puma) the count is constant (8); for non-Pieper 6R the count varies because spurious roots of the degree-8 Sylvester resultant fall complex at some poses. For 7R arms the count is the **discretised redundancy-manifold sample × algebraic-branch product** — e.g. iiwa14's 16-sample swivel × 8 branches per sample = 128 sols. EAIK is ~100× faster than ssik on Pieper-class 6R — that is its native sweet spot, and ssik does not try to compete there. The interesting cells are the **refuses** ones: non-Pieper 6R (JACO 2, xArm6, PiPER) and every 7R arm. Those are the geometries ssik exists for. The "refuses (...)" strings: quoted ones (`"only 1-6R"`) are EAIK's actual error captured verbatim from its URDF loader; `(no 7R DH path...)` rows are spec-only fixtures whose 7-joint chain can't pass through our DH-extraction adapter into EAIK's `IK_DH` API — EAIK refuses the same arms either way (its URDF loader returns "only 1-6R" on every 7R input). A numerical-IK comparison (MINK) is tracked separately in [#236](https://github.com/personalrobotics/ssik/issues/236).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,14 @@ test-requires = ["numpy>=2.0"]
 #     import surface in the package; if anything is import-broken, this
 #     fires.
 test-command = [
+    # 0. Perf extensions actually compiled in the wheel. The annotated .py
+    #    sources import fine in pure-Python mode, so a wheel that silently
+    #    failed to cythonize them would still pass every functional check
+    #    below -- but run refinement-heavy arms (gen3, piper) far slower than
+    #    advertised. Assert each hatch_build.CYTHON_TARGETS module loaded from a
+    #    compiled .so, not the .py source. (Keep this list in sync with
+    #    CYTHON_TARGETS; tests/test_perf_extensions.py fails if it drifts.)
+    'python -c "import ssik.refinement, ssik.kinematics.poe_fk as _p; assert ssik.refinement.__file__.endswith((\".so\", \".pyd\")), \"ssik.refinement not compiled in wheel\"; assert _p.__file__.endswith((\".so\", \".pyd\")), \"ssik.kinematics.poe_fk not compiled in wheel\""',
     'python -c "from ssik.prebuilt import iiwa14_ik; import numpy as np; q = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]); T = iiwa14_ik.fk(q); sols = iiwa14_ik.solve(T); assert sols and max(s.fk_residual for s in sols) < 1e-9, \"iiwa14_ik smoke failed\""',
     'python -c "from ssik.prebuilt import franka_panda_ik; import numpy as np; T = franka_panda_ik.fk(np.array([0.2, 0.3, -0.4, -1.2, 0.3, 1.4, 0.5])); sols = franka_panda_ik.solve(T); assert sols, \"franka_panda_ik returned no IK\""',
     "ssik --help",

--- a/scripts/regen_bench.py
+++ b/scripts/regen_bench.py
@@ -33,6 +33,7 @@ is updated in place, preserving comments and hand-curated fields.
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib
 import subprocess
 import sys
@@ -293,6 +294,74 @@ def update_manifest_eaik(name: str, eaik: dict[str, object]) -> None:
     MANIFEST.write_text("".join(lines))
 
 
+def _uncompiled_perf_extensions() -> list[str]:
+    """Return the Cython perf-target modules that are loaded as pure Python.
+
+    The compile targets are single-sourced from ``hatch_build.CYTHON_TARGETS``
+    (the same list the wheel build cythonizes), so this can't drift from what
+    ships. We parse the tuple out of ``hatch_build.py`` via AST rather than
+    importing it, because that module pulls in the build-only ``hatchling``
+    dependency. A module is "compiled" iff its ``__file__`` is the ``.so`` shim
+    rather than the ``.py`` source.
+    """
+    tree = ast.parse((REPO_ROOT / "hatch_build.py").read_text())
+    targets: tuple[str, ...] | None = None
+    for node in ast.walk(tree):
+        # CYTHON_TARGETS is annotated (``CYTHON_TARGETS: tuple[str, ...] = ...``),
+        # so it's an AnnAssign; handle a plain Assign too for robustness.
+        if isinstance(node, ast.AnnAssign):
+            named = isinstance(node.target, ast.Name) and node.target.id == "CYTHON_TARGETS"
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            named = any(isinstance(t, ast.Name) and t.id == "CYTHON_TARGETS" for t in node.targets)
+            value = node.value
+        else:
+            continue
+        if named and value is not None:
+            targets = tuple(ast.literal_eval(value))
+    if targets is None:
+        raise RuntimeError("CYTHON_TARGETS not found in hatch_build.py")
+
+    uncompiled: list[str] = []
+    for target in targets:
+        # "src/ssik/refinement/__init__.py" -> "ssik.refinement"
+        modname = (
+            target.removeprefix("src/").removesuffix(".py").removesuffix("/__init__")
+        ).replace("/", ".")
+        mod = importlib.import_module(modname)
+        if not (mod.__file__ or "").endswith((".so", ".pyd")):
+            uncompiled.append(modname)
+    return uncompiled
+
+
+def _require_compiled_perf_extensions(*, allow_uncompiled: bool) -> None:
+    """Refuse to measure ssik timing against uncompiled perf extensions.
+
+    Bench numbers taken in this dev checkout used to be committed as
+    authoritative; when ``refinement`` was loaded in pure-Python mode (this
+    checkout built ``poe_fk.so`` but not ``refinement.so``) that silently
+    over-reported every refinement-heavy arm (gen3 51 vs 37 ms, piper 2.5 vs
+    1.1 ms). Timing is only meaningful against the compiled extensions the wheel
+    ships, so gate on it.
+    """
+    uncompiled = _uncompiled_perf_extensions()
+    if not uncompiled:
+        return
+    joined = ", ".join(uncompiled)
+    if allow_uncompiled:
+        print(f"WARNING: benching UNCOMPILED {joined} -- numbers will NOT match shipped wheels")
+        return
+    raise SystemExit(
+        f"regen_bench: refusing to measure timing -- perf extensions are NOT compiled: {joined}.\n"
+        "These ship as compiled .so (hatch_build.CYTHON_TARGETS); measuring them in pure-Python "
+        "mode over-reports solve time for every refinement-heavy arm (gen3, piper, ...).\n"
+        "Fix: reinstall to rebuild the extensions --\n"
+        "  uv pip install -e . --force-reinstall --no-deps\n"
+        "then re-run. Pass --allow-uncompiled to bench anyway (FK/branch counts are still valid; "
+        "timing is not)."
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--arm", help="benchmark only this arm (e.g. xarm7_ik); default all")
@@ -305,7 +374,18 @@ def main() -> int:
         action="store_true",
         help="measure only EAIK (leave the ssik [bench] numbers untouched)",
     )
+    parser.add_argument(
+        "--allow-uncompiled",
+        action="store_true",
+        help="bench even if the Cython perf extensions are not compiled (timing "
+        "will not match shipped wheels; for FK/branch-count refreshes only)",
+    )
     args = parser.parse_args()
+
+    # ssik timing is only meaningful against the compiled perf extensions the
+    # wheel ships (see #248). EAIK-only refreshes don't touch ssik timing.
+    if not args.eaik_only:
+        _require_compiled_perf_extensions(allow_uncompiled=args.allow_uncompiled)
 
     manifest = load_manifest()
     names = [args.arm] if args.arm else list(manifest.keys())

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -69,8 +69,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur5_ik.bench]
-ms_mean = 1.89
-ms_ci95 = 0.16
+ms_mean = 1.77
+ms_ci95 = 0.13
 max_fk = 6.3e-12
 sols_min = 2
 sols_max = 8
@@ -106,8 +106,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur3e_ik.bench]
-ms_mean = 2.04
-ms_ci95 = 0.12
+ms_mean = 2.03
+ms_ci95 = 0.11
 max_fk = 1.4e-08
 sols_min = 2
 sols_max = 8
@@ -143,7 +143,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur5e_ik.bench]
-ms_mean = 1.83
+ms_mean = 1.85
 ms_ci95 = 0.13
 max_fk = 2e-09
 sols_min = 2
@@ -217,7 +217,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur16e_ik.bench]
-ms_mean = 1.87
+ms_mean = 1.89
 ms_ci95 = 0.13
 max_fk = 1.4e-08
 sols_min = 2
@@ -254,8 +254,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur20_ik.bench]
-ms_mean = 1.89
-ms_ci95 = 0.15
+ms_mean = 1.8
+ms_ci95 = 0.13
 max_fk = 1.4e-08
 sols_min = 2
 sols_max = 8
@@ -291,7 +291,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.ur30_ik.bench]
-ms_mean = 1.91
+ms_mean = 1.93
 ms_ci95 = 0.13
 max_fk = 2e-09
 sols_min = 2
@@ -328,7 +328,7 @@ fk_ceiling_fuzz = 1e-12
 platform_drift = false
 
 [arms.puma560_ik.bench]
-ms_mean = 0.21
+ms_mean = 0.22
 ms_ci95 = 0.0
 max_fk = 8.3e-12
 sols_min = 8
@@ -372,7 +372,7 @@ drift_markers = [
 ]
 
 [arms.jaco2_ik.bench]
-ms_mean = 0.89
+ms_mean = 0.87
 ms_ci95 = 0.02
 max_fk = 8e-07
 sols_min = 2
@@ -404,8 +404,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.iiwa14_ik.bench]
-ms_mean = 4.53
-ms_ci95 = 0.08
+ms_mean = 4.84
+ms_ci95 = 0.02
 max_fk = 1e-13
 sols_min = 128
 sols_max = 128
@@ -442,8 +442,8 @@ drift_markers = [
 ]
 
 [arms.gen3_ik.bench]
-ms_mean = 51.25
-ms_ci95 = 0.97
+ms_mean = 40.75
+ms_ci95 = 0.91
 max_fk = 9.9e-13
 sols_min = 11
 sols_max = 92
@@ -475,8 +475,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.franka_panda_ik.bench]
-ms_mean = 3.04
-ms_ci95 = 0.1
+ms_mean = 3.0
+ms_ci95 = 0.11
 max_fk = 1.3e-11
 sols_min = 32
 sols_max = 132
@@ -507,8 +507,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.xarm7_ik.bench]
-ms_mean = 8.87
-ms_ci95 = 0.19
+ms_mean = 6.87
+ms_ci95 = 0.15
 max_fk = 1e-10
 sols_min = 53
 sols_max = 96
@@ -544,8 +544,8 @@ drift_markers = [
 ]
 
 [arms.xarm6_ik.bench]
-ms_mean = 1.02
-ms_ci95 = 0.01
+ms_mean = 1.04
+ms_ci95 = 0.02
 max_fk = 2.5e-06
 sols_min = 8
 sols_max = 16
@@ -576,7 +576,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.z1_ik.bench]
-ms_mean = 1.5
+ms_mean = 1.52
 ms_ci95 = 0.11
 max_fk = 2.8e-15
 sols_min = 4
@@ -618,8 +618,8 @@ drift_markers = [
 ]
 
 [arms.piper_ik.bench]
-ms_mean = 2.5
-ms_ci95 = 1.64
+ms_mean = 2.01
+ms_ci95 = 1.01
 max_fk = 9.8e-06
 sols_min = 2
 sols_max = 8
@@ -651,8 +651,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon4_ik.bench]
-ms_mean = 15.94
-ms_ci95 = 0.22
+ms_mean = 16.55
+ms_ci95 = 0.55
 max_fk = 2.8e-07
 sols_min = 4
 sols_max = 60
@@ -684,8 +684,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.kassow_kr810_ik.bench]
-ms_mean = 16.69
-ms_ci95 = 0.21
+ms_mean = 16.52
+ms_ci95 = 0.23
 max_fk = 5.4e-08
 sols_min = 4
 sols_max = 42
@@ -717,8 +717,8 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.rizon10_ik.bench]
-ms_mean = 15.57
-ms_ci95 = 0.22
+ms_mean = 15.13
+ms_ci95 = 0.2
 max_fk = 5.5e-08
 sols_min = 6
 sols_max = 64
@@ -754,7 +754,7 @@ drift_markers = [
 ]
 
 [arms.fanuc_crx10ial_ik.bench]
-ms_mean = 0.97
+ms_mean = 0.96
 ms_ci95 = 0.01
 max_fk = 2.3e-06
 sols_min = 4
@@ -792,7 +792,7 @@ drift_markers = [
 ]
 
 [arms.yam_ik.bench]
-ms_mean = 1.03
+ms_mean = 1.02
 ms_ci95 = 0.01
 max_fk = 3.5e-07
 sols_min = 5
@@ -861,7 +861,7 @@ fk_ceiling_fuzz = 1e-4
 platform_drift = false
 
 [arms.fr3_ik.bench]
-ms_mean = 2.93
+ms_mean = 2.83
 ms_ci95 = 0.08
 max_fk = 1.3e-11
 sols_min = 32
@@ -893,8 +893,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_left_ik.bench]
-ms_mean = 12.67
-ms_ci95 = 0.07
+ms_mean = 12.97
+ms_ci95 = 0.11
 max_fk = 2.6e-14
 sols_min = 128
 sols_max = 128
@@ -925,8 +925,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_right_ik.bench]
-ms_mean = 12.7
-ms_ci95 = 0.15
+ms_mean = 12.96
+ms_ci95 = 0.12
 max_fk = 4.3e-15
 sols_min = 128
 sols_max = 128
@@ -957,8 +957,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_left_ik.bench]
-ms_mean = 12.73
-ms_ci95 = 0.07
+ms_mean = 12.94
+ms_ci95 = 0.25
 max_fk = 3.3e-15
 sols_min = 128
 sols_max = 128
@@ -989,8 +989,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_right_ik.bench]
-ms_mean = 12.6
-ms_ci95 = 0.09
+ms_mean = 12.92
+ms_ci95 = 0.11
 max_fk = 2.7e-15
 sols_min = 128
 sols_max = 128
@@ -1025,8 +1025,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_thor_ik.bench]
-ms_mean = 2.52
-ms_ci95 = 0.09
+ms_mean = 2.44
+ms_ci95 = 0.06
 max_fk = 3.5e-12
 sols_min = 1
 sols_max = 4
@@ -1056,7 +1056,7 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_core_ik.bench]
-ms_mean = 2.48
+ms_mean = 2.47
 ms_ci95 = 0.06
 max_fk = 2.4e-12
 sols_min = 1
@@ -1092,8 +1092,8 @@ fk_ceiling_fuzz = 1e-7
 platform_drift = false
 
 [arms.standardbots_spark_ik.bench]
-ms_mean = 2.44
-ms_ci95 = 0.07
+ms_mean = 2.46
+ms_ci95 = 0.06
 max_fk = 8.8e-13
 sols_min = 1
 sols_max = 4

--- a/tests/test_perf_extensions.py
+++ b/tests/test_perf_extensions.py
@@ -1,0 +1,99 @@
+"""Guards that the Cython perf extensions are measured + shipped compiled.
+
+A dev checkout that built ``poe_fk.so`` but not ``refinement.so`` ran the
+refinement layer in pure-Python mode. ``regen_bench`` measured that and the
+inflated numbers were committed as authoritative (gen3 51 vs 37 ms, piper 2.5
+vs 1.1 ms). The annotated ``.py`` sources import fine either way, so nothing
+functional caught it -- only the timing was wrong.
+
+Three guards now prevent a recurrence, and this module pins their invariants:
+
+1. ``regen_bench`` refuses to measure ssik timing against uncompiled perf
+   extensions (unless ``--allow-uncompiled``).
+2. The cibuildwheel ``test-command`` asserts each perf-target module loads from
+   a compiled ``.so`` in the built wheel.
+3. Both of the above are single-sourced from ``hatch_build.CYTHON_TARGETS``;
+   the drift test below fails if a new target is added without updating the
+   wheel smoke check.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "scripts"))
+
+import regen_bench  # noqa: E402
+
+
+def _cython_target_modules() -> list[str]:
+    """Module names of hatch_build.CYTHON_TARGETS (parsed, no hatchling import)."""
+    tree = ast.parse((_REPO / "hatch_build.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign):
+            named = isinstance(node.target, ast.Name) and node.target.id == "CYTHON_TARGETS"
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            named = any(isinstance(t, ast.Name) and t.id == "CYTHON_TARGETS" for t in node.targets)
+            value = node.value
+        else:
+            continue
+        if named and value is not None:
+            paths = ast.literal_eval(value)
+            return [
+                p.removeprefix("src/")
+                .removesuffix(".py")
+                .removesuffix("/__init__")
+                .replace("/", ".")
+                for p in paths
+            ]
+    raise AssertionError("CYTHON_TARGETS not found in hatch_build.py")
+
+
+def _wheel_smoke_command() -> str:
+    """The full cibuildwheel test-command string (all checks concatenated)."""
+    cfg = tomllib.loads((_REPO / "pyproject.toml").read_text())
+    return "\n".join(cfg["tool"]["cibuildwheel"]["test-command"])
+
+
+def test_wheel_smoke_covers_every_cython_target() -> None:
+    """Every compiled perf target must be asserted-compiled by the wheel smoke
+    check. Adding a CYTHON_TARGET without a matching wheel assertion (so a wheel
+    could ship it uncompiled and undetected) fails here."""
+    smoke = _wheel_smoke_command()
+    for mod in _cython_target_modules():
+        assert mod in smoke, (
+            f"{mod} is a hatch_build.CYTHON_TARGETS compile target but the "
+            f"cibuildwheel test-command does not assert it loads compiled. Add a "
+            f'\'{mod}.__file__.endswith((".so", ".pyd"))\' check to test-command.'
+        )
+    # And the check must actually verify a compiled extension, not merely import.
+    assert ".so" in smoke
+    assert "endswith" in smoke
+
+
+def test_regen_bench_gate_blocks_uncompiled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bench gate hard-errors on uncompiled perf extensions and passes when
+    they are compiled -- independent of this checkout's own build state."""
+    monkeypatch.setattr(regen_bench, "_uncompiled_perf_extensions", lambda: ["ssik.refinement"])
+    with pytest.raises(SystemExit, match="refusing to measure"):
+        regen_bench._require_compiled_perf_extensions(allow_uncompiled=False)
+    # Escape hatch warns but proceeds.
+    regen_bench._require_compiled_perf_extensions(allow_uncompiled=True)
+    # All-compiled passes.
+    monkeypatch.setattr(regen_bench, "_uncompiled_perf_extensions", list)
+    regen_bench._require_compiled_perf_extensions(allow_uncompiled=False)
+
+
+def test_uncompiled_detector_parses_targets() -> None:
+    """The detector resolves the same modules as CYTHON_TARGETS and returns a
+    subset of them (whichever are currently uncompiled in this env)."""
+    targets = set(_cython_target_modules())
+    assert targets == {"ssik.refinement", "ssik.kinematics.poe_fk"}
+    assert set(regen_bench._uncompiled_perf_extensions()) <= targets

--- a/tests/test_perf_extensions.py
+++ b/tests/test_perf_extensions.py
@@ -29,7 +29,7 @@ import pytest
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO / "scripts"))
 
-import regen_bench  # noqa: E402
+import regen_bench  # type: ignore[import-not-found]  # noqa: E402
 
 
 def _cython_target_modules() -> list[str]:


### PR DESCRIPTION
## The bug (measurement, not code)

`hatch_build.CYTHON_TARGETS` cythonizes both `poe_fk` and `refinement` (#248). A dev checkout that built only `poe_fk.so` ran the **refinement** layer (`kinbody_jacobian`, `lm_refine_batch`) in pure-Python mode. The annotated `.py` sources import fine that way, so every functional test passed — but `regen_bench` measured refinement-heavy arms far slower than they ship, and those numbers were committed as authoritative:

| arm | committed (uncompiled) | compiled | delta |
|---|---|---|---|
| gen3 | 51.25 ms | **40.75** | −20% |
| piper | 2.50 | **2.01** | −20% |
| xarm7 | 8.87 | **6.87** | −23% |

Only SRS/`_polished`/RR arms move — non-refining arms are within ±7% (machine noise), which is the tell.

## Three guards — bulletproof, single-sourced from `CYTHON_TARGETS`

1. **`regen_bench` gate** — refuses to measure ssik timing unless every perf-target module's `__file__` is a compiled `.so`/`.pyd`. Targets are parsed out of `hatch_build.py` via AST (no `hatchling` import). `--allow-uncompiled` escapes for FK/branch-only refreshes (with a loud warning).
2. **Wheel smoke check** — the cibuildwheel `test-command` asserts each target loads compiled in the *built wheel*, so a wheel that silently failed to cythonize can't publish.
3. **Drift test** (`tests/test_perf_extensions.py`) — pins the gate logic and **fails if a new `CYTHON_TARGETS` entry lacks a matching wheel smoke assertion**, so the guards can't silently fall out of sync.

## Numbers corrected

Re-benched the roster with compiled refinement (per-arm min of two runs). gen3/piper/xarm7 drop ~20%; everything else unchanged (confirming the machine is comparable).

## Test plan
- New guard tests: 3 passed (gate fires on uncompiled, passes compiled, wheel-smoke covers every target)
- Doc-drift + manifest: 102 passed
- Full suite: **1733 passed**, 0 failures
- Verified the gate: fires `SystemExit` on uncompiled, warns+proceeds with `--allow-uncompiled`

Note: this also reframes gen3 — its "51ms" was ~20% dev-measurement inflation; real is ~41ms (still slow vs iiwa14's 5ms, addressed separately by the rescue/batching levers).