### PR TITLE
Onboard KUKA iiwa7 + Kinova j2s7s300 as prebuilts (closes #424)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ keywords:
   - manipulation
 abstract: >
   ssik is a Python library that produces every analytical inverse-kinematics
-  branch for 6R and 7R revolute manipulators. It ships 45 prebuilt arms
-  (UR5, UR3e, UR5e, UR10e, UR16e, UR20, UR30, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, xArm7, xArm6, Z1, PiPER, Rizon 4, Kassow KR810, Rizon 10, CRX-3iA, CRX-5iA, CRX-10iA, CRX-10iA/LP, CRX-20iA/L, CRX-30iA, CRX-10iA/L, YAM, big_yam, FR3, OpenArm L, OpenArm R, R1 Pro L, R1 Pro R, Thor, Core, Spark, Gen3 Lite, UR7E, UR12E, UR15, UR18, YuMi L, YuMi R, M-710iC, JACO j2s6s300) and a "ssik build"
+  branch for 6R and 7R revolute manipulators. It ships 47 prebuilt arms
+  (UR5, UR3e, UR5e, UR10e, UR16e, UR20, UR30, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, xArm7, xArm6, Z1, PiPER, Rizon 4, Kassow KR810, Rizon 10, CRX-3iA, CRX-5iA, CRX-10iA, CRX-10iA/LP, CRX-20iA/L, CRX-30iA, CRX-10iA/L, YAM, big_yam, FR3, OpenArm L, OpenArm R, R1 Pro L, R1 Pro R, Thor, Core, Spark, Gen3 Lite, UR7E, UR12E, UR15, UR18, YuMi L, YuMi R, M-710iC, JACO j2s6s300, iiwa7, JACO j2s7s300) and a "ssik build"
   CLI that emits a self-contained per-arm artifact from a URDF. ssik covers kinematic classes that the
   standard subproblem-decomposition libraries do not — non-Pieper 6R
   (JACO 2's 55° twists), non-SRS 7R (Rizon 4, Kassow KR810), and

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are two artifact paths:
 
 ### Use a prebuilt arm (`ssik.prebuilt`)
 
-The wheel ships <!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> ready-to-import artifacts, grouped by vendor below (expand a vendor to see its arms). Each imports as `ssik.prebuilt.<vendor>.<module>` (e.g. `from ssik.prebuilt.universal_robots import ur5_ik`) and the flat `from ssik.prebuilt import ur5_ik` alias still works. Each was built against a specific URDF (or extracted spec); `T_target` is the pose of `EE_LINK` expressed in `BASE_LINK`:
+The wheel ships <!-- AUTOGEN:arm_count -->47<!-- /AUTOGEN --> ready-to-import artifacts, grouped by vendor below (expand a vendor to see its arms). Each imports as `ssik.prebuilt.<vendor>.<module>` (e.g. `from ssik.prebuilt.universal_robots import ur5_ik`) and the flat `from ssik.prebuilt import ur5_ik` alias still works. Each was built against a specific URDF (or extracted spec); `T_target` is the pose of `EE_LINK` expressed in `BASE_LINK`:
 
 <!-- AUTOGEN:readme_prebuilt_table -->
 <details>
@@ -114,7 +114,7 @@ The wheel ships <!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> ready-to-import ar
 </details>
 
 <details>
-<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (4 arms)</summary>
+<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (5 arms)</summary>
 
 | Module | Arm | Class | base_link | ee_link |
 |---|---|---|---|---|
@@ -122,15 +122,17 @@ The wheel ships <!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> ready-to-import ar
 | `gen3_ik` | Kinova Gen3 7-DOF | **approximate-SRS 7R** | `base_link` | `end_effector_link` |
 | `gen3_lite_ik` | Kinova Gen3 Lite | **non-Pieper 6R** | `base_link` | `end_effector_link` |
 | `j2s6s300_ik` | Kinova JACO j2s6s300 | Pieper 6R (spherical wrist) | `j2s6s300_link_base` | `j2s6s300_end_effector` |
+| `j2s7s300_ik` | Kinova JACO j2s7s300 | **approximate-SRS 7R** (spherical wrist) | `j2s7s300_link_base` | `j2s7s300_link_7` |
 
 </details>
 
 <details>
-<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (1 arm)</summary>
+<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (2 arms)</summary>
 
 | Module | Arm | Class | base_link | ee_link |
 |---|---|---|---|---|
 | `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R | `base` | `iiwa_link_ee_kuka` |
+| `iiwa7_ik` | KUKA iiwa LBR 7 | SRS 7R (offset wrist) | `iiwa_link_0` | `iiwa_link_ee` |
 
 </details>
 
@@ -522,7 +524,7 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 </details>
 
 <details>
-<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (4 arms)</summary>
+<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (5 arms)</summary>
 
 | Arm (class) | EAIK | ssik |
 |---|---|---|
@@ -530,15 +532,17 @@ EAIK (Ostermeier 2024) is the canonical Python wrapper around C++ subproblem-dec
 | Gen3 (**approximate-SRS 7R**, 12 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 12.87 ± 0.27 ms / FK 1e-12 / 11-92 sols |
 | Gen3 Lite (**non-Pieper 6R**) | **refuses** ("Intersection point can't be calculated for two parallel axes") | 1.35 ± 0.08 ms / FK 1e-8 / 1-12 sols |
 | JACO j2s6s300 (Pieper 6R, spherical wrist) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 380 ± 10 µs / FK 4e-8 / 6-8 sols |
+| JACO j2s7s300 (**approximate-SRS 7R**, 1.6 mm offset) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 17.50 ± 0.98 ms / FK 1e-12 / 2-66 sols |
 
 </details>
 
 <details>
-<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (1 arm)</summary>
+<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (2 arms)</summary>
 
 | Arm (class) | EAIK | ssik |
 |---|---|---|
 | iiwa14 (SRS 7R) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 4.84 ± 0.02 ms / FK 1e-13 / 128 sols |
+| iiwa7 (SRS 7R, offset wrist) | **refuses** ("Currently, only 1-6R robots are solvable with EAIK") | 5.83 ± 0.59 ms / FK 5e-14 / 128 sols |
 
 </details>
 

--- a/docs/arm_coverage.md
+++ b/docs/arm_coverage.md
@@ -140,7 +140,7 @@ Each prebuilt's kinematic chain is sourced from a specific upstream URDF (or, fo
 </details>
 
 <details>
-<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (4 arms)</summary>
+<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (5 arms)</summary>
 
 | Module | Fixture provenance |
 |---|---|
@@ -148,15 +148,17 @@ Each prebuilt's kinematic chain is sourced from a specific upstream URDF (or, fo
 | `gen3_ik` | Kinovarobotics / ros_kortex (kortex_description / gen3.xacro) |
 | `gen3_lite_ik` | robot_descriptions / gen3_lite_description |
 | `j2s6s300_ik` | robot_descriptions / j2s6s300_description |
+| `j2s7s300_ik` | kinova-ros (kinova_description / j2s7s300_standalone.xacro) |
 
 </details>
 
 <details>
-<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (1 arm)</summary>
+<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (2 arms)</summary>
 
 | Module | Fixture provenance |
 |---|---|
 | `iiwa14_ik` | robot_descriptions / iiwa14_description |
+| `iiwa7_ik` | robot_descriptions / iiwa7_description |
 
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ T_target[:3, 3] = [0.5, 0.1, 0.3]
 sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
 ```
 
-<!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> prebuilt arms ship with the wheel: <!-- AUTOGEN:arm_roster -->UR5, UR3e, UR5e, UR10e, UR16e, UR20, UR30, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, xArm7, xArm6, Z1, PiPER, Rizon 4, Kassow KR810, Rizon 10, CRX-3iA, CRX-5iA, CRX-10iA, CRX-10iA/LP, CRX-20iA/L, CRX-30iA, CRX-10iA/L, YAM, big_yam, FR3, OpenArm L, OpenArm R, R1 Pro L, R1 Pro R, Thor, Core, Spark, Gen3 Lite, UR7E, UR12E, UR15, UR18, YuMi L, YuMi R, M-710iC, JACO j2s6s300<!-- /AUTOGEN -->. For other arms, run `ssik build <your.urdf>` once and import the emitted module.
+<!-- AUTOGEN:arm_count -->47<!-- /AUTOGEN --> prebuilt arms ship with the wheel: <!-- AUTOGEN:arm_roster -->UR5, UR3e, UR5e, UR10e, UR16e, UR20, UR30, Puma 560, JACO 2, iiwa14, Gen3, Franka Panda, xArm7, xArm6, Z1, PiPER, Rizon 4, Kassow KR810, Rizon 10, CRX-3iA, CRX-5iA, CRX-10iA, CRX-10iA/LP, CRX-20iA/L, CRX-30iA, CRX-10iA/L, YAM, big_yam, FR3, OpenArm L, OpenArm R, R1 Pro L, R1 Pro R, Thor, Core, Spark, Gen3 Lite, UR7E, UR12E, UR15, UR18, YuMi L, YuMi R, M-710iC, JACO j2s6s300, iiwa7, JACO j2s7s300<!-- /AUTOGEN -->. For other arms, run `ssik build <your.urdf>` once and import the emitted module.
 
 ## Where to go next
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,7 +54,7 @@ sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
 </details>
 
 <details>
-<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (4 arms)</summary>
+<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (5 arms)</summary>
 
 | Module | Arm | Class | base_link | ee_link |
 |---|---|---|---|---|
@@ -62,15 +62,17 @@ sols = franka_panda_ik.solve(T_target)        # every analytical IK branch
 | `gen3_ik` | Kinova Gen3 7-DOF | approximate-SRS 7R | `base_link` | `end_effector_link` |
 | `gen3_lite_ik` | Kinova Gen3 Lite | non-Pieper 6R | `base_link` | `end_effector_link` |
 | `j2s6s300_ik` | Kinova JACO j2s6s300 | Pieper 6R (spherical wrist) | `j2s6s300_link_base` | `j2s6s300_end_effector` |
+| `j2s7s300_ik` | Kinova JACO j2s7s300 | approximate-SRS 7R (spherical wrist) | `j2s7s300_link_base` | `j2s7s300_link_7` |
 
 </details>
 
 <details>
-<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (1 arm)</summary>
+<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (2 arms)</summary>
 
 | Module | Arm | Class | base_link | ee_link |
 |---|---|---|---|---|
 | `iiwa14_ik` | KUKA iiwa LBR 14 | SRS 7R | `base` | `iiwa_link_ee_kuka` |
+| `iiwa7_ik` | KUKA iiwa LBR 7 | SRS 7R (offset wrist) | `iiwa_link_0` | `iiwa_link_ee` |
 
 </details>
 

--- a/docs/setting_up_your_robot.md
+++ b/docs/setting_up_your_robot.md
@@ -1,10 +1,10 @@
 # Setting up your robot
 
-Guide for getting your specific arm working with ssik — beyond the <!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> prebuilts. Three real-world friction points: **URDF readiness**, **link selection** (base + EE + tool), and **verification** (does the baked geometry match your robot?).
+Guide for getting your specific arm working with ssik — beyond the <!-- AUTOGEN:arm_count -->47<!-- /AUTOGEN --> prebuilts. Three real-world friction points: **URDF readiness**, **link selection** (base + EE + tool), and **verification** (does the baked geometry match your robot?).
 
 ## When a prebuilt is enough vs when to `ssik build`
 
-The <!-- AUTOGEN:arm_count -->45<!-- /AUTOGEN --> prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
+The <!-- AUTOGEN:arm_count -->47<!-- /AUTOGEN --> prebuilts cover **nominal manufacturer geometry with a bare flange**. They work when:
 
 - You're using the same URDF source we built against (ros-industrial, vendor reference, etc.)
 - Your robot's calibration matches the nominal kinematic parameters

--- a/src/ssik/prebuilt/MANIFEST.toml
+++ b/src/ssik/prebuilt/MANIFEST.toml
@@ -1701,3 +1701,72 @@ sols_max = 8
 supported = false
 refusal = "Currently, only 1-6R robots are solvable with EAIK"
 
+[arms.iiwa7_ik]
+display_name = "KUKA iiwa LBR 7"
+short_name = "iiwa7"
+vendor = "kuka"
+fixture = "kuka_iiwa7.urdf"
+fixture_kind = "urdf"
+fixture_source = "robot_descriptions / iiwa7_description"
+base_link = "iiwa_link_0"
+ee_link = "iiwa_link_ee"
+dof = 7
+solver = "seven_r.srs"
+tier = 0
+kinematic_class = "SRS 7R (offset wrist)"
+short_class = "SRS 7R, offset wrist"
+class_tags = ["SRS", "7R", "offset-wrist"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 14
+sample_q = [0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]
+fk_ceiling_fuzz = 1e-10
+platform_drift = false
+
+[arms.iiwa7_ik.bench]
+ms_mean = 5.83
+ms_ci95 = 0.59
+max_fk = 5.1e-14
+sols_min = 128
+sols_max = 128
+
+[arms.iiwa7_ik.eaik]
+supported = false
+refusal = "Currently, only 1-6R robots are solvable with EAIK"
+[arms.j2s7s300_ik]
+display_name = "Kinova JACO j2s7s300"
+short_name = "JACO j2s7s300"
+vendor = "kinova"
+fixture = "j2s7s300.urdf"
+fixture_kind = "urdf"
+fixture_source = "kinova-ros (kinova_description / j2s7s300_standalone.xacro)"
+base_link = "j2s7s300_link_base"
+ee_link = "j2s7s300_link_7"
+dof = 7
+solver = "seven_r.srs_polished"
+tier = 0
+kinematic_class = "approximate-SRS 7R (spherical wrist)"
+short_class = "approximate-SRS 7R, 1.6 mm offset"
+class_tags = ["approximate-SRS", "7R"]
+slow_build = false
+build_time_sec = 1
+artifact_size_kb = 14
+sample_q = [0.3, 2.0, -0.5, 3.0, 0.2, 3.0, 0.4]
+fk_ceiling_fuzz = 1e-9
+platform_drift = true
+drift_markers = [
+    "_solver_solve",
+    'SOLVER_NAME = "seven_r.srs_polished"',
+    "def fk(q):",
+]
+
+[arms.j2s7s300_ik.bench]
+ms_mean = 17.50
+ms_ci95 = 0.98
+max_fk = 9.9e-13
+sols_min = 2
+sols_max = 66
+
+[arms.j2s7s300_ik.eaik]
+supported = false
+refusal = "Currently, only 1-6R robots are solvable with EAIK"

--- a/src/ssik/prebuilt/README.md
+++ b/src/ssik/prebuilt/README.md
@@ -63,7 +63,7 @@ preprocessing) and cleaner to ship in production stacks.
 </details>
 
 <details>
-<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (4 arms)</summary>
+<summary><b>Kinova</b>: <code>ssik.prebuilt.kinova</code> (5 arms)</summary>
 
 | Arm | Solver | Build time | Artifact size |
 |---|---|:---:|:---:|
@@ -71,15 +71,17 @@ preprocessing) and cleaner to ship in production stacks.
 | `gen3_ik` | `seven_r.srs_polished` | <1 s | ~10 KB |
 | `gen3_lite_ik` | `ikgeo.general_6r` | <1 s | ~10 KB |
 | `j2s6s300_ik` | `ikgeo.spherical_two_parallel` | <1 s | ~28 KB |
+| `j2s7s300_ik` | `seven_r.srs_polished` | <1 s | ~14 KB |
 
 </details>
 
 <details>
-<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (1 arm)</summary>
+<summary><b>KUKA</b>: <code>ssik.prebuilt.kuka</code> (2 arms)</summary>
 
 | Arm | Solver | Build time | Artifact size |
 |---|---|:---:|:---:|
 | `iiwa14_ik` | `seven_r.srs` | <1 s | ~9 KB |
+| `iiwa7_ik` | `seven_r.srs` | <1 s | ~14 KB |
 
 </details>
 

--- a/src/ssik/prebuilt/__init__.py
+++ b/src/ssik/prebuilt/__init__.py
@@ -78,6 +78,8 @@ _LEGACY_ALIASES: dict[str, str] = {
     "yumi_right_ik": "abb.yumi_right_ik",
     "fanuc_m710ic_ik": "fanuc.m710ic_ik",
     "j2s6s300_ik": "kinova.j2s6s300_ik",
+    "iiwa7_ik": "kuka.iiwa7_ik",
+    "j2s7s300_ik": "kinova.j2s7s300_ik",
 }
 
 _PKG = __name__  # "ssik.prebuilt"

--- a/src/ssik/prebuilt/kinova/j2s7s300_ik.py
+++ b/src/ssik/prebuilt/kinova/j2s7s300_ik.py
@@ -1,0 +1,313 @@
+"""Generated IK module for Kinova JACO j2s7s300.
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Provenance: KinBody hash f0ec71f81c0a (sha256/12 of the input chain).
+``T_target`` is the pose of ``j2s7s300_link_7`` (end-effector link) in
+``j2s7s300_link_base`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
+
+DOF: 7    BASE_LINK: "j2s7s300_link_base"    EE_LINK: "j2s7s300_link_7"
+Solver: ``seven_r.srs_polished`` (tier 0)
+Expected median IK time: ~56.0 ms on commodity
+single-thread hardware. FLOP budget: 80,000 per solve.
+
+Usage:
+
+    import j2s7s300_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose of j2s7s300_link_7 in j2s7s300_link_base
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions = j2s7s300_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``j2s7s300_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.postprocess import finalize_solutions as _ps_finalize
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement import seeded_track as _seeded_track
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
+from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
+from ssik.solvers.seven_r.srs_polished import solve as _solver_solve
+
+SOLVER_NAME = "seven_r.srs_polished"
+SOLVER_TIER = 0
+EXPECTED_MS_MEDIAN = 56.0
+FLOP_BUDGET = 80000
+DISPATCH_REASON = 'Approximately-SRS 7R: shoulder axes meet within 1.6 mm, wrist axes meet within 0.0 mm.\nSingh-Kreutz on the relaxed pivots produces algebraic\ncandidates; LM polish recovers machine-precision FK\nagainst the original URDF. 16-30x faster than the\nuniversal jointlock+HP fallback on small-drift arms.\nCovers Kinova Gen3 (12 mm / 0.4 mm drift).'
+BASE_LINK = "j2s7s300_link_base"
+EE_LINK = "j2s7s300_link_7"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, -1.2246467991473537e-16, -1.2246467991473532e-16, 1.0280909878842028e-17], [1.2246467991473535e-16, 1.0, -3.67394039744206e-16, -0.009799999999999996], [1.2246467991473532e-16, 3.6739403974420594e-16, 1.0, 0.07279999999999999], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['j2s7s300_link_base', '_poe_link_1', '_poe_link_2', '_poe_link_3', '_poe_link_4', '_poe_link_5', '_poe_link_6', 'j2s7s300_link_7']
+
+_JOINT_NAMES = [
+    'j2s7s300_joint_1',
+    'j2s7s300_joint_2',
+    'j2s7s300_joint_3',
+    'j2s7s300_joint_4',
+    'j2s7s300_joint_5',
+    'j2s7s300_joint_6',
+    'j2s7s300_joint_7',
+]
+
+_JOINT_AXES = [
+    np.array([1.2246467991473532e-16, 0.0, -1.0], dtype=np.float64),
+    np.array([1.2246467991473532e-16, -1.0, -6.123233995736765e-17], dtype=np.float64),
+    np.array([-1.2246467991473532e-16, -1.2246467991473532e-16, 1.0], dtype=np.float64),
+    np.array([-7.498798913309288e-33, 1.0, 1.8369701987210297e-16], dtype=np.float64),
+    np.array([2.4492935982947064e-16, 2.4492935982947064e-16, -1.0], dtype=np.float64),
+    np.array([1.2246467991473537e-16, -1.0, -3.0616169978683826e-16], dtype=np.float64),
+    np.array([-1.2246467991473532e-16, -3.67394039744206e-16, 1.0], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.15675], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -1.4542680739874818e-17], [0.0, 1.0, 0.0, 0.0016], [0.0, 0.0, 1.0, 0.11874999999999997], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 2.510525938252074e-17], [0.0, 1.0, 0.0, 1.2576745200831851e-17], [0.0, 0.0, 1.0, -0.205], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 2.5105259382520738e-17], [0.0, 1.0, 0.0, 2.5153490401663703e-17], [0.0, 0.0, 1.0, -0.205], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -2.5386928146324632e-17], [0.0, 1.0, 0.0, -0.011400000000000039], [0.0, 0.0, 1.0, 0.2073], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -2.5411421082307578e-17], [0.0, 1.0, 0.0, -2.6020852139652106e-17], [0.0, 0.0, 1.0, 0.10374999999999998], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 2.5411421082307578e-17], [0.0, 1.0, 0.0, 3.122502256758253e-17], [0.0, 0.0, 1.0, -0.10375], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, -1.2246467991473537e-16, -1.2246467991473532e-16, 0.0], [1.2246467991473535e-16, 1.0, -3.67394039744206e-16, 0.0], [1.2246467991473532e-16, 3.6739403974420594e-16, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+_JOINT_LIMITS = [
+    None,
+    (0.8203047484373349, 5.462880558742252),
+    None,
+    (0.5235987755982988, 5.759586531581287),
+    None,
+    (1.1344640137963142, 5.148721293383272),
+    None,
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+def solve(
+    T_target,
+    *,
+    max_solutions=None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = False,
+    allow_rescue: bool = True,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+):
+    """Inverse kinematics. Returns ``list[Solution]``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full enumeration.
+    :param q_seed: optional joint config. When provided, solutions
+        are sorted by distance from ``q_seed`` (closest first, via
+        ``seed_metric``). Combine with ``max_solutions=1`` for the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default, largest single-joint move) holds
+        the branch during tracking; ``"wrap_l2"`` uses the summed
+        move. Ignored when ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. ``False`` returns
+        the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates. Tightens FK
+        closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    :returns: list of :class:`Solution`, one per analytical IK
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
+
+    Solver: srs_polished.
+    """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
+    # Seeded numerical-tracking fast path (#380): the caller gave a seed
+    # and wants a single IK -- the trajectory-tracking idiom. Newton-
+    # continue from the seed (~0.2 ms) instead of resolving the whole
+    # redundancy (several ms). On a smooth trajectory the continuation is
+    # exactly the seed-nearest solution the full solve would return; it
+    # is run through the same limit/tolerance postprocess below so its
+    # output is indistinguishable from the full path's. When the seed
+    # doesn't continue cleanly (Newton jumped a branch, diverged, or the
+    # result fails limits/seed_tolerance) ``_seeded_track`` returns
+    # ``None`` / the postprocess empties and we fall through to the full
+    # analytical solve -- correctness is never traded for speed.
+    if q_seed is not None and max_solutions == 1:
+        _tracked = _seeded_track(
+            np.asarray(q_seed, dtype=np.float64),
+            fk,
+            lambda _q: _kinbody_jacobian(_KB, _q),
+            np.asarray(T_target, dtype=np.float64),
+        )
+        if _tracked is not None:
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
+            if _fast:
+                return _fast
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
+    )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+
+from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
+
+
+def fk(q):
+    """Forward kinematics: returns the 4x4 base->ee pose at ``q``."""
+    return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
+
+__all__ = [
+    "BASE_LINK",
+    "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "T_HOME",
+    "fk",
+    "solve",
+]

--- a/src/ssik/prebuilt/kuka/iiwa7_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa7_ik.py
@@ -1,0 +1,313 @@
+"""Generated IK module for KUKA iiwa LBR 7.
+
+This file was emitted by ``ssik build`` and is the public artifact for
+running analytical inverse kinematics on this specific arm. The
+per-arm KinBody constants are baked in below; you do not need to
+load a URDF or MJCF at runtime.
+
+Provenance: KinBody hash 74f3e2d08823 (sha256/12 of the input chain).
+``T_target`` is the pose of ``iiwa_link_ee`` (end-effector link) in
+``iiwa_link_0`` (base link). If your URDF differs (calibrated
+geometry, custom tool past the flange, different link names),
+run ``ssik build <your.urdf> --base <yours> --ee <yours>`` to
+produce an artifact correct for your hardware.
+
+DOF: 7    BASE_LINK: "iiwa_link_0"    EE_LINK: "iiwa_link_ee"
+Solver: ``seven_r.srs`` (tier 0)
+Expected median IK time: ~8.5 ms on commodity
+single-thread hardware. FLOP budget: 1,900 per solve.
+
+Usage:
+
+    import iiwa7_ik
+    import numpy as np
+    T_target = np.eye(4)  # 4x4 SE(3) pose of iiwa_link_ee in iiwa_link_0
+    T_target[:3, 3] = [0.5, 0.1, 0.3]
+    solutions = iiwa7_ik.solve(T_target)
+    for sol in solutions:
+        print(sol.q, sol.fk_residual)
+
+``solve(T)`` returns ``list[Solution]``. Empty list iff no
+candidate closed within the solver's FK tolerance -- check
+``if not solutions:`` for the "unreachable" case.
+
+Sanity-check the baked geometry: ``iiwa7_ik.T_HOME`` is the
+4x4 home pose (FK at ``q = np.zeros(DOF)``). If it doesn't match
+your robot's home pose, the artifact is for a different URDF.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ssik._kinbody import Joint, KinBody, Link
+from ssik.core.solution import Solution
+from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
+from ssik.postprocess import finalize_solutions as _ps_finalize
+import functools as _functools
+from ssik.refinement import kinbody_jacobian as _kinbody_jacobian
+from ssik.refinement import seeded_track as _seeded_track
+from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
+from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
+from ssik.solvers.seven_r.srs import solve as _solver_solve
+
+SOLVER_NAME = "seven_r.srs"
+SOLVER_TIER = 0
+EXPECTED_MS_MEDIAN = 8.5
+FLOP_BUDGET = 1900
+DISPATCH_REASON = 'SRS-class 7R: shoulder axes (joints 0, 1, 2) meet at\none point + wrist axes (joints 4, 5, 6) meet at one\npoint + joint 3 is the elbow. Closed-form Singh-Kreutz\n1989 algorithm, parameterised by elbow swivel angle.\nCovers KUKA iiwa LBR (canonical strict-SRS).'
+BASE_LINK = "iiwa_link_0"
+EE_LINK = "iiwa_link_ee"
+DOF = 7
+# Home pose: FK at q = np.zeros(DOF). Sanity-check this against
+# your robot's documented home pose to verify the baked geometry
+# matches your URDF.
+T_HOME = np.array([[1.0, 3.6739403974420594e-16, -1.2246467991473537e-16, -8.768471081895049e-17], [-3.6739403974420594e-16, 1.0, 2.465190328815662e-32, 2.7755575615628914e-17], [1.2246467991473532e-16, 3.697785493223493e-32, 1.0, 1.2659999999999998], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64)
+
+# --- baked KinBody constants ---
+
+_LINK_NAMES = ['iiwa_link_0', '_poe_link_1', '_poe_link_2', '_poe_link_3', '_poe_link_4', '_poe_link_5', '_poe_link_6', 'iiwa_link_ee']
+
+_JOINT_NAMES = [
+    'iiwa_joint_1',
+    'iiwa_joint_2',
+    'iiwa_joint_3',
+    'iiwa_joint_4',
+    'iiwa_joint_5',
+    'iiwa_joint_6',
+    'iiwa_joint_7',
+]
+
+_JOINT_AXES = [
+    np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    np.array([1.2246467991473532e-16, 1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([-1.2246467991473532e-16, 1.232595164407831e-32, 1.0], dtype=np.float64),
+    np.array([-1.2246467991473532e-16, -1.0, 6.123233995736766e-17], dtype=np.float64),
+    np.array([-1.2246467991473532e-16, 1.2246467991473535e-16, 1.0], dtype=np.float64),
+    np.array([2.4492935982947064e-16, 1.0, -6.123233995736764e-17], dtype=np.float64),
+    np.array([-1.2246467991473537e-16, 2.465190328815662e-32, 1.0], dtype=np.float64),
+]
+
+_JOINT_T_LEFTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.15], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.18999999999999997], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -1.5747477717949504e-33], [0.0, 1.0, 0.0, -1.2858791391047208e-17], [0.0, 0.0, 1.0, 0.20999999999999996], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -2.3268289183799712e-17], [0.0, 1.0, 0.0, 3.0814879110195774e-33], [0.0, 0.0, 1.0, 0.19000000000000006], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -2.5717582782094416e-17], [0.0, 1.0, 0.0, 1.2858791391047211e-17], [0.0, 0.0, 1.0, 0.20999999999999996], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, -3.813550132544858e-17], [0.0, 1.0, 0.0, -0.060699999999999976], [0.0, 0.0, 1.0, 0.18999999999999995], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 4.947573068555306e-18], [0.0, 1.0, 0.0, 0.060700000000000004], [0.0, 0.0, 1.0, 0.08099999999999996], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_T_RIGHTS = [
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+    np.array([[1.0, 3.6739403974420594e-16, -1.2246467991473537e-16, -5.5109105961630896e-18], [-3.6739403974420594e-16, 1.0, 2.465190328815662e-32, 0.0], [1.2246467991473532e-16, 3.697785493223493e-32, 1.0, 0.04499999999999993], [0.0, 0.0, 0.0, 1.0]], dtype=np.float64),
+]
+
+_JOINT_TYPES = [
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+    'revolute',
+]
+
+_JOINT_LIMITS = [
+    (-2.9670597283903604, 2.9670597283903604),
+    (-2.0943951023931953, 2.0943951023931953),
+    (-2.9670597283903604, 2.9670597283903604),
+    (-2.0943951023931953, 2.0943951023931953),
+    (-2.9670597283903604, 2.9670597283903604),
+    (-2.0943951023931953, 2.0943951023931953),
+    (-3.0543261909900763, 3.0543261909900763),
+]
+
+
+def _build_kb() -> KinBody:
+    """Reconstruct the baked KinBody. Run once at module import."""
+    links = [Link(name=n) for n in _LINK_NAMES]
+    joints = [
+        Joint(
+            name=_JOINT_NAMES[i],
+            dof_index=i,
+            parent_link=links[i],
+            T_left=_JOINT_T_LEFTS[i],
+            T_right=_JOINT_T_RIGHTS[i],
+            axis=_JOINT_AXES[i],
+            joint_type=_JOINT_TYPES[i],
+            limits=_JOINT_LIMITS[i],
+        )
+        for i in range(len(_JOINT_NAMES))
+    ]
+    return KinBody(links=links, joints=joints)
+
+
+_KB = _build_kb()
+
+
+def solve(
+    T_target,
+    *,
+    max_solutions=None,
+    q_seed=None,
+    respect_limits: bool = True,
+    allow_refinement: bool = False,
+    allow_rescue: bool = True,
+    policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+):
+    """Inverse kinematics. Returns ``list[Solution]``.
+
+    :param T_target: 4x4 SE(3) target end-effector pose, np.float64.
+    :param max_solutions: optional cap on returned IKs (post-dedup,
+        post-limits filter). ``None`` = full enumeration.
+    :param q_seed: optional joint config. When provided, solutions
+        are sorted by distance from ``q_seed`` (closest first, via
+        ``seed_metric``). Combine with ``max_solutions=1`` for the
+        trajectory-tracking idiom.
+    :param seed_metric: distance used to rank against ``q_seed``.
+        ``"wrap_linf"`` (default, largest single-joint move) holds
+        the branch during tracking; ``"wrap_l2"`` uses the summed
+        move. Ignored when ``q_seed`` is ``None``.
+    :param seed_tolerance: optional max per-joint deviation from
+        ``q_seed`` (radians, wrap-to-pi). When set, only solutions with
+        *every* joint within ``seed_tolerance`` are returned -- a hard
+        tracking guarantee that may return an empty list when no branch
+        qualifies. ``None`` (default) keeps the best-effort behaviour.
+        Requires ``q_seed``.
+    :param respect_limits: when ``True`` (default), solutions
+        outside URDF joint limits are dropped. ``False`` returns
+        the raw geometric set.
+    :param allow_refinement: when ``True`` (default), Newton polish
+        fires on near-miss algebraic candidates. Tightens FK
+        closure to machine precision.
+    :param allow_rescue: when ``True`` (default), if the analytical
+        path returns no solutions but the target is within the arm's
+        reach-sphere, ``solve()`` recovers the IK via the
+        T-perturbation rescue (#319) -- reachable-but-degenerate poses
+        (near-singular / near-parallel-axis) return LM-polished
+        solutions tagged ``refinement_used="lm"`` instead of ``[]``.
+        Set ``False`` for a guaranteed-analytical-or-empty result.
+        Gated by the reach-sphere, so far-field unreachable targets
+        stay cheap (no rescue fired).
+    :param policy: tolerance policy. Rarely customised.
+    :param refinement_max_iters: cap on Newton iterations per
+        candidate when ``allow_refinement=True``.
+    :returns: list of :class:`Solution`, one per analytical IK
+        branch (plus any rescued at a degenerate pose). Empty list
+        iff the target is unreachable or ``allow_rescue=False`` and
+        the analytical path found nothing.
+
+    Solver: srs.
+    """
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
+    # Seeded numerical-tracking fast path (#380): the caller gave a seed
+    # and wants a single IK -- the trajectory-tracking idiom. Newton-
+    # continue from the seed (~0.2 ms) instead of resolving the whole
+    # redundancy (several ms). On a smooth trajectory the continuation is
+    # exactly the seed-nearest solution the full solve would return; it
+    # is run through the same limit/tolerance postprocess below so its
+    # output is indistinguishable from the full path's. When the seed
+    # doesn't continue cleanly (Newton jumped a branch, diverged, or the
+    # result fails limits/seed_tolerance) ``_seeded_track`` returns
+    # ``None`` / the postprocess empties and we fall through to the full
+    # analytical solve -- correctness is never traded for speed.
+    if q_seed is not None and max_solutions == 1:
+        _tracked = _seeded_track(
+            np.asarray(q_seed, dtype=np.float64),
+            fk,
+            lambda _q: _kinbody_jacobian(_KB, _q),
+            np.asarray(T_target, dtype=np.float64),
+        )
+        if _tracked is not None:
+            # Same post-processing as the full path (no in-limits
+            # fallback: a tracked seed that fails limits/tolerance falls
+            # through to the full analytical solve below).
+            _fast = _ps_finalize(
+                [_tracked],
+                _KB,
+                respect_limits=respect_limits,
+                q_seed=q_seed,
+                seed_metric=seed_metric,
+                seed_tolerance=seed_tolerance,
+                max_solutions=1,
+            )
+            if _fast:
+                return _fast
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
+    )
+    # Bulletproof fallback (#319 / #358): the analytical path found
+    # nothing. If the target is within the arm's max reach it may be a
+    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
+    # near-parallel-axis spherical joint) the algebraic extraction
+    # can't resolve -- rather than an unreachable target. Recover via
+    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
+    # an exact upper bound by the triangle inequality, so it never
+    # rejects a reachable pose) is checked only in this rare empty
+    # branch and keeps far-field targets cheap. Perturbed re-solves run
+    # with allow_rescue=False (recursion guard + analytical escape
+    # hatch); the rescue calls back with respect_limits=False, so the
+    # rescued set flows through the same limit/seed postprocess below.
+    if not sols and allow_rescue:
+        _reach_radius = sum(
+            float(np.linalg.norm(np.asarray(_t)[:3, 3]))
+            for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
+        )
+        _T = np.asarray(T_target, dtype=np.float64)
+        if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
+            sols = _rescue_via_T_perturbation(
+                fk,
+                _functools.partial(solve, allow_rescue=False),
+                _T,
+                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            )
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions. The
+    # in-limits fallback (#359) recovers a reachable in-limits solution
+    # the coarse sweep missed via the solver-matched exact resolver
+    # (no-op for non-redundant chains).
+    return _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        q_seed=q_seed,
+        seed_metric=seed_metric,
+        seed_tolerance=seed_tolerance,
+        max_solutions=max_solutions,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+
+from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk
+
+
+def fk(q):
+    """Forward kinematics: returns the 4x4 base->ee pose at ``q``."""
+    return _poe_fk(_KB, np.asarray(q, dtype=np.float64))
+
+__all__ = [
+    "BASE_LINK",
+    "DISPATCH_REASON",
+    "DOF",
+    "EE_LINK",
+    "EXPECTED_MS_MEDIAN",
+    "FLOP_BUDGET",
+    "SOLVER_NAME",
+    "SOLVER_TIER",
+    "T_HOME",
+    "fk",
+    "solve",
+]


### PR DESCRIPTION
## What

Ships the last two arms blocked on #424, now that the underlying solver/dispatch bugs are fixed (#439, #440). Roster **45 → 47**.

| Arm | Solver | Bench | Sols | Worst FK | Notes |
|---|---|---|---|---|---|
| `iiwa7_ik` (kuka) | `seven_r.srs` | 5.8 ms | 128 | 5.1e-14 | Offset-wrist SRS → general Davenport path (#439) |
| `j2s7s300_ik` (kinova) | `seven_r.srs_polished` | 17.5 ms | 2-66 | 9.9e-13 | Approximate-SRS: 1.6 mm shoulder + exact spherical wrist (#440) |

Both hit **100% coverage over 300 `respect_limits=False` poses**.

## Details

- **Fixtures reused** from the fix PRs (no duplication): `kuka_iiwa7.urdf` (#439), `j2s7s300.urdf` (#440).
- iiwa7's `fixture_source` is `robot_descriptions / iiwa7_description`, which points at the exact upstream URDF — so `test_prebuilt_fixture_parity` FK-matches it. j2s7's upstream (`j2s7s300_description`) is MJCF-only (no `URDF_PATH`), so its source is non-`robot_descriptions` and parity is skipped (as for other vendor-URDF arms); it's still covered by the 500-pose uniform fuzz.
- Manifest stanzas complete: `fk_ceiling_fuzz` from measured `max_fk` (1e-10 / 1e-9), `platform_drift` by solver class (false for `srs`, true for `srs_polished` + drift_markers), EAIK marked unsupported (7R).
- Artifacts built (`regen_artifacts --arm`), benched (`regen_bench --arm`), docs regenerated (`regen_docs`).

## Test plan

- `test_manifest`, `test_prebuilt_uniform_fuzz`, `test_prebuilt_sanity`, `test_prebuilt_fixture_parity`, `test_artifact_snapshots`, `test_prebuilt_namespace` — all green for both arms.
- Flat (`ssik.prebuilt.iiwa7_ik`) + hierarchical (`ssik.prebuilt.kuka.iiwa7_ik`) imports + `list_arms()` include both.
- `regen_docs --check` in sync; `ruff check` / `format --check` / `mypy` (219 files) clean.

Closes #424.