### PR TITLE
Fix rescue completeness regression from the batched refine (#405)

### DIFF
--- a/src/ssik/refinement/rescue.py
+++ b/src/ssik/refinement/rescue.py
@@ -196,6 +196,15 @@ def rescue_via_T_perturbation(
                 T_target,
                 fk_atol=min(_TIGHT_POLISH_FK_ATOL, fk_atol),
                 max_iters=refinement_max_iters,
+                # Match the loose divergence tolerance the per-candidate lm_refine
+                # rescue used (5.0 / 4). lm_refine_batch defaults to the tight
+                # 2.0 / 2 tuned for srs_polished (#203); that tighter guard aborts
+                # rescuable perturbed candidates whose trajectory dips before
+                # converging, dropping valid solutions (piper lost 3 of 6 on a
+                # ridge pose). Rescue seeds land off-ridge and genuinely converge,
+                # so the loose tolerance recovers the full set.
+                divergence_factor=5.0,
+                divergence_min_iters=4,
             )
             polished = zip(q_polished, fk_resids, strict=True)
         else:

--- a/tests/test_refinement_rescue.py
+++ b/tests/test_refinement_rescue.py
@@ -229,3 +229,34 @@ def test_rescue_polishes_well_conditioned_to_machine_precision_384() -> None:
         f"rescue left a branch under-polished at {worst:.2e} (> gen3 1e-9 ceiling); "
         f"the tight polish should reach machine precision on this well-conditioned pose"
     )
+
+
+def test_batched_rescue_recovers_full_set_piper_ridge() -> None:
+    """Regression: the batched rescue (#405) must recover the SAME solution set
+    as the per-candidate rescue it replaced.
+
+    lm_refine_batch defaults to a tight divergence tolerance (2.0 / 2, tuned for
+    srs_polished #203); the per-candidate lm_refine rescue used the loose 5.0 / 4.
+    Inheriting the tight default aborted rescuable perturbed candidates whose
+    trajectory dips before converging, dropping valid solutions -- this piper
+    ridge pose (normal solve returns 0) recovered 6 distinct machine-precision
+    IKs at v3.2.0 but only 3 after #405 until the rescue passed 5.0 / 4 through.
+    """
+    piper = pytest.importorskip("ssik.prebuilt.piper_ik")
+    q = np.array(
+        [0.6062325102, 0.4261052819, -0.0456657578, 0.398668829, -0.6750285024, -0.5471984045]
+    )
+    t = piper.fk(q)
+    assert not piper.solve(t, respect_limits=False, allow_rescue=False), (
+        "expected an empty analytical solve (a genuine rescue pose)"
+    )
+    sols = piper.solve(t, respect_limits=False)
+    assert len(sols) >= 6, f"batched rescue recovered {len(sols)} sols, expected the full 6"
+    # Every recovered solution FK-closes and they are distinct.
+    for s in sols:
+        assert float(np.max(np.abs(piper.fk(s.q) - t))) < 1e-6
+    qs = [s.q for s in sols]
+    for i in range(len(qs)):
+        for j in range(i + 1, len(qs)):
+            gap = float(np.max(np.abs((qs[i] - qs[j] + np.pi) % (2.0 * np.pi) - np.pi)))
+            assert gap > 1e-3, "rescue returned duplicate solutions"


### PR DESCRIPTION
**Found by a pre-v3.3.0 audit** comparing solution counts against v3.2.0 across the whole roster.

## The regression
Lever A (#405) replaced the per-candidate tight-then-loose `lm_refine` rescue with one `lm_refine_batch` call — but `lm_refine_batch` defaults to a **tight** divergence tolerance (`2.0 / 2`, tuned for srs_polished in #203), while the per-candidate `lm_refine` it replaced used the **loose** default (`5.0 / 4`). The tighter guard aborts rescuable perturbed candidates whose Newton trajectory dips before converging, so the rescue silently returned **fewer** solutions.

Concretely: a piper ridge pose (normal solve returns 0) recovered **6** distinct machine-precision IKs at v3.2.0, but only **3** after #405. Every other arm matched — this was the *one* behaviour change for an existing arm in the entire unreleased window (#390–#407), and per `docs/semver_policy.md` a dropped valid branch is **breaking**. So it must be fixed before the release, not shipped.

## The fix
Pass `divergence_factor=5.0` / `divergence_min_iters=4` through to the rescue's `lm_refine_batch`, matching the original `lm_refine` behaviour. Rescue seeds land off-ridge and genuinely converge, so the loose tolerance is correct here (the tight default only makes sense for srs_polished's dense in-workspace sweep).

## Verification
- piper ridge pose: **6/6 restored**.
- Re-ran the full v3.2.0-vs-main solution-count comparison (30 arms × 60 poses): **zero differences** on every common arm. Existing arms now behave identically to v3.2.0 → clean MINOR.
- Regression guard `test_batched_rescue_recovers_full_set_piper_ridge` pins the exact pose + ≥6 distinct FK-closing recovery.
- rescue/general_6r/HP subset: 724 passed.

This clears the last blocker for tagging **v3.3.0**.