### PR TITLE
add-arm: auto-detect --base/--ee from the URDF (#425)

### DIFF
--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -36,6 +36,7 @@ __all__ = [
     "load_urdf_kinbody_normalized",
     "process_xacro",
     "strip_urdf_to_fixture",
+    "suggest_base_ee",
 ]
 
 # Non-kinematic elements stripped when vendoring a URDF as a test fixture:
@@ -74,6 +75,123 @@ def strip_urdf_to_fixture(source: Path, dest: Path) -> tuple[int, int]:
     dest.parent.mkdir(parents=True, exist_ok=True)
     tree.write(dest, encoding="unicode", xml_declaration=True)
     return len(root.findall("link")), len(root.findall("joint"))
+
+
+_ACTIVE_URDF_JOINTS = ("revolute", "continuous", "prismatic")
+# Substrings marking end-effector/gripper links, so ``suggest_base_ee`` backs
+# the EE up from a finger to the kinematic flange.
+_GRIPPER_HINTS = (
+    "finger",
+    "gripper",
+    "knuckle",
+    "tip",
+    "hand",
+    "jaw",
+    "pad",
+    "suction",
+    "tool",
+    "flange",
+)
+
+
+def suggest_base_ee(
+    source: str | Path, xacro_args: dict[str, str] | None = None
+) -> tuple[str, str, list[str]]:
+    """Suggest ``(base_link, ee_link)`` for the longest actuated chain in a
+    URDF/xacro, plus human-readable notes about alternatives.
+
+    ``base_link`` is the parent of the first active joint (leading fixed joints,
+    e.g. ``world -> robot_base``, fold into the base). ``ee_link`` is the child
+    of the last active joint (the kinematic flange; trailing fixed ``tool0`` /
+    gripper frames are reported as alternatives, not chosen). For multi-arm
+    robots (ABB YuMi) the other arm's tip is reported so the caller can pass an
+    explicit ``--ee``.
+
+    :returns: ``(base_link, ee_link, notes)`` where ``notes`` are strings to
+        show the user (empty for an unambiguous single-chain arm).
+    """
+    src = Path(source)
+    if needs_xacro_expansion(src):
+        with _as_plain_urdf(src, xacro_args) as plain:
+            root = ET.parse(plain).getroot()
+    else:
+        root = ET.parse(src).getroot()
+
+    links = [n for el in root.findall("link") if (n := el.get("name")) is not None]
+    joints: list[tuple[str, str, str]] = []
+    for j in root.findall("joint"):
+        parent, child = j.find("parent"), j.find("child")
+        if parent is None or child is None:
+            continue
+        p, c = parent.get("link"), child.get("link")
+        if p is None or c is None:
+            continue
+        joints.append((j.get("type") or "fixed", p, c))
+
+    children = {c for _, _, c in joints}
+    parents = {p for _, p, _ in joints}
+    child_edges: dict[str, list[tuple[str, str]]] = {}
+    for jtype, p, c in joints:
+        child_edges.setdefault(p, []).append((c, jtype))
+    roots = [ln for ln in links if ln not in children]
+
+    # Longest chain by number of ACTIVE joints, over every root.
+    best: tuple[int, list[str], list[str]] | None = None
+
+    def walk(link: str, path_links: list[str], path_types: list[str]) -> None:
+        nonlocal best
+        n_active = sum(1 for t in path_types if t in _ACTIVE_URDF_JOINTS)
+        if best is None or n_active > best[0]:
+            best = (n_active, list(path_links), list(path_types))
+        for c, jtype in child_edges.get(link, []):
+            walk(c, [*path_links, c], [*path_types, jtype])
+
+    for r in roots:
+        walk(r, [r], [])
+
+    if best is None or best[0] == 0:
+        raise ValueError("suggest_base_ee: no actuated joints found in URDF")
+
+    n_active, chain_links, chain_types = best
+    active_idx = [i for i, t in enumerate(chain_types) if t in _ACTIVE_URDF_JOINTS]
+    base_link = chain_links[active_idx[0]]
+    ee_idx = active_idx[-1] + 1
+
+    # Gripper joints (fingers) are active too, so the longest actuated chain
+    # runs past the wrist into a finger. Back the EE up to the last link that
+    # isn't gripper-named -- the kinematic flange.
+    while ee_idx > active_idx[0] and any(
+        hint in chain_links[ee_idx].lower() for hint in _GRIPPER_HINTS
+    ):
+        ee_idx -= 1
+    ee_link = chain_links[ee_idx]
+
+    notes: list[str] = []
+    # Trailing fixed frames past the flange (tool0, gripper mounts).
+    trailing = [
+        ln
+        for ln in chain_links[ee_idx + 1 :]
+        if not any(hint in ln.lower() for hint in _GRIPPER_HINTS)
+    ]
+    if trailing:
+        notes.append(f"flange frames past {ee_link!r}: {trailing} (pass --ee to use one)")
+    # Other arm tips (multi-arm robots) with a comparably long actuated chain.
+    tips = [ln for ln in links if ln not in parents and ln != ee_link]
+    other_arms: list[tuple[int, str]] = []
+    for r in roots:
+        stack = [(r, 0)]
+        while stack:
+            link, depth = stack.pop()
+            for c, jtype in child_edges.get(link, []):
+                nd = depth + (1 if jtype in _ACTIVE_URDF_JOINTS else 0)
+                if c in tips and nd >= n_active - 1 and c not in [t for _, t in other_arms]:
+                    other_arms.append((nd, c))
+                stack.append((c, nd))
+    names = sorted({c for _, c in other_arms if not any(h in c.lower() for h in _GRIPPER_HINTS)})
+    if names:
+        notes.append(f"other actuated chain tip(s): {names} (pass --ee to pick one)")
+
+    return base_link, ee_link, notes
 
 
 _IDENTITY: NDArray[np.float64] = np.eye(4, dtype=np.float64)

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -34,6 +34,7 @@ from ssik._urdf import (
     load_urdf_kinbody_normalized,
     needs_xacro_expansion,
     strip_urdf_to_fixture,
+    suggest_base_ee,
 )
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import DispatchPlan, dispatch
@@ -194,13 +195,20 @@ def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("urdf", type=Path, help="Path to the URDF or xacro file.")
     parser.add_argument(
         "--base",
-        required=True,
-        help="Link name to treat as the base of the kinematic chain.",
+        default=None,
+        help=(
+            "Link name to treat as the base of the kinematic chain. "
+            "Auto-detected (parent of the first actuated joint) when omitted."
+        ),
     )
     parser.add_argument(
         "--ee",
-        required=True,
-        help="Link name to treat as the end-effector of the kinematic chain.",
+        default=None,
+        help=(
+            "Link name to treat as the end-effector of the kinematic chain. "
+            "Auto-detected (the actuated flange of the longest chain) when omitted. "
+            "The onboarding gate (fixture parity + coverage) catches a wrong pick."
+        ),
     )
     parser.add_argument(
         "--xacro-arg",
@@ -213,6 +221,25 @@ def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
             "e.g. --xacro-arg ur_type:=ur10e. Ignored for plain URDFs."
         ),
     )
+
+
+def _resolve_base_ee(args: argparse.Namespace) -> None:
+    """Fill ``args.base`` / ``args.ee`` by auto-detection when omitted, and
+    print what was chosen plus any alternatives. A wrong guess is caught by the
+    onboarding gate (fixture parity + coverage), so this is a convenience, not a
+    correctness risk."""
+    if args.base and args.ee:
+        return
+    base, ee, notes = suggest_base_ee(args.urdf, _parse_xacro_args(args))
+    if not args.base:
+        args.base = base
+        print(f"[ssik]   auto-detected --base {base}")
+    if not args.ee:
+        args.ee = ee
+        print(f"[ssik]   auto-detected --ee {ee}")
+    for note in notes:
+        print(f"[ssik]   note: {note}")
+    print("[ssik]   verify these against your robot; the gate catches a wrong ee.")
 
 
 def _parse_xacro_args(args: argparse.Namespace) -> dict[str, str] | None:
@@ -261,6 +288,7 @@ def _configure_logging(verbose_count: int) -> None:
 
 def _run_classify(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
+    _resolve_base_ee(args)
     kb = load_urdf_kinbody_normalized(
         args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
     )
@@ -277,6 +305,7 @@ def _run_classify(args: argparse.Namespace) -> int:
 
 def _run_build(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
+    _resolve_base_ee(args)
     kb = load_urdf_kinbody_normalized(
         args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
     )
@@ -477,6 +506,7 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     if not args.urdf.is_file():
         print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
         return 1
+    _resolve_base_ee(args)
     # Vendor a mesh-free, kinematics-only fixture FIRST, then load + classify
     # from THAT (never the mesh-laden source). Stripping meshes up front drops
     # every ``package://`` reference, so vendor URDFs that declare xmlns:xacro

--- a/tests/test_urdf_ingestion.py
+++ b/tests/test_urdf_ingestion.py
@@ -74,3 +74,50 @@ def test_package_mesh_urdf_strips_and_loads() -> None:
         assert "package://" not in dest.read_text()
         kb = load_urdf_kinbody_normalized(dest, "base", "link2")
         assert len(kb.joints) == 2
+
+
+# ---------------------------------------------------------------------------
+# base/ee auto-detection (suggest_base_ee)
+# ---------------------------------------------------------------------------
+
+
+def _rev(name: str, parent: str, child: str) -> str:
+    return (
+        f'<joint name="{name}" type="revolute">'
+        f'<parent link="{parent}"/><child link="{child}"/>'
+        '<origin xyz="0.2 0 0"/><axis xyz="0 0 1"/>'
+        '<limit lower="-3" upper="3" effort="1" velocity="1"/></joint>'
+    )
+
+
+# world -> base_link (fixed) -> l1 -> l2 -> wrist (3R), then a gripper with two
+# revolute fingers branching off ``gripper_base`` past the wrist.
+_ARM_WITH_GRIPPER = f"""<?xml version="1.0"?>
+<robot name="arm">
+  <link name="world"/><link name="base_link"/>
+  <link name="l1"/><link name="l2"/><link name="wrist"/>
+  <link name="gripper_base"/><link name="finger_left"/><link name="finger_right"/>
+  <joint name="fixed_world" type="fixed">
+    <parent link="world"/><child link="base_link"/><origin xyz="0 0 0.05"/></joint>
+  {_rev("j1", "base_link", "l1")}
+  {_rev("j2", "l1", "l2")}
+  {_rev("j3", "l2", "wrist")}
+  <joint name="wrist_to_gripper" type="fixed">
+    <parent link="wrist"/><child link="gripper_base"/><origin xyz="0.05 0 0"/></joint>
+  {_rev("fl", "gripper_base", "finger_left")}
+  {_rev("fr", "gripper_base", "finger_right")}
+</robot>
+"""
+
+
+def test_suggest_base_ee_skips_leading_fixed_and_gripper() -> None:
+    """base folds past ``world->base_link``; ee backs off the gripper fingers
+    to the wrist flange."""
+    from ssik._urdf import suggest_base_ee
+
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "arm.urdf"
+        src.write_text(_ARM_WITH_GRIPPER)
+        base, ee, _ = suggest_base_ee(src)
+        assert base == "base_link"
+        assert ee == "wrist"


### PR DESCRIPTION
Onboarding required hand-tracing every URDF's link tree to find the base and end-effector links (I did this for all of Wave 1). `suggest_base_ee()` now derives them.

## What
- **`--base`/`--ee` are optional** across `classify`/`build`/`add-arm`. When omitted they're auto-detected and printed with a "verify" note.
- **base** = parent of the first actuated joint (leading `world → base` fixed joints fold in).
- **ee** = the actuated flange of the longest chain, **backing off gripper fingers by name** so a wrist is chosen, not a finger. Trailing `tool0`/gripper frames and other actuated-chain tips are reported as alternatives.
- A wrong guess is **caught by the hardened onboarding gate** (fixture parity + coverage), so this is convenience, not a correctness risk.

## Verified
| Arm | auto base | auto ee |
|---|---|---|
| UR5 | `base_link` | `wrist_3_link` (+ ee_link/tool0 noted) |
| iiwa14 | `iiwa_link_0` | `iiwa_link_7` (+ iiwa_link_ee noted) |
| FANUC M-710iC | `base_link` | `link_6` (+ tool0 noted) |
| ABB YuMi (dual-arm) | `yumi_body` | `yumi_link_7_r` |

## Tests
`test_urdf_ingestion.py`: base folds past leading fixed joints; ee backs off a two-finger gripper to the wrist. ruff/format/mypy clean; `test_cli_add_arm` 6/6.

Refs #425.