### PR TITLE
Route spherical-wrist near-SRS 7R to srs_polished (j2s7s300, #424)

### DIFF
--- a/src/ssik/core/dispatcher.py
+++ b/src/ssik/core/dispatcher.py
@@ -173,6 +173,38 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
             _LOG.info("dispatch: chose %s (tier 0, spherical-shoulder-7R)", plan.solver_name)
             return plan
 
+        # Tier-0 7R: approximate-SRS variant for arms whose URDF axes only
+        # nearly meet (Kinova Gen3: 12 mm shoulder + 0.4 mm wrist drift; Kinova
+        # j2s7s300: 1.6 mm shoulder + exact spherical wrist). Singh-Kreutz
+        # solver as warm-start factory + LM polish to machine precision against
+        # the original URDF FK.
+        #
+        # Checked BEFORE approximate-spherical-shoulder: an arm with an
+        # (approximately) spherical WRIST is SRS-family, and approximate-SRS
+        # requires BOTH shoulder and wrist near-concurrent, so it only claims
+        # spherical-wrist arms. The spherical-shoulder-polished path is for
+        # genuinely offset wrists (xArm7), whose wrist fails this 4 cm gate
+        # (``is_approximately_srs_7r`` returns None) and so falls through below.
+        # j2s7s300 matches the shoulder predicate too but is fully covered only
+        # by srs_polished (100% vs 38% on spherical_shoulder_polished, #424).
+        approx = is_approximately_srs_7r(kb, max_drift_m=0.04, policy=policy)
+        if approx is not None:
+            plan = _make_plan(
+                "seven_r.srs_polished",
+                reason=(
+                    "Approximately-SRS 7R: shoulder axes meet within "
+                    f"{approx.shoulder_drift_m * 1000:.1f} mm, wrist axes "
+                    f"meet within {approx.wrist_drift_m * 1000:.1f} mm.\n"
+                    "Singh-Kreutz on the relaxed pivots produces algebraic\n"
+                    "candidates; LM polish recovers machine-precision FK\n"
+                    "against the original URDF. 16-30x faster than the\n"
+                    "universal jointlock+HP fallback on small-drift arms.\n"
+                    "Covers Kinova Gen3 (12 mm / 0.4 mm drift)."
+                ),
+            )
+            _LOG.info("dispatch: chose %s (tier 0, approximate-SRS-7R)", plan.solver_name)
+            return plan
+
         # Tier-0 7R: approximately-spherical-shoulder (xArm7) -- the reversed
         # lock-6 wrist triple is concurrent to within a small drift, so the
         # closed-form q_i(q6) seeds + LM polish reach machine precision.
@@ -192,28 +224,6 @@ def dispatch(kb: KinBody, policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY) ->
                 ),
             )
             _LOG.info("dispatch: chose %s (tier 0, approx-spherical-7R)", plan.solver_name)
-            return plan
-
-        # Tier-0 7R: approximate-SRS variant for arms whose URDF axes only
-        # nearly meet (Kinova Gen3: 12 mm shoulder + 0.4 mm wrist drift).
-        # Singh-Kreutz solver as warm-start factory + LM polish to
-        # machine precision against the original URDF FK.
-        approx = is_approximately_srs_7r(kb, max_drift_m=0.04, policy=policy)
-        if approx is not None:
-            plan = _make_plan(
-                "seven_r.srs_polished",
-                reason=(
-                    "Approximately-SRS 7R: shoulder axes meet within "
-                    f"{approx.shoulder_drift_m * 1000:.1f} mm, wrist axes "
-                    f"meet within {approx.wrist_drift_m * 1000:.1f} mm.\n"
-                    "Singh-Kreutz on the relaxed pivots produces algebraic\n"
-                    "candidates; LM polish recovers machine-precision FK\n"
-                    "against the original URDF. 16-30x faster than the\n"
-                    "universal jointlock+HP fallback on small-drift arms.\n"
-                    "Covers Kinova Gen3 (12 mm / 0.4 mm drift)."
-                ),
-            )
-            _LOG.info("dispatch: chose %s (tier 0, approximate-SRS-7R)", plan.solver_name)
             return plan
 
         # Tier-1 7R fallback: joint-lock + dispatch the inner 6R.

--- a/tests/fixtures/j2s7s300.urdf
+++ b/tests/fixtures/j2s7s300.urdf
@@ -1,0 +1,150 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot name="j2s7s300">
+  <link name="root" />
+  <link name="world" />
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin rpy="0 0 0" xyz="0 0 0" />
+  </joint>
+  <link name="j2s7s300_link_base">
+    </link>
+  <joint name="j2s7s300_joint_base" type="fixed">
+    <parent link="root" />
+    <child link="j2s7s300_link_base" />
+    <axis xyz="0 0 0" />
+    <origin rpy="0 0 0" xyz="0 0 0" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_1">
+    </link>
+  <joint name="j2s7s300_joint_1" type="continuous">
+    <parent link="j2s7s300_link_base" />
+    <child link="j2s7s300_link_1" />
+    <axis xyz="0 0 1" />
+    <limit effort="40" velocity="0.6283185307179586" />
+    <origin rpy="0 3.141592653589793 0" xyz="0 0 0.15675" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_2">
+    </link>
+  <joint name="j2s7s300_joint_2" type="revolute">
+    <parent link="j2s7s300_link_1" />
+    <child link="j2s7s300_link_2" />
+    <axis xyz="0 0 1" />
+    <limit effort="80" lower="0.8203047484373349" upper="5.462880558742252" velocity="0.6283185307179586" />
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.0016 -0.11875" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_3">
+    </link>
+  <joint name="j2s7s300_joint_3" type="continuous">
+    <parent link="j2s7s300_link_2" />
+    <child link="j2s7s300_link_3" />
+    <axis xyz="0 0 1" />
+    <limit effort="40" velocity="0.6283185307179586" />
+    <origin rpy="-1.5707963267948966 0 0" xyz="0 -0.205 0" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_4">
+    </link>
+  <joint name="j2s7s300_joint_4" type="revolute">
+    <parent link="j2s7s300_link_3" />
+    <child link="j2s7s300_link_4" />
+    <axis xyz="0 0 1" />
+    <limit effort="40" lower="0.5235987755982988" upper="5.759586531581287" velocity="0.6283185307179586" />
+    <origin rpy="1.5707963267948966 0 3.141592653589793" xyz="0 0 -0.205" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_5">
+    </link>
+  <joint name="j2s7s300_joint_5" type="continuous">
+    <parent link="j2s7s300_link_4" />
+    <child link="j2s7s300_link_5" />
+    <axis xyz="0 0 1" />
+    <limit effort="20" velocity="0.8377580409572781" />
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.2073 -0.0114" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_6">
+    </link>
+  <joint name="j2s7s300_joint_6" type="revolute">
+    <parent link="j2s7s300_link_5" />
+    <child link="j2s7s300_link_6" />
+    <axis xyz="0 0 1" />
+    <limit effort="20" lower="1.1344640137963142" upper="5.148721293383272" velocity="0.8377580409572781" />
+    <origin rpy="1.5707963267948966 0 3.141592653589793" xyz="0 0 -0.10375" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_link_7">
+    </link>
+  <joint name="j2s7s300_joint_7" type="continuous">
+    <parent link="j2s7s300_link_6" />
+    <child link="j2s7s300_link_7" />
+    <axis xyz="0 0 1" />
+    <limit effort="20" velocity="0.8377580409572781" />
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.10375 0" />
+    <dynamics damping="0.0" friction="0.0" />
+  </joint>
+  <link name="j2s7s300_end_effector" />
+  <joint name="j2s7s300_joint_end_effector" type="fixed">
+    <parent link="j2s7s300_link_7" />
+    <child link="j2s7s300_end_effector" />
+    <axis xyz="0 0 0" />
+    <origin rpy="3.141592653589793 0 1.5707963267948966" xyz="0 0 -0.1600" />
+  </joint>
+  <link name="j2s7s300_link_finger_1">
+    </link>
+  <joint name="j2s7s300_joint_finger_1" type="revolute">
+    <parent link="j2s7s300_link_7" />
+    <child link="j2s7s300_link_finger_1" />
+    <axis xyz="0 0 1" />
+    <origin rpy="-1.7047873384941834 0.6476144647144773 1.67317415161155" xyz="0.00279 0.03126 -0.11467" />
+    <limit effort="2" lower="0" upper="1.51" velocity="1" />
+  </joint>
+  <link name="j2s7s300_link_finger_tip_1">
+    </link>
+  <joint name="j2s7s300_joint_finger_tip_1" type="revolute">
+    <parent link="j2s7s300_link_finger_1" />
+    <child link="j2s7s300_link_finger_tip_1" />
+    <axis xyz="0 0 1" />
+    <origin rpy="0 0 0" xyz="0.044 -0.003 0" />
+    <limit effort="2" lower="0" upper="2" velocity="1" />
+  </joint>
+  <link name="j2s7s300_link_finger_2">
+    </link>
+  <joint name="j2s7s300_joint_finger_2" type="revolute">
+    <parent link="j2s7s300_link_7" />
+    <child link="j2s7s300_link_finger_2" />
+    <axis xyz="0 0 1" />
+    <origin rpy="-1.570796327 .649262481663582 -1.38614049188413" xyz="0.02226 -0.02707 -0.11482" />
+    <limit effort="2" lower="0" upper="1.51" velocity="1" />
+  </joint>
+  <link name="j2s7s300_link_finger_tip_2">
+    </link>
+  <joint name="j2s7s300_joint_finger_tip_2" type="revolute">
+    <parent link="j2s7s300_link_finger_2" />
+    <child link="j2s7s300_link_finger_tip_2" />
+    <axis xyz="0 0 1" />
+    <origin rpy="0 0 0" xyz="0.044 -0.003 0" />
+    <limit effort="2" lower="0" upper="2" velocity="1" />
+  </joint>
+  <link name="j2s7s300_link_finger_3">
+    </link>
+  <joint name="j2s7s300_joint_finger_3" type="revolute">
+    <parent link="j2s7s300_link_7" />
+    <child link="j2s7s300_link_finger_3" />
+    <axis xyz="0 0 1" />
+    <origin rpy="-1.570796327 .649262481663582 -1.75545216211587" xyz="-0.02226 -0.02707 -0.11482" />
+    <limit effort="2" lower="0" upper="1.51" velocity="1" />
+  </joint>
+  <link name="j2s7s300_link_finger_tip_3">
+    </link>
+  <joint name="j2s7s300_joint_finger_tip_3" type="revolute">
+    <parent link="j2s7s300_link_finger_3" />
+    <child link="j2s7s300_link_finger_tip_3" />
+    <axis xyz="0 0 1" />
+    <origin rpy="0 0 0" xyz="0.044 -0.003 0" />
+    <limit effort="2" lower="0" upper="2" velocity="1" />
+  </joint>
+</robot>

--- a/tests/test_seven_r_srs_polished.py
+++ b/tests/test_seven_r_srs_polished.py
@@ -43,10 +43,15 @@ from _perf import best_call_ms
 GEN3_URDF = Path(__file__).parent / "fixtures" / "gen3.urdf"
 RIZON4_URDF = Path(__file__).parent / "fixtures" / "rizon4.urdf"
 KR810_URDF = Path(__file__).parent / "fixtures" / "kassow_kr810.urdf"
+J2S7_URDF = Path(__file__).parent / "fixtures" / "j2s7s300.urdf"
 
 
 def _gen3_kb():
     return load_urdf_kinbody_normalized(GEN3_URDF, "base_link", "end_effector_link")
+
+
+def _j2s7_kb():
+    return load_urdf_kinbody_normalized(J2S7_URDF, "j2s7s300_link_base", "j2s7s300_link_7")
 
 
 def _rizon4_kb():
@@ -316,3 +321,49 @@ def test_polished_works_on_iiwa14() -> None:
     assert sols
     best_fk = min(s.fk_residual for s in sols)
     assert best_fk < 1e-10
+
+
+# ----------------------------------------------------------------------------
+# Kinova j2s7s300 (#424): spherical wrist + near-spherical shoulder (1.6 mm).
+# It matches BOTH the approximate-spherical-shoulder and approximate-SRS
+# predicates; approximate-SRS must win (dispatch order) because only
+# srs_polished gives full coverage (100% vs ~38% on spherical_shoulder_polished).
+# ----------------------------------------------------------------------------
+
+
+def test_dispatcher_routes_j2s7_to_srs_polished_not_spherical_shoulder() -> None:
+    """j2s7s300 has an exact spherical wrist, so it is SRS-family and must
+    route to srs_polished -- NOT spherical_shoulder_polished, which only
+    covers ~38% of its reachable poses (#424). Guards the dispatch precedence:
+    an (approximately) spherical-wrist arm is claimed by approximate-SRS first.
+    """
+    kb = _j2s7_kb()
+    approx = is_approximately_srs_7r(kb, max_drift_m=0.04)
+    assert approx is not None, "j2s7 must satisfy approximate-SRS"
+    assert approx.wrist_drift_m < 1e-3, "j2s7 wrist is (near-)exactly spherical"
+    assert dispatch(kb).solver_name == "seven_r.srs_polished"
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_j2s7_random_pose_fk_closure(seed: int) -> None:
+    """50 random reachable j2s7 poses: at least one retained IK FK-closes.
+
+    Regression for #424: spherical_shoulder_polished (the pre-fix route) covered
+    only ~38%; srs_polished covers 100%. This asserts full coverage on the
+    correctly-dispatched solver.
+    """
+    kb = _j2s7_kb()
+    rng = np.random.default_rng(seed)
+    lim = [j.limits if j.limits else (-np.pi, np.pi) for j in kb.joints]
+    q_star = np.array([rng.uniform(lo, hi) for lo, hi in lim])
+    T_target = poe_forward_kinematics(kb, q_star)
+    sols, _ = srs_polished.solve(kb, T_target)
+    assert sols, f"no IK for reachable j2s7 pose (seed={seed})"
+    assert any(
+        float(np.linalg.norm(poe_forward_kinematics(kb, s.q) - T_target)) < 1e-8 for s in sols
+    ), f"no FK-closing IK among {len(sols)} for seed={seed}"


### PR DESCRIPTION
## Root cause

Kinova j2s7s300 has an **exact spherical wrist** (0.0 mm axis drift) and a **near-spherical shoulder** (1.6 mm drift). It satisfies *both* `is_approximately_spherical_shoulder_7r` and `is_approximately_srs_7r`, and the dispatcher checked the **spherical-shoulder predicate first** — so j2s7 routed to `seven_r.spherical_shoulder_polished`, which covers only **~38%** of its reachable poses (the #424 coverage gap). `seven_r.srs_polished` covers **100%**.

The mismatch: the spherical-shoulder-polished path is designed for **offset-wrist** arms (xArm7). j2s7 has a *spherical* wrist, which makes it SRS-family.

## Fix

Check `is_approximately_srs_7r` **before** `is_approximately_spherical_shoulder_7r`. Approximate-SRS requires **both** shoulder and wrist near-concurrent, so it only claims spherical-wrist arms; genuinely offset-wrist arms fail its 4 cm gate (`is_approximately_srs_7r` returns `None`) and fall through to the spherical-shoulder path unchanged.

## No shipped-arm regression (verified)

Measured `is_approximately_srs_7r` + coverage under both solvers for the only affected arm and confirmed all 10 shipped 7R spherical/SRS arms route to their manifest solver unchanged:

| Arm | approx-SRS? | srs_polished | spherical_shoulder_polished | routes to |
|---|---|---|---|---|
| **j2s7s300** | yes (1.6mm / 0.0mm) | **100%** | 38% | srs_polished ✅ (was spherical_shoulder_polished) |
| xArm7 | **None** (offset wrist) | 0% | **100%** | spherical_shoulder_polished ✅ (unchanged) |
| Gen3 / YuMi L+R | yes | 100% | — | srs_polished ✅ (unchanged) |
| Franka / FR3 | — | — | — | exact spherical_shoulder ✅ (unchanged, checked earlier) |

## Test plan

- `tests/fixtures/j2s7s300.urdf` (vendored, mesh-free) + 2 regression tests: dispatch routing (asserts spherical wrist + srs_polished) and 50-pose Hypothesis FK-closure coverage.
- `test_dispatcher` + `test_seven_r_srs_polished` + `test_spherical_shoulder_polished` (32) green; broader dispatch/spherical/srs sweep (187) green.
- Local gate: ruff + format + mypy (219 files) clean.

Closes the last arm on #424 (with iiwa7 fixed in #439). j2s7 is now ready to onboard as a prebuilt.