### PR TITLE
Make Manipulator.from_urdf as robust as ssik add-arm (#434)

### DIFF
--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover — typing only
 __all__ = [
     "load_urdf_kinbody",
     "load_urdf_kinbody_normalized",
+    "load_urdf_kinbody_robust",
     "process_xacro",
     "strip_urdf_to_fixture",
     "suggest_base_ee",
@@ -538,3 +539,34 @@ def load_urdf_kinbody_normalized(
     final_t_right = final_t_right @ final_rotation
 
     return build_poe_kinbody(records, final_t_right, base_link, ee_link)
+
+
+def load_urdf_kinbody_robust(
+    source: str | Path,
+    base_link: str,
+    ee_link: str,
+    *,
+    xacro_args: dict[str, str] | None = None,
+) -> KinBody:
+    """Load a POE-normalized :class:`KinBody`, tolerant of vendor URDFs.
+
+    Same result as :func:`load_urdf_kinbody_normalized` (FK-identical), but
+    strips the source to a mesh-free, kinematics-only temp copy *first*, so a
+    URDF that references meshes by an unresolvable ``package://`` path (most
+    vendor URDFs: ABB, FANUC, ...) loads without a ROS workspace on disk.
+    Genuinely-macro'd xacro is expanded before stripping. This mirrors the
+    ``ssik add-arm`` ingestion path (#428) so the public
+    :meth:`ssik.Manipulator.from_urdf` entry point is as robust as the CLI.
+
+    :param xacro_args: substitution args for parametrized xacro descriptions
+        (see :func:`process_xacro`); ignored for plain URDFs.
+    """
+    src = Path(source)
+    with tempfile.TemporaryDirectory() as tmp:
+        stripped = Path(tmp) / "kinematics.urdf"
+        if needs_xacro_expansion(src):
+            with _as_plain_urdf(src, xacro_args) as plain:
+                strip_urdf_to_fixture(plain, stripped)
+        else:
+            strip_urdf_to_fixture(src, stripped)
+        return load_urdf_kinbody_normalized(stripped, base_link, ee_link)

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -136,8 +136,8 @@ class Manipulator:
         cls,
         path: str | Path,
         *,
-        base: str,
-        ee: str,
+        base: str | None = None,
+        ee: str | None = None,
         policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
         xacro_args: dict[str, str] | None = None,
     ) -> Manipulator:
@@ -145,29 +145,35 @@ class Manipulator:
         between ``base`` and ``ee``.
 
         The kinematic chain is POE-normalised internally so the dispatcher
-        can match the arm's topology against the solver roster. Mesh loading
-        is lazy (the URDF parser does not load STL files unless asked).
+        can match the arm's topology against the solver roster.
 
-        Xacro descriptions (``.xacro`` / ``*.urdf.xacro``, or a ``.urdf`` with a
-        xacro namespace) are expanded automatically via ``xacrodoc``
-        (``pip install ssik[xacro]``).
+        Ingestion mirrors ``ssik add-arm``: the URDF is stripped to a
+        mesh-free, kinematics-only copy before loading, so vendor URDFs that
+        reference meshes by an unresolvable ``package://`` path (ABB, FANUC,
+        ...) load without a ROS workspace on disk. Xacro descriptions
+        (``.xacro`` / ``*.urdf.xacro``, or a ``.urdf`` with a xacro namespace)
+        are expanded automatically via ``xacrodoc`` (``pip install ssik[xacro]``).
 
         :param path: path to the URDF or xacro file.
-        :param base: name of the base link in the URDF.
-        :param ee: name of the end-effector link in the URDF.
+        :param base: name of the base link in the URDF. When omitted, the base
+            of the longest actuated chain is auto-detected.
+        :param ee: name of the end-effector link in the URDF. When omitted, the
+            kinematic flange of the longest actuated chain is auto-detected
+            (trailing fixed ``tool0`` / gripper frames are skipped).
         :param policy: tolerance policy. Defaults to
             :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
         :param xacro_args: substitution args for parametrized xacro descriptions
             (e.g. ``{"ur_type": "ur10e"}``); ignored for plain URDFs.
 
         :raises FileNotFoundError: if ``path`` doesn't exist.
-        :raises ValueError: if ``base`` or ``ee`` are not link names in the URDF.
+        :raises ValueError: if ``base`` or ``ee`` are not link names in the URDF,
+            or (when auto-detecting) if the URDF has no actuated joints.
         :raises ImportError: if the optional dependency ``urchin`` is not
             installed (``pip install ssik[urdf]``).
         """
         # Imported lazily so the urchin dependency is only required when
         # from_urdf is actually called (it's an optional extra).
-        from ssik._urdf import load_urdf_kinbody_normalized
+        from ssik._urdf import load_urdf_kinbody_robust, suggest_base_ee
 
         # urchin raises ValueError on missing files; rewrite to the more
         # idiomatic FileNotFoundError for the public API contract.
@@ -175,7 +181,14 @@ class Manipulator:
         if not path_obj.exists():
             raise FileNotFoundError(f"URDF file not found: {path_obj}")
 
-        kb = load_urdf_kinbody_normalized(path, base, ee, xacro_args=xacro_args)
+        # Auto-detect base/ee (longest actuated chain) when not given, so the
+        # library entry point is as one-click as ``ssik add-arm``.
+        if base is None or ee is None:
+            det_base, det_ee, _notes = suggest_base_ee(path, xacro_args)
+            base = base if base is not None else det_base
+            ee = ee if ee is not None else det_ee
+
+        kb = load_urdf_kinbody_robust(path, base, ee, xacro_args=xacro_args)
         return cls(kb, policy=policy)
 
     @classmethod

--- a/tests/test_from_urdf_robust.py
+++ b/tests/test_from_urdf_robust.py
@@ -1,0 +1,86 @@
+"""``Manipulator.from_urdf`` ingestion robustness (#434).
+
+The public library entry point must be as one-click as ``ssik add-arm``:
+
+- **``package://`` tolerance.** Vendor URDFs (ABB, FANUC, ...) declare
+  ``xmlns:xacro`` and reference meshes by ROS ``package://`` paths that don't
+  resolve outside a ROS workspace. ``from_urdf`` strips the URDF to a
+  mesh-free copy before loading, so those load without a workspace on disk.
+  Loading such a URDF via the non-stripping path raises ``PackageNotFoundError``
+  (asserted below), so this guard has teeth.
+- **base/ee auto-detection.** With ``base``/``ee`` omitted, the longest
+  actuated chain is detected and gives FK-identical results to the explicit call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import ssik
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def pkg_urdf(tmp_path: Path) -> Path:
+    """A dispatchable 6-DOF arm (UR5) dressed as a raw vendor URDF: an
+    ``xmlns:xacro`` namespace on the robot tag and an unresolvable
+    ``package://`` mesh -- the exact shape that breaks a naive load."""
+    src = (FIXTURES / "ur5.urdf").read_text(encoding="utf-8")
+    assert "xmlns:xacro" not in src  # the shipped fixture is already clean
+    dressed = src.replace(
+        '<robot name="ur5">',
+        '<robot name="ur5" xmlns:xacro="http://www.ros.org/wiki/xacro">',
+    ).replace(
+        '<link name="base_link">',
+        '<link name="base_link"><visual><geometry>'
+        '<mesh filename="package://no_such_pkg/base.stl"/></geometry></visual>',
+        1,
+    )
+    assert "package://" in dressed
+    assert "xmlns:xacro" in dressed
+    path = tmp_path / "pkg_arm.urdf"
+    path.write_text(dressed, encoding="utf-8")
+    return path
+
+
+def test_from_urdf_tolerates_package_meshes(pkg_urdf: Path) -> None:
+    """A URDF with xmlns:xacro + package:// meshes loads without a ROS workspace,
+    FK-identical to the clean shipped fixture."""
+    arm = ssik.Manipulator.from_urdf(pkg_urdf, base="base_link", ee="ee_link")
+    clean = ssik.Manipulator.from_urdf(FIXTURES / "ur5.urdf", base="base_link", ee="ee_link")
+    assert arm.dof == 6
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        q = rng.uniform(-1.0, 1.0, size=6)
+        assert np.allclose(arm.fk(q), clean.fk(q), atol=1e-12)
+
+
+def test_non_stripping_path_fails_on_package_meshes(pkg_urdf: Path) -> None:
+    """Teeth: the raw (non-stripping) loader raises on the same file, so the
+    strip-first ingestion in from_urdf is doing real work."""
+    from ssik._urdf import load_urdf_kinbody_normalized
+
+    with pytest.raises(Exception, match=r"[Pp]ackage"):
+        load_urdf_kinbody_normalized(pkg_urdf, "base_link", "ee_link")
+
+
+def test_from_urdf_autodetects_base_ee(pkg_urdf: Path) -> None:
+    """Omitting base/ee auto-detects the actuated chain and yields a usable,
+    dispatchable arm whose IK round-trips (FK closure) end-to-end.
+
+    We don't pin the auto-detected EE (it resolves to the kinematic flange,
+    ``wrist_3_link``, not the fixture's ``ee_link``): the guarantee is a
+    working 6-DOF solver, verified by an FK -> IK -> FK round-trip.
+    """
+    auto = ssik.Manipulator.from_urdf(pkg_urdf)
+    assert auto.dof == 6
+    rng = np.random.default_rng(0)
+    q = rng.uniform(-1.0, 1.0, size=6)
+    T = auto.fk(q)
+    sols = auto.solve(T)
+    assert sols, "auto-detected arm returned no IK solutions"
+    assert any(np.allclose(auto.fk(s.q), T, atol=1e-8) for s in sols)


### PR DESCRIPTION
## Why

The onboarding-robustness work (#425/#428/#430) went into the **CLI only** (`ssik add-arm`). The public library entry point `Manipulator.from_urdf` still loaded the URDF directly, so end users got none of it:

- **`package://` meshes under `xmlns:xacro` failed.** `from_urdf` → `load_urdf_kinbody_normalized` → `_as_plain_urdf`, which runs xacrodoc on any file declaring the xacro namespace; xacrodoc resolves `package://` mesh paths and raises `PackageNotFoundError` outside a ROS workspace. Vendor URDFs (ABB, FANUC, Kinova) all have this shape.
- **No base/ee auto-detection.** `from_urdf` required `base=`/`ee=`; `add-arm` auto-detects them (#430).

## What

- New `ssik._urdf.load_urdf_kinbody_robust`: strips the URDF to a mesh-free, kinematics-only temp copy **before** loading (expanding only genuinely-macro'd xacro via `needs_xacro_expansion`), so unresolvable `package://` refs vanish. FK-identical to `load_urdf_kinbody_normalized`. This is exactly the `add-arm` ingestion path (#428).
- `Manipulator.from_urdf` routes through it, and `base`/`ee` are now optional (auto-detected via `suggest_base_ee` when omitted).

## Test plan

`tests/test_from_urdf_robust.py` (3 tests, all green):
- A UR5 dressed with an `xmlns:xacro` namespace + an unresolvable `package://` mesh loads **FK-identically** to the clean shipped fixture.
- **Teeth:** the non-stripping `load_urdf_kinbody_normalized` still raises `PackageNotFoundError` on that same file, so the strip-first ingestion is doing real work.
- base/ee auto-detection (no `base`/`ee` args) yields a solvable arm, verified by an FK → IK → FK round-trip.

Local gate: ruff + format + mypy clean on all changed files.

Fixes #434