### PR TITLE
add-arm --no-validate: live-solver smoke instead of silent skip (#445)

### DIFF
--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -563,6 +563,8 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     worst_fk: float | None = None
     if not args.no_validate:
         worst_fk = _build_and_validate(args, kb, plan)
+    else:
+        _live_smoke(kb, args.name)
 
     stanza = _render_manifest_stanza(
         args.name, args.base, args.ee, len(kb.joints), plan, args.vendor, worst_fk
@@ -642,6 +644,45 @@ def _build_and_validate(args: argparse.Namespace, kb: KinBody, plan: DispatchPla
         return None
     print(f"[ssik add-arm] ✓ VALIDATED: coverage {coverage:.0%}, worst FK {worst_fk:.1e}")
     return worst_fk
+
+
+def _live_smoke(kb: KinBody, name: str, *, n_poses: int = 8) -> None:
+    """Live-solver coverage smoke for a ``--no-validate`` (slow-build) arm.
+
+    ``--no-validate`` skips the minutes-long artifact build + coverage gate, and
+    used to skip onboarding validation entirely -- so a broken slow-build arm
+    (0 IK / ``[0,0]``-locked limits / wrong ee) scaffolded green (#445). This
+    runs a bounded live-solver smoke instead: no artifact build, ~seconds even on
+    HP-fallback 7R arms, enough to rule OUT catastrophic breakage. It is NOT a
+    coverage certification (7R arms run the slower HP fallback here, with reduced
+    coverage vs the built cached-RR artifact), so it always prints a loud
+    UNVALIDATED reminder to build + run the full gate before shipping."""
+    import numpy as np
+
+    from ssik.kinematics.poe_fk import poe_forward_kinematics
+    from ssik.manipulator import Manipulator
+
+    print("[ssik add-arm] --no-validate: skipping the artifact build + coverage gate.")
+    print(f"[ssik add-arm] Running a live-solver smoke instead ({n_poses} in-limits poses):")
+    arm = Manipulator(kb)
+    rng = np.random.default_rng(0)
+    limits = [(j.limits if j.limits is not None else (-np.pi, np.pi)) for j in kb.joints]
+    covered = 0
+    for _ in range(n_poses):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in limits])
+        if arm.solve(poe_forward_kinematics(kb, q)):
+            covered += 1
+
+    if covered == 0:
+        print(f"[ssik add-arm] ✗ LIKELY BROKEN: live solver returned no IK on any of {n_poses}")
+        print("[ssik add-arm]   reachable poses. Check --base/--ee, joint limits ([0,0] locks the")
+        print("[ssik add-arm]   arm), and wrist gauge BEFORE shipping.")
+    else:
+        print(f"[ssik add-arm] ~ live smoke: {covered}/{n_poses} poses solved (catastrophic-only")
+        print("[ssik add-arm]   check; 7R arms use the slower HP fallback here, reduced coverage).")
+    print("[ssik add-arm] ⚠ UNVALIDATED artifact -- before shipping, build + run the full gate:")
+    print(f"[ssik add-arm]     uv run python scripts/regen_artifacts.py --arm {name}")
+    print(f"[ssik add-arm]     uv run pytest tests/test_{name}.py")
 
 
 def _append_manifest_stanza(manifest_path: Path, name: str, stanza: str, *, force: bool) -> int:

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -323,6 +323,33 @@ def test_add_arm_write_manifest_refuses_duplicate(workspace: Path) -> None:
     assert "already exists" in third.stdout
 
 
+def test_add_arm_no_validate_runs_live_smoke(workspace: Path) -> None:
+    """``--no-validate`` no longer silently skips onboarding validation (#445):
+    it runs a bounded live-solver smoke and prints a loud UNVALIDATED reminder
+    with the build + full-gate commands, so a broken slow-build arm can't
+    scaffold green unnoticed. Uses UR5 (fast) to exercise the path."""
+    result = _run_cli(
+        "add-arm",
+        "--no-validate",
+        str(REPO_ROOT / "tests" / "fixtures" / "ur5.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "ee_link",
+        "--name",
+        "ur5_smoke_test",
+        "--vendor",
+        "universal_robots",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "live-solver smoke" in result.stdout
+    assert "8/8 poses solved" in result.stdout  # UR5 is fully covered
+    assert "UNVALIDATED" in result.stdout
+    assert "regen_artifacts.py --arm ur5_smoke_test" in result.stdout
+
+
 def test_add_arm_missing_urdf_errors_cleanly(workspace: Path) -> None:
     """Pointing at a non-existent URDF errors instead of silently writing."""
     result = _run_cli(


### PR DESCRIPTION
## Why

`--no-validate` skips the minutes-long artifact build + coverage gate for slow-build (cached-RR 7R) arms — but it used to skip onboarding validation **entirely**, so the riskiest arms (0 IK / `[0,0]`-locked limits / wrong ee) could scaffold green with no verdict. The onboarding gate that catches exactly those catastrophic failures (#423) had a hole precisely where risk is highest.

## What

Run a bounded **live-solver smoke** instead of skipping: build a live `Manipulator` (no artifact emission) and solve 8 in-limits poses.

- **Bounded**: ~seconds even on HP-fallback 7R arms (rizon4 ≈ 4s vs *minutes* to build).
- **Catches catastrophic breakage**: a 0-coverage smoke prints a `✗ LIKELY BROKEN` diagnosis pointing at `--base`/`--ee` / `[0,0]` limits / wrist gauge.
- **Honest about scope**: it's not a coverage certification (7R arms run the slower HP fallback here, reduced coverage vs the built artifact), so it **always** prints a loud `⚠ UNVALIDATED` reminder with the exact build + full-gate commands to run before shipping.

Example (`ur5 --no-validate`):
```
[ssik add-arm] Running a live-solver smoke instead (8 in-limits poses):
[ssik add-arm] ~ live smoke: 8/8 poses solved (catastrophic-only check; ...)
[ssik add-arm] ⚠ UNVALIDATED artifact -- before shipping, build + run the full gate:
[ssik add-arm]     uv run python scripts/regen_artifacts.py --arm ur5
[ssik add-arm]     uv run pytest tests/test_ur5.py
```

## Test plan

New `test_add_arm_no_validate_runs_live_smoke` asserts the smoke verdict + UNVALIDATED reminder + build command. Full add-arm suite (10) green. ruff / format / mypy (222 files) clean.

Closes #445.