### PR TITLE
Vectorize the general Davenport SRS sweep (rebase + reconcile #368)

### DIFF
--- a/src/ssik/kinematics/_generalized_euler.py
+++ b/src/ssik/kinematics/_generalized_euler.py
@@ -32,10 +32,33 @@ carrying ``R^T n1`` onto ``Rot(n2, b)^T n1``.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 __all__ = ["decompose_3axis"]
+
+# Constant identity -- np.eye(3) allocates + fills on every call (~0.8 us);
+# these 3-vector/3x3 hot paths run it hundreds of times per solve.
+_EYE3 = np.eye(3, dtype=np.float64)
+
+
+def _cross3(a: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Scalar 3-vector cross product. ~12x faster than ``np.cross`` on
+    length-3 inputs, which pays for axis-normalization + moveaxis machinery
+    irrelevant to a single 3-vector."""
+    a0, a1, a2 = a[0], a[1], a[2]
+    b0, b1, b2 = b[0], b[1], b[2]
+    return np.array(
+        [a1 * b2 - a2 * b1, a2 * b0 - a0 * b2, a0 * b1 - a1 * b0], dtype=np.float64
+    )
+
+
+def _norm3(a: NDArray[np.float64]) -> float:
+    """Euclidean norm of a 3-vector. ~2x faster than ``np.linalg.norm``,
+    which pays for ravel + complex-type checks + dispatcher."""
+    return math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2])
 
 # Below this the b-sinusoid amplitude sqrt(A^2 + B^2) is ~0: the three axes are
 # (near-)collinear and no general decomposition exists. SRS shoulder/wrist
@@ -48,10 +71,10 @@ _GIMBAL_EPS = 1e-9
 
 def _axis_angle_matrix(axis: NDArray[np.float64], theta: float) -> NDArray[np.float64]:
     """Rodrigues rotation matrix for ``theta`` about a unit ``axis``."""
-    c, s = np.cos(theta), np.sin(theta)
+    c, s = math.cos(theta), math.sin(theta)
     x, y, z = axis
     k = np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]], dtype=np.float64)
-    out: NDArray[np.float64] = np.eye(3, dtype=np.float64) + s * k + (1.0 - c) * (k @ k)
+    out: NDArray[np.float64] = _EYE3 + s * k + (1.0 - c) * (k @ k)
     return out
 
 
@@ -59,7 +82,7 @@ def _unit_perp(axis: NDArray[np.float64]) -> NDArray[np.float64]:
     """Some unit vector perpendicular to ``axis``."""
     ref = np.array([1.0, 0.0, 0.0]) if abs(axis[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
     v = ref - axis * (axis @ ref)
-    unit: NDArray[np.float64] = v / np.linalg.norm(v)
+    unit: NDArray[np.float64] = v / _norm3(v)
     return unit
 
 
@@ -74,9 +97,9 @@ def _angle_about(
     """
     vf = v_from - axis * (axis @ v_from)
     vt = v_to - axis * (axis @ v_to)
-    if np.linalg.norm(vf) < _GIMBAL_EPS or np.linalg.norm(vt) < _GIMBAL_EPS:
+    if _norm3(vf) < _GIMBAL_EPS or _norm3(vt) < _GIMBAL_EPS:
         return 0.0
-    return float(np.arctan2(axis @ np.cross(vf, vt), vf @ vt))
+    return float(np.arctan2(axis @ _cross3(vf, vt), vf @ vt))
 
 
 def decompose_3axis(
@@ -97,12 +120,12 @@ def decompose_3axis(
     u1 = np.asarray(n1, dtype=np.float64)
     u2 = np.asarray(n2, dtype=np.float64)
     u3 = np.asarray(n3, dtype=np.float64)
-    u1 = u1 / np.linalg.norm(u1)
-    u2 = u2 / np.linalg.norm(u2)
-    u3 = u3 / np.linalg.norm(u3)
+    u1 = u1 / _norm3(u1)
+    u2 = u2 / _norm3(u2)
+    u3 = u3 / _norm3(u3)
 
     a_coef = u1 @ u3 - (u1 @ u2) * (u2 @ u3)
-    b_coef = u1 @ np.cross(u2, u3)
+    b_coef = u1 @ _cross3(u2, u3)
     c_const = u1 @ R @ u3 - (u1 @ u2) * (u2 @ u3)
 
     amplitude = float(np.hypot(a_coef, b_coef))
@@ -125,7 +148,7 @@ def decompose_3axis(
         # ``a = 0`` and recover ``c`` from the residual ``Rot(n2,-b) R``, which
         # is then a pure ``n3`` rotation. (Hit by symmetric ZYZ triples at
         # b = 0 / pi -- classical Euler gimbal.)
-        if np.linalg.norm(vf - u1 * (u1 @ vf)) < _GIMBAL_EPS:
+        if _norm3(vf - u1 * (u1 @ vf)) < _GIMBAL_EPS:
             a = 0.0
             residual = _axis_angle_matrix(u2, -b) @ R
             ref = _unit_perp(u3)

--- a/src/ssik/kinematics/_generalized_euler.py
+++ b/src/ssik/kinematics/_generalized_euler.py
@@ -158,3 +158,115 @@ def decompose_3axis(
             c = _angle_about(u3, rt_n1, rb.T @ u1)
         out.append((a, b, c))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Batched variants (vectorise over a leading N axis of rotation matrices).
+#
+# For a *fixed* triple of axes (n1, n2, n3) -- the SRS-class case, where the
+# joint axes are constant across the swivel sweep -- the b-sinusoid amplitude
+# and phase are scalars; only the ``u1 . R u3`` term and the per-branch frame
+# algebra vary per row. These helpers evaluate the scalar :func:`decompose_3axis`
+# math for an ``(N, 3, 3)`` stack of ``R`` in one broadcast, so the general
+# SRS sweep runs branch-batched like the canonical ZYZ path.
+# ---------------------------------------------------------------------------
+
+
+def _rodrigues_axis_batch(
+    axis: NDArray[np.float64], angles: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Rodrigues matrices for a fixed unit ``axis`` and ``(N,)`` ``angles`` ->
+    ``(N, 3, 3)``."""
+    c = np.cos(angles)
+    s = np.sin(angles)
+    omc = 1.0 - c
+    x, y, z = float(axis[0]), float(axis[1]), float(axis[2])
+    k = np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]], dtype=np.float64)
+    k2 = k @ k
+    return (
+        _EYE3[None, :, :]
+        + s[:, None, None] * k[None, :, :]
+        + omc[:, None, None] * k2[None, :, :]
+    )
+
+
+def _angle_about_batch(
+    axis: NDArray[np.float64],
+    v_from: NDArray[np.float64],
+    v_to: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Vectorised :func:`_angle_about` over ``(N, 3)`` vector stacks (``v_from``
+    may be ``(3,)`` and broadcasts). Gimbal rows (vanishing perpendicular
+    component) return ``0.0``, matching the scalar contract."""
+    vf = v_from - axis * (v_from @ axis)[..., None]
+    vt = v_to - axis * (v_to @ axis)[..., None]
+    vf = np.broadcast_to(vf, vt.shape)
+    num = np.cross(vf, vt) @ axis
+    den = np.einsum("ni,ni->n", vf, vt)
+    out = np.arctan2(num, den)
+    nf = np.linalg.norm(vf, axis=1)
+    nt = np.linalg.norm(vt, axis=1)
+    out[(nf < _GIMBAL_EPS) | (nt < _GIMBAL_EPS)] = 0.0
+    return out
+
+
+def decompose_3axis_batch(
+    R: NDArray[np.float64],
+    n1: ArrayLike,
+    n2: ArrayLike,
+    n3: ArrayLike,
+) -> tuple[list[tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]], bool]:
+    """Batched :func:`decompose_3axis` for an ``(N, 3, 3)`` stack ``R`` and a
+    single fixed axis triple.
+
+    :returns: ``(branches, ok)``. ``ok`` is ``False`` iff the axes are
+        (near-)collinear (no decomposition exists for any row) -- then
+        ``branches`` is empty. Otherwise ``branches`` holds the two b-solution
+        branches, each a ``(a, b, c)`` tuple of ``(N,)`` arrays. Unlike the
+        scalar variant this always emits *both* branches (even at the
+        ``delta -> 0`` boundary where they coincide); the coincident duplicates
+        are collapsed by the caller's dedup pass.
+    """
+    R = np.asarray(R, dtype=np.float64)
+    u1 = np.asarray(n1, dtype=np.float64)
+    u2 = np.asarray(n2, dtype=np.float64)
+    u3 = np.asarray(n3, dtype=np.float64)
+    u1 = u1 / _norm3(u1)
+    u2 = u2 / _norm3(u2)
+    u3 = u3 / _norm3(u3)
+
+    a_coef = float(u1 @ u3 - (u1 @ u2) * (u2 @ u3))
+    b_coef = float(u1 @ _cross3(u2, u3))
+    amplitude = float(np.hypot(a_coef, b_coef))
+    if amplitude < _DEGENERATE_AMPLITUDE:
+        return [], False
+
+    # c_const per row: u1 . R u3.
+    c_const = np.einsum("i,nij,j->n", u1, R, u3) - (u1 @ u2) * (u2 @ u3)
+    phi = float(np.arctan2(b_coef, a_coef))
+    delta = np.arccos(np.clip(c_const / amplitude, -1.0, 1.0))  # (N,)
+
+    r_n3 = R @ u3  # (N, 3)
+    rt_n1 = np.einsum("nij,i->nj", R, u1)  # R^T u1, (N, 3)
+    ref = _unit_perp(u3)  # (3,), constant
+
+    branches: list[tuple[NDArray, NDArray, NDArray]] = []
+    for b in (phi + delta, phi - delta):  # each (N,)
+        rb = _rodrigues_axis_batch(u2, b)  # (N, 3, 3)
+        vf = np.einsum("nij,j->ni", rb, u3)  # (N, 3)
+        # Non-gimbal outer angles.
+        a_ng = _angle_about_batch(u1, vf, r_n3)
+        rbT_u1 = np.einsum("nij,i->nj", rb, u1)  # rb^T u1, (N, 3)
+        c_ng = _angle_about_batch(u3, rt_n1, rbT_u1)
+        # Gimbal rows: Rot(n2,b) n3 parallel to n1 -> pin a = 0, recover c from
+        # the residual Rot(n2,-b) R (a pure n3 rotation).
+        gim = np.linalg.norm(vf - u1 * (vf @ u1)[:, None], axis=1) < _GIMBAL_EPS
+        a = np.where(gim, 0.0, a_ng)
+        c = c_ng
+        if gim.any():
+            rb_inv = _rodrigues_axis_batch(u2, -b)
+            residual = rb_inv @ R  # (N, 3, 3)
+            c_g = _angle_about_batch(u3, ref, residual @ ref)
+            c = np.where(gim, c_g, c_ng)
+        branches.append((a, b, c))
+    return branches, True

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -73,7 +73,7 @@ from ssik.kinematics._generalized_euler import (
     _axis_angle_matrix,
     _cross3,
     _norm3,
-    decompose_3axis,
+    decompose_3axis_batch,
 )
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import (
@@ -184,6 +184,80 @@ def _frame_at_joint_batch(
     return R, p
 
 
+def _rodrigues_axes_batch(
+    axes: NDArray[np.float64], angles: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Rodrigues matrices for *per-row* ``axes`` ``(N, 3)`` and ``angles``
+    ``(N,)`` -> ``(N, 3, 3)``. Unlike :func:`_rodrigues_batch` (fixed axis),
+    the rotation axis varies per row -- needed for the shoulder-roll about the
+    per-swivel elbow direction ``d_hat``."""
+    c = np.cos(angles)
+    s = np.sin(angles)
+    omc = 1.0 - c
+    ax, ay, az = axes[:, 0], axes[:, 1], axes[:, 2]
+    n = axes.shape[0]
+    K = np.zeros((n, 3, 3), dtype=np.float64)
+    K[:, 0, 1] = -az
+    K[:, 0, 2] = ay
+    K[:, 1, 0] = az
+    K[:, 1, 2] = -ax
+    K[:, 2, 0] = -ay
+    K[:, 2, 1] = ax
+    K2 = K @ K
+    return (
+        np.eye(3)[None, :, :]
+        + s[:, None, None] * K
+        + omc[:, None, None] * K2
+    )
+
+
+def _min_rotation_batch(
+    u_home: NDArray[np.float64], v_batch: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Vectorised :func:`_min_rotation`: minimal rotations carrying ``u_home``
+    onto each row of ``v_batch`` ``(N, 3)`` -> ``(N, 3, 3)``. The rare
+    (anti)parallel rows (cross product degenerate) fall back to the scalar
+    path to preserve its exact perpendicular-axis choice."""
+    u = u_home / _norm3(u_home)
+    vn = v_batch / np.linalg.norm(v_batch, axis=1, keepdims=True)
+    c = vn @ u  # (N,)
+    axis = np.cross(np.broadcast_to(u, vn.shape), vn)  # (N, 3)
+    an = np.linalg.norm(axis, axis=1)  # (N,)
+    ok = an > 1e-9
+    axu = np.zeros_like(axis)
+    axu[ok] = axis[ok] / an[ok, None]
+    out = _rodrigues_axes_batch(axu, np.arccos(np.clip(c, -1.0, 1.0)))
+    for idx in np.nonzero(~ok)[0]:
+        out[idx] = _min_rotation(u_home, v_batch[idx])
+    return out
+
+
+def _sp4_branches_batch(
+    h: NDArray[np.float64],
+    k: NDArray[np.float64],
+    p: NDArray[np.float64],
+    delta: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.bool_]]:
+    """Vectorised :func:`_sp4_branches` over ``(N, 3)`` vector stacks.
+
+    :returns: ``(q_a, q_b, valid)`` -- the two elbow branches ``(N,)`` and a
+        ``(N,)`` mask that is ``False`` where the projection is unreachable
+        (``|C| > |A,B|``) or the amplitude degenerates. Both branches coincide
+        where ``off -> 0``; the duplicate is collapsed downstream by dedup."""
+    h_dot_k = np.einsum("ni,ni->n", h, k)
+    k_dot_p = np.einsum("ni,ni->n", k, p)
+    a_coef = np.einsum("ni,ni->n", h, p) - h_dot_k * k_dot_p
+    b_coef = np.einsum("ni,ni->n", h, np.cross(k, p))
+    c_const = delta - h_dot_k * k_dot_p
+    amplitude = np.hypot(a_coef, b_coef)
+    valid = amplitude >= 1e-12
+    ratio = np.where(valid, c_const / np.where(valid, amplitude, 1.0), 2.0)
+    valid &= np.abs(ratio) <= 1.0 + 1e-9
+    base = np.arctan2(b_coef, a_coef)
+    off = np.arccos(np.clip(ratio, -1.0, 1.0))
+    return base + off, base - off, valid
+
+
 def _shoulder_angles_zyz(
     d: NDArray[np.float64], q_1_sign: int
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -220,32 +294,6 @@ def _min_rotation(u: NDArray[np.float64], v: NDArray[np.float64]) -> NDArray[np.
         return _axis_angle_matrix(perp / _norm3(perp), np.pi)
     axis = _cross3(u, v)
     return _axis_angle_matrix(axis / _norm3(axis), float(np.arccos(c)))
-
-
-def _sp4_branches(
-    h: NDArray[np.float64], k: NDArray[np.float64], p: NDArray[np.float64], delta: float
-) -> tuple[float, ...]:
-    """Subproblem 4: solve ``h . (Rot(k, q) p) == delta`` for ``q``.
-
-    ``A cos q + B sin q == C`` with ``A = h.p - (h.k)(k.p)``,
-    ``B = h.(k x p)``, ``C = delta - (h.k)(k.p)`` -- up to two roots
-    ``atan2(B, A) +/- arccos(C / |A,B|)`` (the elbow-up / elbow-down pair).
-    Empty when the projection is unreachable (``|C| > |A,B|``).
-    """
-    h_dot_k = float(h @ k)
-    k_dot_p = float(k @ p)
-    a_coef = float(h @ p) - h_dot_k * k_dot_p
-    b_coef = float(h @ _cross3(k, p))
-    c_const = delta - h_dot_k * k_dot_p
-    amplitude = float(np.hypot(a_coef, b_coef))
-    if amplitude < 1e-12:
-        return ()
-    ratio = c_const / amplitude
-    if abs(ratio) > 1.0 + 1e-9:
-        return ()
-    base = float(np.arctan2(b_coef, a_coef))
-    off = float(np.arccos(np.clip(ratio, -1.0, 1.0)))
-    return (base + off,) if off < 1e-12 else (base + off, base - off)
 
 
 def _verify_fk(
@@ -586,41 +634,55 @@ def solve(
         n3_axis = n_axes[cls.elbow_index]
         n4_axis, n5_axis, n6_axis = n_axes[4], n_axes[5], n_axes[6]
         forearm_home = cls.wrist_pivot - origins[cls.elbow_index]  # elbow -> wrist at q = 0
-        for i in range(N):
-            elbow = E_t[i]
-            upper = elbow - S  # S -> elbow (target), length L_se
-            d_hat = d[i]
-            # R0: a reference shoulder rotation placing the elbow (upper_home
-            # -> upper). The true shoulder also rolls about d_hat by phi.
-            r0 = _min_rotation(upper_home, upper)
-            wrist_vec = W_t - elbow  # elbow -> wrist pivot (target), length L_ew
 
-            # q_3 (elbow): the wrist-pivot latitude along the upper arm,
-            # ``d_hat . (W - E)``, is invariant under the shoulder roll about
-            # d_hat, so it fixes q_3. SP4 on the forearm rotated by R0.
-            k_elbow = r0 @ n3_axis
-            v_forearm0 = r0 @ forearm_home
-            for q_3 in _sp4_branches(d_hat, k_elbow, v_forearm0, float(wrist_vec @ d_hat)):
-                g = _axis_angle_matrix(n3_axis, q_3) @ forearm_home
-                g = r0 @ g  # forearm direction at this q_3, before the roll
-                # phi (shoulder roll about d_hat) mapping g onto wrist_vec: SP1.
-                g_perp = g - d_hat * float(d_hat @ g)
-                w_perp = wrist_vec - d_hat * float(d_hat @ wrist_vec)
-                if _norm3(g_perp) < 1e-9:
-                    phi = 0.0
-                else:
-                    phi = float(
-                        np.arctan2(float(d_hat @ _cross3(g_perp, w_perp)), float(g_perp @ w_perp))
-                    )
-                r_sh = _axis_angle_matrix(d_hat, phi) @ r0
-                r_pre_elbow = r_sh @ _axis_angle_matrix(n3_axis, q_3)
-                r_res = r_pre_elbow.T @ R_target @ R_post_wrist.T
-                wrist_branches = decompose_3axis(r_res, n4_axis, n5_axis, n6_axis)
-                for s0, s1, s2 in decompose_3axis(r_sh, n0_axis, n1_axis, n2_axis):
-                    for w4, w5, w6 in wrist_branches:
-                        capped = _append(np.array([s0, s1, s2, q_3, w4, w5, w6], dtype=np.float64))
-                        if capped is not None:
-                            return capped, False
+        # Batched over the N swivels (mirrors the canonical path's structure:
+        # discrete branch enumeration outside, one broadcast per branch). The
+        # elbow direction ``d`` and the target wrist offset vary per swivel; the
+        # joint axes are constant, so the Davenport coefficients reduce to
+        # scalars inside ``decompose_3axis_batch``.
+        uppers = E_t - S  # (N, 3): S -> elbow (target)
+        wrist_vecs = W_t - E_t  # (N, 3): elbow -> wrist pivot (target)
+        # R0: reference shoulder rotations placing the elbow (upper_home -> upper).
+        r0 = _min_rotation_batch(upper_home, uppers)  # (N, 3, 3)
+        k_elbow = np.einsum("nij,j->ni", r0, n3_axis)  # (N, 3)
+        v_forearm0 = np.einsum("nij,j->ni", r0, forearm_home)  # (N, 3)
+        # q_3 (elbow): wrist-pivot latitude along the upper arm fixes it; SP4 on
+        # the forearm rotated by R0. Two elbow branches, both computed.
+        delta_sp4 = np.einsum("ni,ni->n", wrist_vecs, d)  # wrist_vec . d_hat
+        q3a, q3b, sp4_valid = _sp4_branches_batch(d, k_elbow, v_forearm0, delta_sp4)
+
+        # Wrist post-rotation folded once (r_res = r_pre_elbow^T @ R_target @ R_post^T).
+        M_wrist = R_target @ R_post_wrist.T  # (3, 3)
+        dw = np.einsum("ni,ni->n", d, wrist_vecs)  # d_hat . wrist_vec (roll-invariant)
+
+        for q3 in (q3a, q3b):  # each (N,)
+            rot_n3_q3 = _rodrigues_batch(n3_axis, q3)  # (N, 3, 3)
+            g = np.einsum("nij,j->ni", rot_n3_q3, forearm_home)  # axis_angle(n3,q3) @ forearm
+            g = np.einsum("nij,nj->ni", r0, g)  # r0 @ g (forearm dir before roll)
+            # phi (shoulder roll about d_hat) mapping g onto wrist_vec: SP1.
+            g_perp = g - d * np.einsum("ni,ni->n", d, g)[:, None]
+            w_perp = wrist_vecs - d * dw[:, None]
+            num = np.einsum("ni,ni->n", d, np.cross(g_perp, w_perp))
+            den = np.einsum("ni,ni->n", g_perp, w_perp)
+            phi = np.arctan2(num, den)
+            phi[np.linalg.norm(g_perp, axis=1) < 1e-9] = 0.0
+
+            r_sh = _rodrigues_axes_batch(d, phi) @ r0  # (N, 3, 3)
+            r_pre_elbow = r_sh @ rot_n3_q3  # (N, 3, 3)
+            r_res = np.einsum("nij,jk->nik", r_pre_elbow.transpose(0, 2, 1), M_wrist)
+
+            sh_branches, sh_ok = decompose_3axis_batch(r_sh, n0_axis, n1_axis, n2_axis)
+            wr_branches, wr_ok = decompose_3axis_batch(r_res, n4_axis, n5_axis, n6_axis)
+            if not (sh_ok and wr_ok):
+                continue
+            for s0, s1, s2 in sh_branches:  # up to 2 shoulder branches
+                for w4, w5, w6 in wr_branches:  # up to 2 wrist branches
+                    q_full = np.stack([s0, s1, s2, q3, w4, w5, w6], axis=1)  # (N, 7)
+                    keep = sp4_valid & np.all(np.isfinite(q_full), axis=1)
+                    for row in np.nonzero(keep)[0]:
+                        candidates.append(
+                            Solution(q=q_full[row], fk_residual=0.0, refinement_used="none")
+                        )
 
     if not candidates:
         return [], True

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -61,6 +61,7 @@ References:
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -68,7 +69,12 @@ from numpy.typing import NDArray
 
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.kinematics._generalized_euler import _axis_angle_matrix, decompose_3axis
+from ssik.kinematics._generalized_euler import (
+    _axis_angle_matrix,
+    _cross3,
+    _norm3,
+    decompose_3axis,
+)
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import (
     SrsClassification,
@@ -111,8 +117,8 @@ def _swivel_basis(
     # Pick a reference vector that's not too aligned with u_sw.
     ref = np.array([0.0, 0.0, 1.0]) if abs(u_sw[2]) < 0.99 else np.array([1.0, 0.0, 0.0])
     u_perp1 = ref - np.dot(ref, u_sw) * u_sw
-    u_perp1 /= np.linalg.norm(u_perp1)
-    u_perp2 = np.cross(u_sw, u_perp1)
+    u_perp1 /= _norm3(u_perp1)
+    u_perp2 = _cross3(u_sw, u_perp1)
     return u_perp1, u_perp2
 
 
@@ -201,19 +207,19 @@ def _shoulder_angles_zyz(
 
 def _min_rotation(u: NDArray[np.float64], v: NDArray[np.float64]) -> NDArray[np.float64]:
     """Minimal rotation matrix carrying the direction of ``u`` onto ``v``."""
-    u = u / np.linalg.norm(u)
-    v = v / np.linalg.norm(v)
+    u = u / _norm3(u)
+    v = v / _norm3(v)
     c = float(u @ v)
     if c > 1.0 - 1e-12:
         return np.eye(3, dtype=np.float64)
     if c < -1.0 + 1e-12:
         # Antiparallel: rotate pi about any axis perpendicular to u.
-        perp = np.cross(u, np.array([1.0, 0.0, 0.0]))
-        if float(np.linalg.norm(perp)) < 1e-6:
-            perp = np.cross(u, np.array([0.0, 1.0, 0.0]))
-        return _axis_angle_matrix(perp / np.linalg.norm(perp), np.pi)
-    axis = np.cross(u, v)
-    return _axis_angle_matrix(axis / np.linalg.norm(axis), float(np.arccos(c)))
+        perp = _cross3(u, np.array([1.0, 0.0, 0.0]))
+        if _norm3(perp) < 1e-6:
+            perp = _cross3(u, np.array([0.0, 1.0, 0.0]))
+        return _axis_angle_matrix(perp / _norm3(perp), np.pi)
+    axis = _cross3(u, v)
+    return _axis_angle_matrix(axis / _norm3(axis), float(np.arccos(c)))
 
 
 def _sp4_branches(
@@ -229,7 +235,7 @@ def _sp4_branches(
     h_dot_k = float(h @ k)
     k_dot_p = float(k @ p)
     a_coef = float(h @ p) - h_dot_k * k_dot_p
-    b_coef = float(h @ np.cross(k, p))
+    b_coef = float(h @ _cross3(k, p))
     c_const = delta - h_dot_k * k_dot_p
     amplitude = float(np.hypot(a_coef, b_coef))
     if amplitude < 1e-12:
@@ -260,7 +266,8 @@ def _verify_fk(
     out: list[Solution] = []
     for s in sols:
         T_fk = poe_forward_kinematics(kb, s.q)
-        fk_residual = float(np.linalg.norm(T_fk - t_target))
+        _d = (T_fk - t_target).ravel()
+        fk_residual = math.sqrt(float(_d @ _d))
         if fk_residual <= fk_threshold:
             # Direct construction beats dataclasses.replace (~10 us per
             # call) on the warm-path post-dedup loop.
@@ -572,7 +579,7 @@ def solve(
         # Unit axes + home forearm (built lazily: the canonical hot path above
         # never needs them, and the per-call cost matters at max_solutions=1).
         n_axes = [
-            np.asarray(jt.axis, dtype=np.float64) / float(np.linalg.norm(jt.axis))
+            np.asarray(jt.axis, dtype=np.float64) / _norm3(np.asarray(jt.axis, dtype=np.float64))
             for jt in kb.joints
         ]
         n0_axis, n1_axis, n2_axis = n_axes[0], n_axes[1], n_axes[2]
@@ -599,11 +606,11 @@ def solve(
                 # phi (shoulder roll about d_hat) mapping g onto wrist_vec: SP1.
                 g_perp = g - d_hat * float(d_hat @ g)
                 w_perp = wrist_vec - d_hat * float(d_hat @ wrist_vec)
-                if float(np.linalg.norm(g_perp)) < 1e-9:
+                if _norm3(g_perp) < 1e-9:
                     phi = 0.0
                 else:
                     phi = float(
-                        np.arctan2(float(d_hat @ np.cross(g_perp, w_perp)), float(g_perp @ w_perp))
+                        np.arctan2(float(d_hat @ _cross3(g_perp, w_perp)), float(g_perp @ w_perp))
                     )
                 r_sh = _axis_angle_matrix(d_hat, phi) @ r0
                 r_pre_elbow = r_sh @ _axis_angle_matrix(n3_axis, q_3)

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -296,6 +296,36 @@ def _min_rotation(u: NDArray[np.float64], v: NDArray[np.float64]) -> NDArray[np.
     return _axis_angle_matrix(axis / _norm3(axis), float(np.arccos(c)))
 
 
+def _sp4_branches(
+    h: NDArray[np.float64], k: NDArray[np.float64], p: NDArray[np.float64], delta: float
+) -> tuple[float, ...]:
+    """Subproblem 4: solve ``h . (Rot(k, q) p) == delta`` for ``q``.
+
+    ``A cos q + B sin q == C`` with ``A = h.p - (h.k)(k.p)``,
+    ``B = h.(k x p)``, ``C = delta - (h.k)(k.p)`` -- up to two roots
+    ``atan2(B, A) +/- arccos(C / |A,B|)`` (the elbow-up / elbow-down pair).
+    Empty when the projection is unreachable (``|C| > |A,B|``).
+
+    Scalar per-swivel form retained alongside :func:`_sp4_branches_batch`
+    for the exact in-limits swivel resolver (``_swivel_limits``, #369),
+    which walks candidate swivels one at a time rather than as a batch.
+    """
+    h_dot_k = float(h @ k)
+    k_dot_p = float(k @ p)
+    a_coef = float(h @ p) - h_dot_k * k_dot_p
+    b_coef = float(h @ _cross3(k, p))
+    c_const = delta - h_dot_k * k_dot_p
+    amplitude = float(np.hypot(a_coef, b_coef))
+    if amplitude < 1e-12:
+        return ()
+    ratio = c_const / amplitude
+    if abs(ratio) > 1.0 + 1e-9:
+        return ()
+    base = float(np.arctan2(b_coef, a_coef))
+    off = float(np.arccos(np.clip(ratio, -1.0, 1.0)))
+    return (base + off,) if off < 1e-12 else (base + off, base - off)
+
+
 def _verify_fk(
     sols: list[Solution],
     kb: KinBody,


### PR DESCRIPTION
Rebase and integration of @griffin-norris's #368 onto current main, which it was 33 commits behind.

## What (from #368)

Speeds up the native SRS solver's **general Davenport path** (`seven_r.srs`, the branch taken by non-canonical concurrent-axis arms — Galaxea R1 Pro, OpenArm):
1. Scalar 3-vector ops (`_cross3`/`_norm3`/module identity const) on the per-swivel hot path, where `np.cross`/`np.linalg.norm`/`np.eye(3)` are dominated by dispatch overhead on length-3 vectors.
2. Vectorize the general swivel sweep (enumerate the 2×2×2 branches outside, broadcast all N swivels per branch) — the same pattern main already uses for the canonical ZYZ path (#217), now extended to the general path which was still a scalar loop.

## Why the extra commit

#368 branched before **#369** (exact feasible-swivel joint-limit resolution) landed. #369's `_swivel_limits.resolve_in_limits` imports the scalar `_sp4_branches` from `srs.py`, which #368 had replaced with `_sp4_branches_batch`. The third commit restores the scalar `_sp4_branches` alongside the batch form so both coexist (the vectorized sweep uses `_batch`; the scalar per-swivel resolver uses the scalar). Textual rebase was clean; this was a semantic interface the rebase didn't catch.

## Verification

- **Behavior-identical to main**: a solution-set parity harness (5 SRS arms × 40 seeded poses — iiwa14 canonical + r1pro/openarm general path) shows **0 differing poses** vs main, worst FK 2.3e-14.
- **Full suite green**: test_seven_r_srs, srs_polished, swivel_limits (#369), generalized_euler, r1pro L/R, openarm L/R, iiwa14 — **86 passed** incl. `--runslow`.
- **Speedup on current main**: r1pro_left full enumeration **26.43 → 15.56 ms/solve (−41%)**. (The −64% in #368 was vs its pre-#369 baseline; #369's coverage resolver added overhead the vectorization now offsets.)
- ruff + mypy clean.

Supersedes #368 (that fork branch can't be pushed to directly for the rebase). Closes #368.