### PR TITLE
Harden Husty-Pfurner against singular-matrix crashes

### DIFF
--- a/src/ssik/solvers/husty_pfurner/_back_substitute.py
+++ b/src/ssik/solvers/husty_pfurner/_back_substitute.py
@@ -443,26 +443,35 @@ def solve_ik(
     skip_chain_check = fk_tol >= 0.1
 
     for u, w in pairs:
-        candidates = back_substitute_one(
-            pre,
-            sigma_E_arr,
-            float(u),
-            float(w),
-            a_1=a_1,
-            l_1=l_1,
-            d_2=d_2,
-            a_2=a_2,
-            l_2=l_2,
-            d_3=d_3,
-            a_3=a_3,
-            l_3=l_3,
-            d_4=d_4,
-            a_4=a_4,
-            l_4=l_4,
-            d_5=d_5,
-            a_5=a_5,
-            l_5=l_5,
-        )
+        try:
+            candidates = back_substitute_one(
+                pre,
+                sigma_E_arr,
+                float(u),
+                float(w),
+                a_1=a_1,
+                l_1=l_1,
+                d_2=d_2,
+                a_2=a_2,
+                l_2=l_2,
+                d_3=d_3,
+                a_3=a_3,
+                l_3=l_3,
+                d_4=d_4,
+                a_4=a_4,
+                l_4=l_4,
+                d_5=d_5,
+                a_5=a_5,
+                l_5=l_5,
+            )
+        except np.linalg.LinAlgError:
+            # Singular Cramer matrix at this (u, w): the back-substitution
+            # is degenerate for this root, so skip it like a candidate that
+            # fails FK closure. One degenerate root must never crash the
+            # whole solve -- the remaining well-conditioned roots still
+            # yield valid IK. (Mirrors the elimination-stage guard in
+            # ``eliminate_uw_pairs``.)
+            continue
         for v_1, v_2, v_3, v_4, v_5, v_6 in candidates:
             if skip_chain_check:
                 out.append([v_1, v_2, v_3, v_4, v_5, v_6])

--- a/src/ssik/solvers/husty_pfurner/_eliminate.py
+++ b/src/ssik/solvers/husty_pfurner/_eliminate.py
@@ -1020,9 +1020,23 @@ def eliminate_uw_pairs(
             )
             if residue < accept_tol:
                 refined.append((u_ref, w_ref))
-    if not refined and last_error is not None:
-        raise last_error
     if not refined:
+        # Every drop index hit a singular Cramer/pencil matrix (or produced
+        # no accepted candidate). This is a degenerate pose for HP's
+        # interpolation-based elimination, not an error to propagate: the
+        # correct solver contract is "no HP-extractable solution here"
+        # (is_ls=True upstream), never an unhandled ``LinAlgError``. Such
+        # poses are a known HP coverage gap on general (non-locked) 6R
+        # geometries -- ``ikgeo.general_6r`` (Raghavan-Roth) is the tier-2
+        # solver for those; HP is only dispatched on locked-7R sub-chains,
+        # where this path does not trigger. Surface the cause at debug level
+        # for diagnosis without crashing the caller.
+        if last_error is not None:
+            _LOG.debug(
+                "HP elimination: all drops %s singular (%s); returning no candidates",
+                drop_indices,
+                type(last_error).__name__,
+            )
         return np.empty((0, 2), dtype=np.float64)
     # Cluster-merge in (u, w) Euclidean space. Multiplicity-k splits and
     # duplicates from different drops cluster within sqrt(eps); two

--- a/tests/test_husty_pfurner_robustness.py
+++ b/tests/test_husty_pfurner_robustness.py
@@ -1,0 +1,81 @@
+"""HP must never raise on any pose -- it returns ``([], is_ls=True)`` for
+poses it cannot solve, never an unhandled exception.
+
+Regression for the singular-matrix crash: on general (non-locked) 6R
+geometries such as the FANUC CRX-10iA/L, HP's interpolation-based
+elimination hits a singular Cramer/pencil matrix on a large fraction of
+poses. Before the fix, ``eliminate_uw_pairs`` re-raised that
+``LinAlgError`` (and a second unguarded ``np.linalg.solve`` in the
+back-substitution path could raise too), so ``solve()`` crashed instead
+of degrading to "no solution here". ~59/100 random FANUC poses crashed.
+
+HP is never *dispatched* on general 6R (Raghavan-Roth is the tier-2
+solver for those; HP only runs on locked-7R sub-chains). But a caller
+that invokes HP directly on such an arm must get the empty-result
+contract, not an exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ssik._urdf import load_urdf_kinbody_normalized
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.husty_pfurner.general_6r import solve as hp_solve
+
+REPO = Path(__file__).resolve().parent.parent
+FANUC_URDF = REPO / "tests" / "fixtures" / "fanuc_crx10ial.urdf"
+
+# A pose that reproduced the singular-matrix crash before the fix
+# (every drop index singular in ``eliminate_uw_pairs``).
+_CRASHING_Q = np.array(
+    [
+        2.245637299378165,
+        -2.930568260297326,
+        1.442967726722393,
+        -2.0379158390962826,
+        2.281920468786123,
+        0.2605085298868298,
+    ]
+)
+
+
+@pytest.fixture(scope="module")
+def fanuc_kb():
+    return load_urdf_kinbody_normalized(FANUC_URDF, "base_link", "flange")
+
+
+def test_hp_pinned_singular_pose_does_not_crash(fanuc_kb):
+    """The exact pose that used to raise ``LinAlgError`` now returns
+    cleanly, and an empty result carries ``is_ls=True``."""
+    T = poe_forward_kinematics(fanuc_kb, _CRASHING_Q)
+    sols, is_ls = hp_solve(fanuc_kb, T, allow_refinement=True)
+    # Whatever HP returns, it must not raise. If it found nothing, the
+    # least-squares flag must say so (the documented empty contract).
+    if not sols:
+        assert is_ls, "HP returned no solutions but is_ls=False"
+    # Any returned solution must be a real FK-closing IK, not a spurious
+    # degenerate root that slipped through.
+    for s in sols:
+        assert s.fk_residual < 1e-6, f"spurious HP solution: fk={s.fk_residual:.3e}"
+
+
+def test_hp_never_raises_on_fanuc_fuzz(fanuc_kb):
+    """No random FANUC pose escapes an unhandled ``LinAlgError`` from HP.
+    Before the fix, ~59/100 crashed."""
+    rng = np.random.default_rng(0)
+    crashes = 0
+    for _ in range(100):
+        q = rng.uniform(-np.pi, np.pi, size=6)
+        T = poe_forward_kinematics(fanuc_kb, q)
+        try:
+            sols, is_ls = hp_solve(fanuc_kb, T, allow_refinement=True)
+        except np.linalg.LinAlgError:
+            crashes += 1
+            continue
+        if not sols:
+            assert is_ls, "HP returned no solutions but is_ls=False"
+    assert crashes == 0, f"HP raised LinAlgError on {crashes}/100 FANUC poses"


### PR DESCRIPTION
## Why

Follow-up to the #409 HP retire-vs-keep evaluation. That evaluation concluded **keep HP** — it's load-bearing for symmetric-DH locked-7R sub-chains (live Raghavan-Roth misses q_truth on 9/20 of those and is 20–75 s), which the general-6R eval had masked. But the eval did surface one genuine robustness bug: **HP raises an unhandled `numpy.linalg.LinAlgError` (`Singular matrix`) on a large fraction of general-6R poses** — ~59/100 random FANUC CRX-10iA/L poses crashed `solve()` instead of returning empty.

HP is never *dispatched* on general 6R (Raghavan-Roth is the tier-2 solver there; HP only runs on locked-7R sub-chains, where this path doesn't trigger). But a caller that invokes HP directly must get the documented empty-result contract, not an exception.

## Root cause

Two paths could propagate the `LinAlgError`:

1. `eliminate_uw_pairs` already catches the per-drop `LinAlgError` and continues, but **re-raised** the last one when *every* drop index came up singular (a degenerate pose for HP's interpolation-based elimination).
2. The back-substitution `_cramer_P_at` (`np.linalg.solve`) was **unguarded**, so a singular Cramer matrix at one `(u, w)` root crashed the whole solve.

## Fix

Both stages now treat a singular matrix as "no HP-extractable solution for this pose/root" and skip it — the correct solver contract, not papering over anything (these poses are a known HP coverage gap on general 6R; RR is the solver for them):

- All-singular elimination returns an empty candidate set (`is_ls=True` upstream) with a debug-level log.
- A singular back-substitution root is skipped like an FK-closure failure, so the remaining well-conditioned roots still yield valid IK.

## Verification

- **FANUC: 0/100 crashes** (was 59). Solved poses actually **rise 41 → 69**, because poses that previously crashed *mid-solve* (losing all candidates) now complete and return their valid ones; the 31 empties are `is_ls=True`.
- **Locked-7R domain unchanged** (HP's actual production use): `test_husty_pfurner_locked_7r` still 41 passed / 2 known-#376 xfail.
- Full HP + jointlock suites green (550 passed); two jaco2 RR-parity oracles flipped to XPASS — a positive side effect of skipping degenerate roots.

## Test plan

New `tests/test_husty_pfurner_robustness.py`:
- pins the exact pose that used to crash, asserts a clean return + `is_ls=True` on empty + FK-closure on any returned solution;
- fuzzes 100 FANUC poses asserting **zero** `LinAlgError` escapes.

Refs #409.