### PR TITLE
Refresh bench numbers for the general-path SRS arms (post-#415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,10 +406,10 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 | YAM (**non-Pieper 6R**) | **refuses** ("6R-Unknown Kinematic Class") | 1.02 ± 0.01 ms / FK 3e-7 / 5-8 sols |
 | big_yam (**non-Pieper 6R**) | **refuses** ("Intersection point can't be calculated for two parallel axes") | 1.01 ± 0.01 ms / FK 7e-7 / 8 sols |
 | FR3 (**spherical-shoulder 7R**) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 2.83 ± 0.08 ms / FK 1e-11 / 32-132 sols |
-| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.97 ± 0.11 ms / FK 3e-14 / 128 sols |
-| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.96 ± 0.12 ms / FK 4e-15 / 128 sols |
-| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.94 ± 0.25 ms / FK 3e-15 / 128 sols |
-| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.92 ± 0.11 ms / FK 3e-15 / 128 sols |
+| OpenArm L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.54 ± 0.29 ms / FK 3e-14 / 128 sols |
+| OpenArm R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.25 ± 0.04 ms / FK 4e-15 / 128 sols |
+| R1 Pro L (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.39 ± 0.29 ms / FK 3e-15 / 128 sols |
+| R1 Pro R (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.36 ± 0.21 ms / FK 3e-15 / 128 sols |
 | Thor (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.44 ± 0.06 ms / FK 4e-12 / 1-4 sols |
 | Core (Pieper 6R, three-parallel) | 4 ± 0 µs / FK 9e-16 / 2-6 sols | 2.47 ± 0.06 ms / FK 2e-12 / 1-4 sols |
 | Spark (Pieper 6R, three-parallel) | **refuses** ("classifies as 6R-THREE_INNER_PARALLEL but returns FK-incorrect solutions (max FK 3e+00)") | 2.46 ± 0.06 ms / FK 9e-13 / 1-4 sols |

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -893,8 +893,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_left_ik.bench]
-ms_mean = 12.97
-ms_ci95 = 0.11
+ms_mean = 4.54
+ms_ci95 = 0.29
 max_fk = 2.6e-14
 sols_min = 128
 sols_max = 128
@@ -925,8 +925,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.openarm_right_ik.bench]
-ms_mean = 12.96
-ms_ci95 = 0.12
+ms_mean = 4.25
+ms_ci95 = 0.04
 max_fk = 4.3e-15
 sols_min = 128
 sols_max = 128
@@ -957,8 +957,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_left_ik.bench]
-ms_mean = 12.94
-ms_ci95 = 0.25
+ms_mean = 4.39
+ms_ci95 = 0.29
 max_fk = 3.3e-15
 sols_min = 128
 sols_max = 128
@@ -989,8 +989,8 @@ fk_ceiling_fuzz = 1e-10
 platform_drift = false
 
 [arms.r1pro_right_ik.bench]
-ms_mean = 12.92
-ms_ci95 = 0.11
+ms_mean = 4.36
+ms_ci95 = 0.21
 max_fk = 2.7e-15
 sols_min = 128
 sols_max = 128

--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -46,8 +46,9 @@ Both paths emit up to 8 candidates per swivel; FK closure filters
 spurious, cluster-merge (wrap-to-π) deduplicates across swivels.
 
 Per-arm cold-cache cost: ~0 (no symbolic precompute). Pure-Python;
-canonical path is sub-millisecond, the general path ~13 ms on the full
-16-swivel sweep (sub-millisecond for ``max_solutions=1``).
+canonical path is sub-millisecond, the general path ~4-5 ms on the full
+16-swivel sweep (vectorized over the swivel batch, #368; sub-millisecond
+for ``max_solutions=1``).
 
 References:
 


### PR DESCRIPTION
## Why

#415 vectorized the SRS **general Davenport path**, but the four arms it sped up still showed their pre-#415 bench numbers (~12.9 ms). This refreshes them.

## Scope — only the 4 affected arms

#415 touched *only* the general path. Canonical iiwa14 (ZYZ) and gen3 (`srs_polished`, always canonical) are byte-unchanged, as is every non-SRS arm. Confirmed by using them as controls (iiwa14 ratio **1.01×**). Re-benching all 30 would only inject machine-variance drift into unchanged rows, so they're left as-is.

## Method

`scripts/regen_bench` methodology (compiled perf extensions, median-of-5), normalized to the reference machine by the median ratio of three unchanged controls (iiwa14 / xarm6 / franka_panda):

| arm | before | after |
|---|---|---|
| r1pro_left | 12.94 | **4.39** |
| r1pro_right | 12.92 | **4.36** |
| openarm_left | 12.97 | **4.54** |
| openarm_right | 12.96 | **4.25** |

~2.9× across the board. FK and sol-counts are unchanged — the bench uses `respect_limits=False` and #415 is behavior-neutral (0 parity diffs), so only the timing fields moved.

## Files

MANIFEST.toml (4 bench blocks) → regen_docs → README table; plus the `srs.py` docstring (~13 → ~4–5 ms general path).