### PR TITLE
add-arm: load package:// vendor URDFs + fix parity base-frame bug (#425)

### DIFF
--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -114,6 +114,27 @@ def _is_xacro(path: Path) -> bool:
     return "xmlns:xacro" in head or "<xacro:" in head
 
 
+def needs_xacro_expansion(path: Path) -> bool:
+    """True if ``path`` actually requires xacro *expansion* -- macro/property
+    tags (``<xacro:...>``) or ``${...}`` / ``$(...)`` substitutions -- as
+    opposed to merely declaring ``xmlns:xacro`` on an already-expanded URDF.
+
+    Many vendor URDFs (ABB YuMi, FANUC) declare the xacro namespace but have
+    no unexpanded macros; running them through the xacro processor there is
+    both unnecessary and harmful -- it forces ROS ``package://`` mesh
+    resolution that fails outside a ROS workspace. Such files can be parsed
+    (and mesh-stripped) as plain XML directly. Only files that return True
+    here need :func:`process_xacro`.
+    """
+    if path.name.lower().endswith(".xacro"):
+        return True
+    try:
+        text = path.read_text(errors="ignore")
+    except OSError:
+        return False
+    return "<xacro:" in text or "${" in text or "$(" in text
+
+
 def process_xacro(source: str | Path, subargs: dict[str, str] | None = None) -> str:
     """Expand a xacro description to a flat URDF string via ``xacrodoc``
     (resolving ``<xacro:include>``, macros, and substitution args).

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -29,7 +29,12 @@ from pathlib import Path
 
 import numpy as np
 
-from ssik._urdf import _as_plain_urdf, load_urdf_kinbody_normalized, strip_urdf_to_fixture
+from ssik._urdf import (
+    _as_plain_urdf,
+    load_urdf_kinbody_normalized,
+    needs_xacro_expansion,
+    strip_urdf_to_fixture,
+)
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.subproblems._rotation import rotation_matrix
@@ -472,23 +477,26 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     if not args.urdf.is_file():
         print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
         return 1
-    # Resolve xacro -> plain URDF once, then load + vendor from the same source
-    # (vendoring a self-contained, expanded URDF, never the raw xacro).
-    with _as_plain_urdf(args.urdf, _parse_xacro_args(args)) as plain_urdf:
-        kb = load_urdf_kinbody_normalized(plain_urdf, args.base, args.ee)
-        print(
-            f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK"
-        )
-
-        print("[ssik add-arm] Classifying topology")
-        plan = dispatch(kb)
-        _print_dispatch_summary(plan)
-
-        rel = urdf_dest.relative_to(repo_root)
-        print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {rel}")
-        n_links, n_joints = strip_urdf_to_fixture(plain_urdf, urdf_dest)
+    # Vendor a mesh-free, kinematics-only fixture FIRST, then load + classify
+    # from THAT (never the mesh-laden source). Stripping meshes up front drops
+    # every ``package://`` reference, so vendor URDFs that declare xmlns:xacro
+    # but reference meshes by ROS package (ABB YuMi, FANUC) load without a ROS
+    # workspace. Only genuinely-macro'd xacro is expanded first.
+    rel = urdf_dest.relative_to(repo_root)
+    print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {rel}")
+    if needs_xacro_expansion(args.urdf):
+        with _as_plain_urdf(args.urdf, _parse_xacro_args(args)) as plain_urdf:
+            n_links, n_joints = strip_urdf_to_fixture(plain_urdf, urdf_dest)
+    else:
+        n_links, n_joints = strip_urdf_to_fixture(args.urdf, urdf_dest)
     kb_bytes = urdf_dest.stat().st_size
     print(f"[ssik add-arm]   stripped to {n_links} links, {n_joints} joints, {kb_bytes:,} bytes")
+
+    kb = load_urdf_kinbody_normalized(urdf_dest, args.base, args.ee)
+    print(f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
+    print("[ssik add-arm] Classifying topology")
+    plan = dispatch(kb)
+    _print_dispatch_summary(plan)
 
     print(f"[ssik add-arm] Generating test scaffold -> {test_dest.relative_to(repo_root)}")
     test_source = _render_test_scaffold(

--- a/tests/test_prebuilt_fixture_parity.py
+++ b/tests/test_prebuilt_fixture_parity.py
@@ -141,7 +141,13 @@ def test_fixture_matches_upstream_urdf(arm_name, description, arm) -> None:
         for i, n in enumerate(ik_names):
             cfg[n] = float(q[i])
         urdf.update_cfg(cfg)
-        T_urdf = np.asarray(urdf.get_transform(arm.ee_link))
+        # Compare in the arm's BASE frame, not the URDF root/world frame:
+        # ssik.fk is base_link -> ee_link, so the upstream pose must be
+        # taken relative to base_link too. For arms whose base_link is not
+        # the URDF root (e.g. YuMi's ``yumi_body``, offset from ``world``),
+        # ``get_transform(ee)`` alone is world->ee and drifts by the
+        # world->base offset -- a false failure.
+        T_urdf = np.asarray(urdf.get_transform(arm.ee_link, arm.base_link))
 
         pos_drift = float(np.linalg.norm(T_urdf[:3, 3] - T_ssik[:3, 3]))
         R_rel = T_urdf[:3, :3] @ T_ssik[:3, :3].T

--- a/tests/test_urdf_ingestion.py
+++ b/tests/test_urdf_ingestion.py
@@ -1,0 +1,76 @@
+"""URDF ingestion robustness: mesh-free loading of vendor URDFs that declare
+``xmlns:xacro`` but reference meshes by ROS ``package://`` (ABB YuMi, FANUC).
+
+Regression for the Wave 1 onboarding friction (#425): such files went through
+the xacro processor (because ``_is_xacro`` matched the namespace) and failed
+with ``PackageNotFoundError`` before any mesh-stripping. The fix strips meshes
+as plain XML first when no real xacro expansion is needed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from ssik._urdf import (
+    load_urdf_kinbody_normalized,
+    needs_xacro_expansion,
+    strip_urdf_to_fixture,
+)
+
+# A minimal 2-revolute chain that declares the xacro namespace and references
+# meshes by an unresolvable ``package://`` -- exactly the YuMi/FANUC shape.
+_PACKAGE_MESH_URDF = """<?xml version="1.0"?>
+<robot name="probe" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="base">
+    <visual><geometry><mesh filename="package://probe_desc/meshes/base.stl"/></geometry></visual>
+    <collision><geometry><mesh filename="package://probe_desc/meshes/base.stl"/></geometry></collision>
+  </link>
+  <link name="link1">
+    <visual><geometry><mesh filename="package://probe_desc/meshes/l1.stl"/></geometry></visual>
+  </link>
+  <link name="link2">
+    <visual><geometry><mesh filename="package://probe_desc/meshes/l2.stl"/></geometry></visual>
+  </link>
+  <joint name="j1" type="revolute">
+    <parent link="base"/><child link="link1"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="1" velocity="1"/>
+  </joint>
+  <joint name="j2" type="revolute">
+    <parent link="link1"/><child link="link2"/>
+    <origin xyz="0.2 0 0" rpy="0 0 0"/><axis xyz="0 1 0"/>
+    <limit lower="-3.14" upper="3.14" effort="1" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+
+def test_namespace_only_urdf_does_not_need_expansion() -> None:
+    """A URDF that only declares ``xmlns:xacro`` (no macros / substitutions)
+    must NOT be routed through the xacro processor."""
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "probe.urdf"
+        src.write_text(_PACKAGE_MESH_URDF)
+        assert needs_xacro_expansion(src) is False
+
+
+def test_macro_urdf_needs_expansion() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "probe.urdf"
+        src.write_text('<robot name="p"><xacro:property name="a" value="${1+1}"/></robot>')
+        assert needs_xacro_expansion(src) is True
+
+
+def test_package_mesh_urdf_strips_and_loads() -> None:
+    """The end-to-end ingestion path: strip meshes as plain XML (dropping the
+    unresolvable ``package://`` refs), then load the mesh-free chain -- no ROS
+    workspace, no ``PackageNotFoundError``."""
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "probe.urdf"
+        src.write_text(_PACKAGE_MESH_URDF)
+        dest = Path(d) / "probe_fixture.urdf"
+        strip_urdf_to_fixture(src, dest)
+        assert "package://" not in dest.read_text()
+        kb = load_urdf_kinbody_normalized(dest, "base", "link2")
+        assert len(kb.joints) == 2


### PR DESCRIPTION
Two onboarding-robustness fixes surfaced by Wave 1 (#292), both toward one-click `add-arm` (#425) and gate correctness (#423).

## 1. `package://` mesh ingestion

Vendor URDFs (ABB YuMi, FANUC) declare `xmlns:xacro` but reference meshes by ROS `package://`. `_is_xacro` matched the namespace and routed them through the xacro processor, which raised `PackageNotFoundError` **before** any mesh-stripping — so onboarding them required a hand-strip that then corrupted geometry.

Fix: `needs_xacro_expansion()` treats a namespace-only URDF as plain (only real `<xacro:`/`${}`/`$()` triggers expansion), and `add-arm` now vendors the **mesh-free fixture first** (pure XML) and loads/classifies from **that**. No ROS workspace needed. `ssik add-arm <raw-yumi.urdf>` now works end-to-end.

## 2. Fixture-parity base-frame bug

`test_prebuilt_fixture_parity` compared `ssik.fk` (base_link → ee_link) against `urdf.get_transform(ee)` in the URDF **root** frame. For arms whose `base_link` isn't the root (YuMi's `yumi_body`, offset from `world`), that's a **0.1 m false failure** — it's why YuMi got deferred in #424. Fixed to compare base-relative (`get_transform(ee, base)`); a no-op for the root-based shipped arms (19/19 still pass).

Together these **unblock YuMi** — the fixture is verified correct to 1.6e-16; the deferral was a phantom of the parity bug plus the `package://` hand-strip workaround.

## Tests
- `test_urdf_ingestion.py` (new): namespace-only vs macro'd detection + end-to-end strip-and-load of a synthetic `package://`-mesh URDF.
- `test_prebuilt_fixture_parity.py`: 19/19 shipped arms still pass with the base-frame fix.
- `test_cli_add_arm.py`: 6/6. ruff, format, mypy (205 files) clean.

Refs #425 (one-click friction), #423 (gate correctness). Unblocks YuMi from #424.