### PR TITLE
Fix seven_r.srs 0-solutions on offset-wrist SRS arms (iiwa7, #424)

### DIFF
--- a/src/ssik/solvers/seven_r/srs.py
+++ b/src/ssik/solvers/seven_r/srs.py
@@ -443,13 +443,24 @@ def solve(
         and np.allclose(j[5].axis, _EY)
         and np.allclose(j[6].axis, _EZ)
     )
+    # The canonical fast-path also assumes an OFFSET-FREE wrist: it uses joint
+    # 5's frame origin as the wrist-pivot reference for the q_2 SP1 (mapping it
+    # onto the target wrist pivot). That is only valid when joint 5's origin
+    # coincides with the axis-concurrency point. iiwa7-class wrists have
+    # intermediate lateral offsets (j5/j6 origins ±e off the pivot, cancelling
+    # at the pivot itself) that keep axes 4/5/6 concurrent but displace joint
+    # 5's origin, so the canonical mapping targets the wrong point and every
+    # candidate misses FK closure by ~e (4-6 cm on iiwa7). Route those to the
+    # general path (#354), which references the wrist pivot explicitly and
+    # solves them to machine precision.
+    wrist_offset_free = bool(np.allclose(origins[5], cls.wrist_pivot, atol=policy.axis_intersect))
     # Approximate-SRS callers (``reach_slack > 0``; only ``srs_polished``,
     # which is Z*Z-gated so the arm is canonical z-y-z up to its small pivot
-    # drift) keep the canonical path: it is the ZYZ warm-start factory their
-    # LM polish + near-singular q_2-sweep (#223) were tuned against. The
-    # general path targets exact concurrent-axis arms (reach_slack == 0) and
-    # carries no reach-slack / elbow-singular handling.
-    use_canonical = canonical_zyz or reach_slack > 0.0
+    # drift, with an offset-free wrist) keep the canonical path: it is the ZYZ
+    # warm-start factory their LM polish + near-singular q_2-sweep (#223) were
+    # tuned against. The general path targets exact concurrent-axis arms
+    # (reach_slack == 0) and carries no reach-slack / elbow-singular handling.
+    use_canonical = (canonical_zyz and wrist_offset_free) or reach_slack > 0.0
 
     t_target = np.asarray(T_target, dtype=np.float64)
     R_target = t_target[:3, :3]

--- a/tests/fixtures/kuka_iiwa7.urdf
+++ b/tests/fixtures/kuka_iiwa7.urdf
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot name="iiwa7">
+  <link name="iiwa_link_0">
+    <self_collision_checking>
+      <origin rpy="0 0 0" xyz="0 0 0" />
+      <geometry>
+        <cylinder length="0.25" radius="0.15" />
+      </geometry>
+    </self_collision_checking>
+  </link>
+  <joint name="iiwa_joint_1" type="revolute">
+    <parent link="iiwa_link_0" />
+    <child link="iiwa_link_1" />
+    <origin rpy="0 0 0" xyz="0 0 0.15" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.9670597283903604" upper="2.9670597283903604" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.9321531433504737" soft_upper_limit="2.9321531433504737" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_1">
+    </link>
+  <joint name="iiwa_joint_2" type="revolute">
+    <parent link="iiwa_link_1" />
+    <child link="iiwa_link_2" />
+    <origin rpy="1.5707963267948966   0 3.141592653589793" xyz="0 0 0.19" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.0943951023931953" upper="2.0943951023931953" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.0594885173533086" soft_upper_limit="2.0594885173533086" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_2">
+    </link>
+  <joint name="iiwa_joint_3" type="revolute">
+    <parent link="iiwa_link_2" />
+    <child link="iiwa_link_3" />
+    <origin rpy="1.5707963267948966 0 3.141592653589793" xyz="0 0.21 0" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.9670597283903604" upper="2.9670597283903604" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.9321531433504737" soft_upper_limit="2.9321531433504737" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_3">
+    </link>
+  <joint name="iiwa_joint_4" type="revolute">
+    <parent link="iiwa_link_3" />
+    <child link="iiwa_link_4" />
+    <origin rpy="1.5707963267948966 0 0" xyz="0 0 0.19" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.0943951023931953" upper="2.0943951023931953" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.0594885173533086" soft_upper_limit="2.0594885173533086" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_4">
+    </link>
+  <joint name="iiwa_joint_5" type="revolute">
+    <parent link="iiwa_link_4" />
+    <child link="iiwa_link_5" />
+    <origin rpy="-1.5707963267948966 3.141592653589793 0" xyz="0 0.21 0" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.9670597283903604" upper="2.9670597283903604" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.9321531433504737" soft_upper_limit="2.9321531433504737" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_5">
+    </link>
+  <joint name="iiwa_joint_6" type="revolute">
+    <parent link="iiwa_link_5" />
+    <child link="iiwa_link_6" />
+    <origin rpy="1.5707963267948966 0 0" xyz="0 0.06070 0.19" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-2.0943951023931953" upper="2.0943951023931953" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.0594885173533086" soft_upper_limit="2.0594885173533086" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_6">
+    </link>
+  <joint name="iiwa_joint_7" type="revolute">
+    <parent link="iiwa_link_6" />
+    <child link="iiwa_link_7" />
+    <origin rpy="-1.5707963267948966 3.141592653589793 0" xyz="0 0.081 0.06070" />
+    <axis xyz="0 0 1" />
+    <limit effort="300" lower="-3.0543261909900763" upper="3.0543261909900763" velocity="10" />
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595019" soft_upper_limit="3.01941960595019" />
+    <dynamics damping="0.5" />
+  </joint>
+  <link name="iiwa_link_7">
+    </link>
+  <joint name="iiwa_joint_ee" type="fixed">
+    <parent link="iiwa_link_7" />
+    <child link="iiwa_link_ee" />
+    <origin rpy="0 0 0" xyz="0 0 0.045" />
+  </joint>
+  <link name="iiwa_link_ee">
+    </link>
+</robot>

--- a/tests/test_seven_r_srs.py
+++ b/tests/test_seven_r_srs.py
@@ -259,3 +259,75 @@ def test_dispatcher_routes_franka_to_spherical_shoulder_not_srs() -> None:
     kb = build_kinbody(franka_panda_specs())
     plan = dispatch(kb)
     assert plan.solver_name == "seven_r.spherical_shoulder"
+
+
+# ----------------------------------------------------------------------------
+# Offset-wrist SRS (#424): concurrent axes but a laterally-offset wrist
+# ----------------------------------------------------------------------------
+
+_IIWA7_URDF = Path(__file__).parent / "fixtures" / "kuka_iiwa7.urdf"
+
+
+def _iiwa7_kb() -> object:
+    from ssik._urdf import load_urdf_kinbody_normalized
+
+    return load_urdf_kinbody_normalized(_IIWA7_URDF, "iiwa_link_0", "iiwa_link_ee")
+
+
+def test_iiwa7_is_offset_wrist_srs() -> None:
+    """iiwa7 (differentiable-robot-model) is genuinely SRS-class (wrist axes
+    4/5/6 concurrent) but has intermediate lateral offsets at joints 5/6 that
+    displace joint 5's origin from the wrist-concurrency point. This is the
+    fixture that exposed the canonical fast-path's offset-free-wrist assumption
+    (#424): iiwa14 (offset-free) does not."""
+    from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY as POL
+    from ssik.kinematics.predicates import is_srs_7r
+    from ssik.solvers.seven_r.srs import _arm_constants, _classify_srs_7r_geometric
+
+    kb = _iiwa7_kb()
+    assert is_srs_7r(kb, POL), "iiwa7 must classify as SRS (concurrent wrist axes)"
+    cls = _classify_srs_7r_geometric(kb, POL)
+    _, _, _, origins = _arm_constants(kb, cls)
+    # Joint 5's origin is NOT at the wrist pivot -- this is what makes the
+    # canonical fast-path invalid and forces the general path.
+    offset = float(np.linalg.norm(origins[5] - cls.wrist_pivot))
+    assert offset > 1e-2, f"expected an offset wrist; joint5 offset={offset:.4f}"
+
+
+@pytest.mark.parametrize("q_star", _HAND_PICKED_Q)
+def test_iiwa7_offset_wrist_fk_closure_hand_picked(q_star: np.ndarray) -> None:
+    """Every IK returned at a reachable iiwa7 pose FK-closes <= 1e-10.
+
+    Regression for #424: the canonical ZYZ fast-path used joint 5's frame as
+    the wrist-pivot reference, so on an offset wrist it placed the wrong point
+    at the target and *every* candidate missed FK closure by ~the offset
+    (~4-6 cm on iiwa7) -> zero solutions. The offset-free-wrist guard routes
+    iiwa7 to the general path, which closes to machine precision.
+    """
+    kb = _iiwa7_kb()
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, is_ls = srs_solve(kb, T_target)
+    assert sols, f"SRS returned no IK for reachable iiwa7 pose q={q_star}"
+    assert not is_ls
+    for sol in sols:
+        fk_err = float(np.linalg.norm(poe_forward_kinematics(kb, sol.q) - T_target))
+        assert fk_err < 1e-10, f"FK closure failed: q={sol.q}, fk_err={fk_err:.2e}"
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_iiwa7_offset_wrist_random_pose_fk_closure(seed: int) -> None:
+    """100 random reachable iiwa7 poses: at least one returned IK FK-closes."""
+    kb = _iiwa7_kb()
+    rng = np.random.default_rng(seed)
+    q_star = rng.uniform(-0.8, 0.8, size=7)
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = srs_solve(kb, T_target)
+    assert sols, f"no IK for reachable iiwa7 pose (seed={seed})"
+    assert any(
+        float(np.linalg.norm(poe_forward_kinematics(kb, s.q) - T_target)) < 1e-8 for s in sols
+    ), f"no FK-closing IK among {len(sols)} for seed={seed}"

--- a/tests/test_seven_r_srs.py
+++ b/tests/test_seven_r_srs.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
 from _perf import best_call_ms
 from kuka_iiwa14 import kuka_iiwa14_specs
 
-from ssik._kinbody import build_kinbody
+from ssik._kinbody import KinBody, build_kinbody
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.solvers.seven_r.srs import solve as srs_solve
 
@@ -268,7 +268,7 @@ def test_dispatcher_routes_franka_to_spherical_shoulder_not_srs() -> None:
 _IIWA7_URDF = Path(__file__).parent / "fixtures" / "kuka_iiwa7.urdf"
 
 
-def _iiwa7_kb() -> object:
+def _iiwa7_kb() -> KinBody:
     from ssik._urdf import load_urdf_kinbody_normalized
 
     return load_urdf_kinbody_normalized(_IIWA7_URDF, "iiwa_link_0", "iiwa_link_ee")
@@ -281,12 +281,13 @@ def test_iiwa7_is_offset_wrist_srs() -> None:
     fixture that exposed the canonical fast-path's offset-free-wrist assumption
     (#424): iiwa14 (offset-free) does not."""
     from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY as POL
-    from ssik.kinematics.predicates import is_srs_7r
-    from ssik.solvers.seven_r.srs import _arm_constants, _classify_srs_7r_geometric
+    from ssik.kinematics.predicates import _classify_srs_7r_geometric, is_srs_7r
+    from ssik.solvers.seven_r.srs import _arm_constants
 
     kb = _iiwa7_kb()
     assert is_srs_7r(kb, POL), "iiwa7 must classify as SRS (concurrent wrist axes)"
     cls = _classify_srs_7r_geometric(kb, POL)
+    assert cls is not None
     _, _, _, origins = _arm_constants(kb, cls)
     # Joint 5's origin is NOT at the wrist pivot -- this is what makes the
     # canonical fast-path invalid and forces the general path.


### PR DESCRIPTION
## Root cause

The native SRS solver (`seven_r.srs`) has two extraction paths: a fast vectorized **canonical ZYZ** path (iiwa-class) and a **general Davenport** path (#354). The canonical path uses **joint 5's frame origin** as the wrist-pivot reference for the q_2 SP1 (it maps that point onto the target wrist pivot). That is only valid when joint 5's origin coincides with the wrist axis-concurrency point.

**iiwa7** (differentiable-robot-model) is genuinely SRS-class (wrist axes 4/5/6 are concurrent, `is_srs_7r` passes) but has intermediate **lateral offsets at joints 5/6**: their origins sit ±6 cm off the pivot and cancel only *at* the pivot. So the canonical path mapped joint 5's origin (6 cm off) onto the target instead of the true pivot: all 128 candidates missed FK closure by ~the offset (measured 4.4 cm), and the solver returned **0 solutions**.

The shipped default path masked this: the T-perturbation rescue produced 30 numerically-polished solutions (100% coverage). But `respect_limits=False` (the path the uniform-fuzz gate uses) exposed the raw 0. That is exactly the "respect_limits invariant" violation reported in #424 for iiwa7.

## Fix

The canonical fast-path has an unstated precondition: an **offset-free wrist**. Guard it (`wrist_offset_free = origins[5] ≈ wrist_pivot`) and route offset-wrist arms to the general path, which references the wrist pivot explicitly.

- **iiwa7**: 0 → **40/40** recovery, worst FK residual **6.7e-16**.
- **iiwa14** (offset-free): keeps the canonical path **byte-for-byte** — unchanged solutions, `<2ms` perf gate still green.
- SRS artifacts are thin wrappers around this runtime `srs.solve` (`from ssik.solvers.seven_r.srs import solve`), so the fix auto-applies to every SRS prebuilt — **no codegen composer mirror needed**.

## Test plan

- `tests/fixtures/kuka_iiwa7.urdf` (vendored, mesh-free) + 3 regression tests in `test_seven_r_srs.py`: iiwa7 is offset-wrist SRS, hand-picked FK closure ≤ 1e-10, 100-pose Hypothesis fuzz.
- **Teeth verified**: reverting the guard fails the hand-picked test at 0 solutions.
- Full `test_seven_r_srs.py` + `test_seven_r_srs_polished.py` (44) green; perf gate + iiwa14 snapshot/sanity green; broader `srs`/`seven_r`/`iiwa` sweep (138) green.
- Local gate: ruff + format + mypy clean.

Progresses #424 (iiwa7 item). j2s7s300 remains the last #424 arm.