### PR TITLE
Prove the coverage gate rejects a broken arm; extract ssik._validation (#423)

### DIFF
--- a/src/ssik/_validation.py
+++ b/src/ssik/_validation.py
@@ -1,0 +1,104 @@
+"""Coverage + FK-closure validation for a prebuilt artifact.
+
+The onboarding gate: sample poses across an arm's real joint limits, FK + solve
+with the **shipped** ``module.solve``, and assert that a minimum fraction return
+at least one IK (coverage) and every returned IK FK-closes within a ceiling.
+
+A broken or degenerate arm (0 solutions, locked ``[0, 0]`` joint limits, a wrong
+end-effector gauge) fails the *coverage* assertion. "FK <= tol on every retained
+IK" is vacuously true at zero coverage, so coverage is asserted separately -- the
+lesson from the Wave 1 onboarding (#423), where a 0-solution arm passed the whole
+gate.
+
+One tested implementation, shared by the ``ssik add-arm`` test scaffold (and any
+future ``add-arm`` build-time validation), so the gate can't silently rot in
+generated code.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class _Solution(Protocol):
+    fk_residual: float
+
+
+class _SolvableArm(Protocol):
+    """The surface a prebuilt artifact exposes that this validator needs."""
+
+    DOF: int
+    _KB: object  # exposes ``.joints`` with per-joint ``.limits``
+
+    def fk(self, q: NDArray[np.float64]) -> NDArray[np.float64]: ...
+
+    def solve(self, t_target: NDArray[np.float64]) -> list[_Solution]: ...
+
+
+def joint_bounds(module: _SolvableArm) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """``(lo, hi)`` per-joint sampling bounds from the artifact's baked KinBody.
+    Continuous / limitless joints sample ``[-pi, pi]``."""
+    lo: list[float] = []
+    hi: list[float] = []
+    for j in module._KB.joints:  # type: ignore[attr-defined]
+        lim = getattr(j, "limits", None)
+        if lim is None:
+            lo.append(-np.pi)
+            hi.append(np.pi)
+        else:
+            lo.append(float(lim[0]))
+            hi.append(float(lim[1]))
+    return np.array(lo), np.array(hi)
+
+
+def check_solve_coverage(
+    module: _SolvableArm, *, n_poses: int = 64, seed: int = 0
+) -> tuple[float, float]:
+    """Sample ``n_poses`` within the arm's joint limits, ``solve(fk(q))`` via the
+    shipped path, and return ``(coverage_fraction, worst_fk)``.
+
+    ``coverage_fraction`` is the fraction of poses that returned >= 1 IK;
+    ``worst_fk`` is the largest FK residual across all returned solutions (0.0 if
+    none were returned).
+    """
+    lo, hi = joint_bounds(module)
+    rng = np.random.default_rng(seed)
+    covered = 0
+    worst_fk = 0.0
+    for _ in range(n_poses):
+        q = rng.uniform(lo, hi)
+        sols = module.solve(module.fk(q))
+        if sols:
+            covered += 1
+            worst_fk = max(worst_fk, max(float(s.fk_residual) for s in sols))
+    return covered / n_poses, worst_fk
+
+
+def assert_solve_coverage(
+    module: _SolvableArm,
+    *,
+    min_coverage: float = 0.95,
+    fk_ceiling: float = 1e-6,
+    n_poses: int = 64,
+    seed: int = 0,
+) -> tuple[float, float]:
+    """Raise :class:`AssertionError` if coverage ``< min_coverage`` or the worst
+    FK residual is ``>= fk_ceiling``. Returns ``(coverage, worst_fk)`` on success.
+
+    This is the bulletproof gate: a broken arm (few/no solutions) trips the
+    coverage assertion instead of passing vacuously.
+    """
+    name = getattr(module, "__name__", "arm")
+    coverage, worst_fk = check_solve_coverage(module, n_poses=n_poses, seed=seed)
+    if coverage < min_coverage:
+        raise AssertionError(
+            f"{name}: coverage {coverage:.0%} < {min_coverage:.0%} "
+            f"({round(coverage * n_poses)}/{n_poses} reachable poses returned an IK). "
+            f"A broken or degenerate arm returns few/no solutions."
+        )
+    if worst_fk >= fk_ceiling:
+        raise AssertionError(f"{name}: worst FK {worst_fk:.2e} >= {fk_ceiling:.0e} ceiling")
+    return coverage, worst_fk

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -699,25 +699,13 @@ def test_{arm_name}_coverage_and_fk_closure() -> None:
         "ssik.prebuilt.{arm_name}",
         reason="build the artifact first: regen_artifacts.py --arm {arm_name}",
     )
+    from ssik._validation import assert_solve_coverage
 
-    lo, hi = _joint_bounds()
-    rng = np.random.default_rng(0)
-    covered = 0
-    worst_fk = 0.0
-    for _ in range(_N_COVERAGE_POSES):
-        q = rng.uniform(lo, hi)
-        sols = art.solve(art.fk(q))
-        if sols:
-            covered += 1
-            worst_fk = max(worst_fk, max(float(s.fk_residual) for s in sols))
-    coverage = covered / _N_COVERAGE_POSES
-    assert coverage >= _MIN_COVERAGE, (
-        f"{arm_name}: coverage {{coverage:.0%}} < {{_MIN_COVERAGE:.0%}} "
-        f"({{covered}}/{{_N_COVERAGE_POSES}} reachable poses returned an IK). "
-        f"A broken or degenerate arm returns few/no solutions."
-    )
-    assert worst_fk < _FK_CEILING, (
-        f"{arm_name}: worst FK {{worst_fk:.2e}} > {{_FK_CEILING:.0e}} ceiling"
+    assert_solve_coverage(
+        art,
+        min_coverage=_MIN_COVERAGE,
+        fk_ceiling=_FK_CEILING,
+        n_poses=_N_COVERAGE_POSES,
     )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,73 @@
+"""The bulletproof gate must actually reject a broken arm.
+
+`ssik._validation.assert_solve_coverage` is what the `ssik add-arm` scaffold
+calls. These tests prove it does its job: a good arm passes; an arm that returns
+no solutions (the FANUC-M710 / Kinova-[0,0] failure mode from #424) trips the
+coverage assertion rather than passing vacuously.
+
+Both directions use a *real* shipped arm's geometry (ur5) so the test exercises
+real joint-limit sampling, not a hand-rigged mock.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik._validation import assert_solve_coverage, check_solve_coverage
+from ssik.prebuilt import ur5_ik
+
+
+class _ZeroSolve:
+    """Wraps a real arm but returns no solutions for every pose -- the shape of
+    a broken solver / a locked-``[0, 0]``-limits fixture."""
+
+    __name__ = "broken_arm"
+
+    def __init__(self, base: object) -> None:
+        self._base = base
+        self._KB = base._KB  # type: ignore[attr-defined]
+        self.DOF = base.DOF  # type: ignore[attr-defined]
+
+    def fk(self, q: np.ndarray) -> np.ndarray:
+        return self._base.fk(q)  # type: ignore[attr-defined,no-any-return]
+
+    def solve(self, t_target: np.ndarray, **_kw: object) -> list[object]:
+        return []
+
+
+def test_gate_passes_a_good_arm() -> None:
+    coverage, worst_fk = assert_solve_coverage(
+        ur5_ik, min_coverage=0.95, fk_ceiling=1e-6, n_poses=32
+    )
+    assert coverage == 1.0
+    assert worst_fk < 1e-6
+
+
+def test_gate_rejects_a_zero_solution_arm() -> None:
+    """The core bulletproof claim: 0 coverage is a loud failure, not a pass."""
+    broken = _ZeroSolve(ur5_ik)
+    cov, _ = check_solve_coverage(broken, n_poses=32)  # type: ignore[arg-type]
+    assert cov == 0.0
+    with pytest.raises(AssertionError, match="coverage"):
+        assert_solve_coverage(broken, min_coverage=0.95, n_poses=32)  # type: ignore[arg-type]
+
+
+def test_gate_rejects_bad_fk_closure() -> None:
+    """An arm that "solves" but with poor FK closure trips the FK ceiling."""
+
+    class _BadFk(_ZeroSolve):
+        __name__ = "bad_fk_arm"
+
+        def solve(self, t_target: np.ndarray, **_kw: object) -> list[object]:
+            # One solution, but with a 1 mm FK residual -- above a tight ceiling.
+            sol = type("S", (), {"fk_residual": 1e-3})()
+            return [sol]
+
+    with pytest.raises(AssertionError, match="FK"):
+        assert_solve_coverage(
+            _BadFk(ur5_ik),  # type: ignore[arg-type]
+            min_coverage=0.5,
+            fk_ceiling=1e-6,
+            n_poses=16,
+        )


### PR DESCRIPTION
The bulletproof coverage gate (from #427) lived **only in generated scaffold code**, so nothing verified it actually rejects a broken arm — "bulletproof" was asserted, not tested. This extracts it into one tested implementation.

## What
- **`ssik._validation`** — `assert_solve_coverage(module, ...)` / `check_solve_coverage`: sample the artifact's real joint limits (from `_KB`), solve via the **shipped `module.solve`**, assert coverage ≥ floor + FK closure. `joint_bounds` handles continuous/limitless joints.
- **`test_validation.py`** — the missing proof:
  - `test_gate_passes_a_good_arm` — ur5 → 100% coverage ✓
  - `test_gate_rejects_a_zero_solution_arm` — a wrapper returning `[]` (the FANUC-M710 / Kinova-`[0,0]` failure mode from #424) → **raises** `AssertionError(coverage)` ✓
  - `test_gate_rejects_bad_fk_closure` — solves but at 1e-3 FK → **raises** `AssertionError(FK)` ✓
  
  Both failure cases wrap ur5's *real* geometry, so it's not a hand-rigged mock.
- The `add-arm` scaffold's coverage test now **calls the shared helper** instead of an inline loop — one implementation, tested, can't silently rot.

This also sets up the future `add-arm --validate` (build + run the smoke locally): it can call the same `assert_solve_coverage`.

## Tests
`test_validation.py` 3/3; regenerated ur5 scaffold passes; ruff/format/mypy (213 files) clean.

Refs #423 (gate hardening).