### PR TITLE
Refresh docs with post-lever-C Gen3 number (~13ms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 | Puma 560 (Pieper 6R, spherical wrist) | 4 ± 0 µs / FK 8e-12 / 8 sols | 220 ± 0 µs / FK 8e-12 / 8 sols |
 | JACO 2 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 870 ± 20 µs / FK 8e-7 / 2-12 sols |
 | iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.84 ± 0.02 ms / FK 1e-13 / 128 sols |
-| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 40.75 ± 0.91 ms / FK 1e-12 / 11-92 sols |
+| Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.87 ± 0.27 ms / FK 1e-12 / 11-92 sols |
 | Franka Panda (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 3.00 ± 0.11 ms / FK 1e-11 / 32-132 sols |
 | xArm7 (**approx spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 6.87 ± 0.15 ms / FK 1e-10 / 53-96 sols |
 | xArm6 (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.04 ± 0.02 ms / FK 3e-6 / 8-16 sols |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ ssik dispatches to one of 11 analytical solvers based on the arm's kinematic top
 |---|---|---|---|
 | 0 — closed-form 6R | `three_parallel`, `spherical_two_parallel`, `spherical_two_intersecting`, `spherical` | ~1 ms | SP1–SP6 composition; one branch per Pieper specialisation |
 | 0 — closed-form 7R (SRS) | `seven_r.srs` | ~5 ms full sweep | Singh-Kreutz 1989 parameterised by elbow swivel angle; 8 branches × 16 swivel samples = 128 IKs (vectorised inner loop, [#217](https://github.com/personalrobotics/ssik/issues/217)). Per-candidate FK verify deferred to post-dedup (#246). |
-| 0 — approximate SRS + LM polish | `seven_r.srs_polished` | ~40 ms full sweep | Relaxed Singh-Kreutz (small-drift arms) + batched LM polish to machine precision against the original URDF FK |
+| 0 — approximate SRS + LM polish | `seven_r.srs_polished` | ~13 ms full sweep | Relaxed Singh-Kreutz (small-drift arms) + batched LM polish (batched FK+Jacobian over the candidate set) to machine precision against the original URDF FK |
 | 1 — univariate search | `two_parallel`, `two_intersecting` | ~100 ms – 2 s | tan-half-angle reduction + 200-sample search + Newton polish |
 | 1 — 7R joint-lock wrapper | `jointlock.seven_r` | ~5-30 ms tier-0 inner; **~17 ms with cached-RR ([#210](https://github.com/personalrobotics/ssik/issues/210))** when artifact-built | lock one joint, dispatch inner 6R, sweep 16 lock samples; Raghavan-Roth pre-baked at codegen for non-Pieper sub-chains |
 | 2 — Raghavan–Roth + Manocha–Canny | `ikgeo.general_6r` | ~0.6-5 ms | numeric RR resultant with AE-3 leftvar selection; **production tier-2** |

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -442,8 +442,8 @@ drift_markers = [
 ]
 
 [arms.gen3_ik.bench]
-ms_mean = 40.75
-ms_ci95 = 0.91
+ms_mean = 12.87
+ms_ci95 = 0.27
 max_fk = 9.9e-13
 sols_min = 11
 sols_max = 92


### PR DESCRIPTION
Final numbers refresh after the gen3 perf stack (#404 guard, #405 rescue, #406 batched FK+Jacobian) landed. Gen3's `srs_polished` solve dropped **40.75 → ~13ms** (batched FK+Jacobian, #406); this updates the number everywhere it appears.

## Changes (docs-only)
- **MANIFEST bench + README EAIK table**: gen3 40.75 → **12.87ms**.
- **docs/architecture.md**: the `srs_polished` tier row said "~40 ms full sweep" → "~13 ms".

## Machine-variance handling
A full-roster re-bench showed *every* unaffected arm rising a uniform ~15% — this machine is slower after a very long session, not a regression. Writing that would pollute the whole table with machine variance (the recurring lesson from #403). So **only gen3 is updated**, and its measured 14.79ms is normalized to the committed reference machine via the median factor of the control arms (those lever A/C don't touch): `14.79 / 1.15 = 12.87ms` — which matches the direct median measurement (12.7ms). Every other arm keeps its committed reference value.

The `regen_bench` compiled-extension gate (#404) was active for this measurement (refinement compiled), so the number reflects the shipped wheel.

## Test plan
- Doc-drift + manifest + perf-extension guards: 102 passed
- Swept README/docs/outreach for other stale gen3/srs_polished timings — none remain