### PR TITLE
Fix poe_to_dh terminal frame for skew wrists (#418)

### DIFF
--- a/src/ssik/kinematics/poe_to_dh.py
+++ b/src/ssik/kinematics/poe_to_dh.py
@@ -245,20 +245,36 @@ def poe_to_dh(kb: KinBody) -> DhWithOffset:
         origins.append(foot_curr)
 
     # Frame n = tool flange. z_n from T_home[:3, 2], origin from T_home[:3, 3].
-    # x_n: project x_{n-1} onto plane perpendicular to z_n.
+    # x_n must satisfy the DH constraint x_n ⟂ z_{n-1} so the terminal transform
+    # A_n is a valid single DH step; t_post then absorbs the fixed offset from
+    # this DH frame n to the true flange.
+    #
+    # When z_{n-1} ∦ z_n (a *skew* wrist -- joint n's axis not parallel to the
+    # flange z), x_n is forced to ±(z_{n-1} x z_n), which is ⟂ both. The old
+    # code instead projected x_{n-1} onto ⟂z_n; that is ⟂z_{n-1} only in the
+    # parallel case, and it degenerates to an arbitrary reference direction when
+    # x_{n-1} ∥ z_n -- exactly the FANUC CRX non-/L geometry (joint 6 ⟂ flange,
+    # flange origin on joint 6's axis), where it silently produced alpha[n-1]=0
+    # instead of ±pi/2 and broke the FK_POE = T_pre @ FK_DH @ T_post invariant
+    # by O(1) (#418). Parallel/anti-parallel wrists (all currently shipped RR
+    # arms) keep the historical projection, so their DH is unchanged.
     z_n = t_home[:3, 2]
     o_n = t_home[:3, 3]
     z_axes.append(z_n)
-    x_prev = x_axes[-1]
-    x_proj = x_prev - _dot3(x_prev, z_n) * z_n
-    x_proj_norm = _norm3(x_proj)
-    if x_proj_norm < 1e-9:
-        ref = np.array([1.0, 0.0, 0.0])
-        if abs(_dot3(ref, z_n)) > 0.99:
-            ref = np.array([0.0, 1.0, 0.0])
-        x_proj = ref - _dot3(ref, z_n) * z_n
+    if abs(_dot3(z_axes[n - 1], z_n)) < 1.0 - 1e-9:
+        cross = _cross3(z_axes[n - 1], z_n)
+        x_axes.append(cross / _norm3(cross))
+    else:
+        x_prev = x_axes[-1]
+        x_proj = x_prev - _dot3(x_prev, z_n) * z_n
         x_proj_norm = _norm3(x_proj)
-    x_axes.append(x_proj / x_proj_norm)
+        if x_proj_norm < 1e-9:
+            ref = np.array([1.0, 0.0, 0.0])
+            if abs(_dot3(ref, z_n)) > 0.99:
+                ref = np.array([0.0, 1.0, 0.0])
+            x_proj = ref - _dot3(ref, z_n) * z_n
+            x_proj_norm = _norm3(x_proj)
+        x_axes.append(x_proj / x_proj_norm)
     origins.append(o_n)
 
     # Compute (alpha_i, a_i, d_i, theta_offset_i) for i=1..n, transitioning

--- a/tests/fixtures/fanuc_crx10ia.urdf
+++ b/tests/fixtures/fanuc_crx10ia.urdf
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot name="crx10ia">
+  <link name="world" />
+  <link name="base_link">
+    </link>
+  <link name="J1_link">
+    </link>
+  <link name="J2_link">
+    </link>
+  <link name="J3_link">
+    </link>
+  <link name="J4_link">
+    </link>
+  <link name="J5_link">
+    </link>
+  <link name="J6_link">
+    </link>
+  <joint name="J1" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 0.245" />
+    <parent link="base_link" />
+    <child link="J1_link" />
+    <axis xyz="0 0 1" />
+    <limit effort="400" lower="-3.3161255787892263" upper="3.3161255787892263" velocity="2.0943951023931953" />
+  </joint>
+  <joint name="J2" type="revolute">
+    <origin rpy="0 0 0" xyz="0.0 0 0" />
+    <parent link="J1_link" />
+    <child link="J2_link" />
+    <axis xyz="0 1 0" />
+    <limit effort="400" lower="-3.139847324337799" upper="3.139847324337799" velocity="2.0943951023931953" />
+  </joint>
+  <joint name="J3" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 0.54" />
+    <parent link="J2_link" />
+    <child link="J3_link" />
+    <axis xyz="0 -1 0" />
+    <limit effort="200" lower="-1.239183768915974" upper="4.380776422505767" velocity="3.141592653589793" />
+  </joint>
+  <joint name="J4" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 0.0" />
+    <parent link="J3_link" />
+    <child link="J4_link" />
+    <axis xyz="-1 0 0" />
+    <limit effort="60" lower="-3.3161255787892263" upper="3.3161255787892263" velocity="3.141592653589793" />
+  </joint>
+  <joint name="J5" type="revolute">
+    <origin rpy="0 0 0" xyz="0.54 0 0" />
+    <parent link="J4_link" />
+    <child link="J5_link" />
+    <axis xyz="0 -1 0" />
+    <limit effort="60" lower="-3.139847324337799" upper="3.139847324337799" velocity="3.141592653589793" />
+  </joint>
+  <joint name="J6" type="revolute">
+    <origin rpy="0 0 0" xyz="0 -0.15 0" />
+    <parent link="J5_link" />
+    <child link="J6_link" />
+    <axis xyz="-1 0 0" />
+    <limit effort="60" lower="-3.9269908169872414" upper="3.9269908169872414" velocity="3.141592653589793" />
+  </joint>
+  <link name="wbase" />
+  <joint name="base_link-wbase" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0.245" />
+    <parent link="base_link" />
+    <child link="wbase" />
+  </joint>
+  <link name="flange" />
+  <joint name="J6-flange" type="fixed">
+    <origin rpy="0 0 0" xyz="0.16 0 0" />
+    <parent link="J6_link" />
+    <child link="flange" />
+  </joint>
+  <link name="fanuc_flange" />
+  <joint name="flange-fanuc_flange" type="fixed">
+    <origin rpy="3.141592653589793 -1.5707963267948966 0.0" xyz="0 0 0" />
+    <parent link="flange" />
+    <child link="fanuc_flange" />
+  </joint>
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0" />
+    <parent link="world" />
+    <child link="base_link" />
+  </joint>
+  <joint name="child_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0" />
+    <parent link="flange" />
+    <child link="tool0" />
+  </joint>
+  <link name="tool0" />
+</robot>

--- a/tests/test_poe_to_dh.py
+++ b/tests/test_poe_to_dh.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 from numpy.typing import NDArray
 
-from ssik._kinbody import KinBody, build_kinbody
+from ssik._kinbody import JointSpec, KinBody, build_kinbody
 from ssik.kinematics.poe_to_dh import poe_to_dh
 from tests.fixtures.ur5 import ur5_specs
 
@@ -84,12 +84,103 @@ def test_poe_to_dh_ur5_alpha_magnitudes(ur5_kb: KinBody) -> None:
 @pytest.mark.parametrize("seed", [0, 1, 7])
 def test_poe_to_dh_fk_roundtrip_ur5(ur5_kb: KinBody, seed: int) -> None:
     """FK_POE(kb, q*) == T_pre @ FK_DH(dh, q* + theta_offset) @ T_post at machine precision."""
-    dh = poe_to_dh(ur5_kb)
+    _assert_invariant(ur5_kb, seed)
+
+
+def _assert_invariant(kb: KinBody, seed: int, n: int = 100) -> None:
+    """The core poe_to_dh contract, over ``n`` random poses at 1e-10:
+
+    FK_POE(kb, q) == T_pre @ FK_DH(alpha, a, d, q + theta_offset) @ T_post
+    """
+    dh = poe_to_dh(kb)
     rng = np.random.default_rng(seed)
-    for _ in range(100):
-        q = rng.uniform(-np.pi, np.pi, size=6)
-        T_poe = _fk_poe(ur5_kb, q)
+    for _ in range(n):
+        q = rng.uniform(-np.pi, np.pi, size=len(kb.joints))
+        T_poe = _fk_poe(kb, q)
         T_dh = dh.t_pre @ _fk_dh(dh.alpha, dh.a, dh.d, q + dh.theta_offset) @ dh.t_post
         assert np.allclose(T_poe, T_dh, atol=1e-10), (
-            f"POE/DH FK mismatch (seed={seed}); max diff = {np.max(np.abs(T_poe - T_dh)):.3e}"
+            f"POE/DH invariant broken (seed={seed}); max diff = {np.max(np.abs(T_poe - T_dh)):.3e}"
         )
+
+
+def _post_rotation_dh(a: float, alpha: float, d: float) -> NDArray[np.float64]:
+    """``Trans_z(d) Trans_x(a) Rot_x(alpha)`` -- the fixed part of a DH link."""
+    T = np.eye(4, dtype=np.float64)
+    T[2, 3] = d
+    Tx = np.eye(4, dtype=np.float64)
+    Tx[0, 3] = a
+    return T @ Tx @ _rot_axis(np.array([1.0, 0.0, 0.0]), alpha)
+
+
+def _dh_kb(rows: list[tuple[float, float, float]]) -> KinBody:
+    """Build a 6R KinBody from ``(a, alpha, d)`` DH rows (theta=0)."""
+    z = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    specs = [
+        JointSpec(
+            parent_link_T=np.eye(4, dtype=np.float64),
+            axis=z,
+            joint_type="revolute",
+            child_link_T=_post_rotation_dh(a, alpha, d),
+            name=f"j{i}",
+        )
+        for i, (a, alpha, d) in enumerate(rows)
+    ]
+    return build_kinbody(specs)
+
+
+# The terminal joint's twist ``alpha[5]`` sets the angle between joint-6's axis
+# and the flange z-axis: 0/±pi are parallel/anti-parallel wrists (all currently
+# shipped RR arms), everything in between is a *skew* wrist. With a non-zero
+# terminal ``a[5]`` (flange offset perpendicular to joint 6) the skew case is
+# exactly the FANUC CRX non-/L geometry that #418 broke: the old terminal-frame
+# construction violated the DH constraint ``x_n ⟂ z_{n-1}`` and the invariant
+# failed by O(1). This sweep is the self-contained guard.
+@pytest.mark.parametrize(
+    "alpha6",
+    [
+        0.0,
+        np.pi / 6,
+        np.pi / 4,
+        np.pi / 3,
+        np.pi / 2,
+        2 * np.pi / 3,
+        3 * np.pi / 4,
+        np.pi,
+        -np.pi / 2,
+    ],
+)
+def test_poe_to_dh_invariant_terminal_wrist_sweep(alpha6: float) -> None:
+    rows = [
+        (0.10, np.pi / 2, 0.30),
+        (0.40, 0.0, 0.0),
+        (0.35, 0.0, 0.0),
+        (0.0, np.pi / 2, 0.15),
+        (0.0, -np.pi / 2, 0.10),
+        (0.12, alpha6, 0.16),  # offset + arbitrary twist terminal wrist
+    ]
+    _assert_invariant(_dh_kb(rows), seed=3)
+
+
+# Real-arm regression: every shipped RR (tier-2) arm must satisfy the invariant,
+# including the FANUC CRX-10iA base -- the concrete skew-wrist geometry that
+# regressed (#418; joint 6 ⟂ flange with the flange origin on joint 6's axis,
+# a projection degeneracy the synthetic sweep above does not reproduce).
+_RR_FIXTURES = [
+    ("xarm6", "xarm6.urdf", "link_base", "link_eef"),
+    ("piper", "piper.urdf", "base_link", "link6"),
+    ("yam", "yam.urdf", "base_link", "link_6"),
+    ("crx10ial", "fanuc_crx10ial.urdf", "base_link", "tool0"),
+    ("fanuc_crx10ia", "fanuc_crx10ia.urdf", "base_link", "tool0"),
+]
+
+
+@pytest.mark.parametrize(("name", "fixture", "base", "ee"), _RR_FIXTURES)
+def test_poe_to_dh_invariant_rr_arms(name: str, fixture: str, base: str, ee: str) -> None:
+    from pathlib import Path
+
+    from ssik._urdf import load_urdf_kinbody_normalized
+
+    path = Path(__file__).resolve().parent / "fixtures" / fixture
+    if not path.is_file():
+        pytest.skip(f"fixture {fixture} not present")
+    _assert_invariant(load_urdf_kinbody_normalized(path, base, ee), seed=5)


### PR DESCRIPTION
## Root cause (reframed)

#418 was filed as an RR *codegen* bug — the emitted `_solve_algebraic` returning FK-wrong candidates for `a[5]≠0` wrists. Deeper diagnosis showed the composer is faithful; the bug is in **`poe_to_dh`**.

The terminal DH frame set `x_n` by **projecting** `x_{n-1}` onto the plane ⟂`z_n`. That is ⟂`z_{n-1}` (the DH constraint) *only* when `z_{n-1} ∥ z_n`, and it **degenerates to an arbitrary reference direction** when `x_{n-1} ∥ z_n` — exactly the FANUC CRX non-/L geometry (joint 6 ⟂ flange, flange origin on joint 6's axis). It computed `alpha[5]=0` instead of ±π/2, breaking

```
FK_POE(q) = T_pre @ FK_DH(q + theta_offset) @ T_post
```

by O(1). RR then solved a *wrong DH chain*. Live `solve()` only appeared to work because `allow_refinement=True` LM-polished the wrong candidates back to precision; the default path and **every prebuilt artifact** for such an arm returned 0 IKs.

## Fix

When `z_{n-1} ∦ z_n`, force `x_n = normalize(z_{n-1} × z_n)` — ⟂ both by construction. Parallel/anti-parallel wrists (every currently shipped RR arm) keep the historical projection.

- **Shipped arms byte-identical**: jaco2 / xarm6 / piper / yam / big_yam / crx10ial DH maxdiff **exactly 0.0** → no artifact regen, zero regression risk.
- **crx10ia fixed**: algebraic FK **2.0 → 1e-8**; rebuilt artifact **0 sols → 8.4 avg sols**.
- No regression across the RR / general_6r / serialize suites (58 passed).

## Test gap closed

The `poe_to_dh` invariant test only covered **UR5** (a parallel wrist) — that's why this slipped through. Added:
- a self-contained **synthetic terminal-twist sweep** (`alpha[5]` from parallel → skew → anti-parallel, offset flange), and
- a **real-arm regression** over every RR fixture, including the concrete **CRX-10iA** skew-wrist-on-axis geometry (the projection degeneracy the synthetic sweep can't reproduce). Both fail on `main`, pass with the fix.

Unblocks the FANUC CRX sibling onboarding (#301). Fixes #418.