### PR TITLE
Resolve multi-package ROS xacros in ingestion ($(find sibling) support) — unblocks Wave 2 (#425)

### DIFF
--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -254,15 +254,50 @@ def needs_xacro_expansion(path: Path) -> bool:
     return "<xacro:" in text or "${" in text or "$(" in text
 
 
-def process_xacro(source: str | Path, subargs: dict[str, str] | None = None) -> str:
+def _discover_package_roots(source: Path) -> list[Path]:
+    """Directories to register with xacrodoc so ``$(find <pkg>)`` in a
+    multi-package ROS xacro resolves.
+
+    Industrial vendor descriptions (ABB, KUKA, FANUC via ros-industrial) split a
+    robot across sibling ROS packages -- e.g. ``irb120_3_58.xacro`` in
+    ``abb_irb120_support`` does ``$(find abb_resources)`` for shared materials.
+    xacrodoc can't find ``abb_resources`` unless told where sibling packages
+    live. Walk up from the source to the nearest ancestor that *contains* a
+    ``package.xml`` (the source's own ROS package), and return that package's
+    parent -- the workspace/repo root that holds all the siblings. xacrodoc's
+    ``look_in`` then recursively discovers every package under it.
+    """
+    src = source.resolve()
+    for parent in src.parents:
+        if (parent / "package.xml").is_file():
+            return [parent.parent]
+    return []
+
+
+def process_xacro(
+    source: str | Path,
+    subargs: dict[str, str] | None = None,
+    package_paths: list[str | Path] | None = None,
+) -> str:
     """Expand a xacro description to a flat URDF string via ``xacrodoc``
     (resolving ``<xacro:include>``, macros, and substitution args).
 
     :param subargs: xacro substitution args (e.g. ``{"ur_type": "ur10e"}``) for
         parametrized descriptions.
+    :param package_paths: extra directories to search for ROS packages
+        referenced by ``$(find <pkg>)``. The source's own workspace root is
+        auto-discovered; pass this only when the referenced packages live
+        elsewhere (a separate checkout).
     """
     xacrodoc = _import_xacrodoc()
-    doc = xacrodoc.XacroDoc.from_file(str(source), subargs=subargs or {})  # type: ignore[attr-defined]
+    src = Path(source)
+    # Register the source's workspace root + any explicit paths so sibling-package
+    # ``$(find ...)`` references resolve (multi-package vendor descriptions).
+    roots = _discover_package_roots(src) + [Path(p) for p in (package_paths or [])]
+    for root in roots:
+        if root.is_dir():
+            xacrodoc.packages.look_in([str(root)])  # type: ignore[attr-defined]
+    doc = xacrodoc.XacroDoc.from_file(str(src), subargs=subargs or {})  # type: ignore[attr-defined]
     return str(doc.to_urdf_string())
 
 

--- a/tests/fixtures/multipkg_ws/robot_support/package.xml
+++ b/tests/fixtures/multipkg_ws/robot_support/package.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<package format="2"><name>robot_support</name><version>0.0.0</version><description>test</description>
+<maintainer email="t@t">t</maintainer><license>BSD-3-Clause</license></package>

--- a/tests/fixtures/multipkg_ws/robot_support/urdf/arm.urdf.xacro
+++ b/tests/fixtures/multipkg_ws/robot_support/urdf/arm.urdf.xacro
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<robot name="multipkg_arm" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find shared_resources)/common.xacro"/>
+  <link name="base_link"/>
+  <link name="tool"/>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/><child link="tool"/>
+    <origin xyz="0 0 ${link_len}" rpy="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="1" velocity="1"/>
+  </joint>
+</robot>

--- a/tests/fixtures/multipkg_ws/shared_resources/common.xacro
+++ b/tests/fixtures/multipkg_ws/shared_resources/common.xacro
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="link_len" value="0.5"/>
+</robot>

--- a/tests/fixtures/multipkg_ws/shared_resources/package.xml
+++ b/tests/fixtures/multipkg_ws/shared_resources/package.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<package format="2"><name>shared_resources</name><version>0.0.0</version><description>test</description>
+<maintainer email="t@t">t</maintainer><license>BSD-3-Clause</license></package>

--- a/tests/test_xacro_multipackage.py
+++ b/tests/test_xacro_multipackage.py
@@ -1,0 +1,75 @@
+"""Multi-package ROS xacro resolution in the ingestion pipeline.
+
+Industrial vendor descriptions (ABB, KUKA, FANUC via ros-industrial) split a
+robot across sibling ROS packages: ``irb120_3_58.xacro`` in ``abb_irb120_support``
+does ``<xacro:include filename="$(find abb_resources)/..."/>`` for shared
+materials. xacrodoc can't resolve ``$(find abb_resources)`` unless told where the
+sibling packages live, so ``process_xacro`` (and thus ``ssik add-arm`` /
+``from_urdf``) failed on every multi-package vendor description with
+``PackageNotFoundError``.
+
+``process_xacro`` now auto-discovers the source's workspace root (the parent of
+its own ROS package) and registers it with xacrodoc, so ``$(find <sibling>)``
+resolves with no manual ``ROS_PACKAGE_PATH`` or ``--package-path``. This test
+uses a self-contained two-package workspace (``robot_support`` includes
+``$(find shared_resources)/common.xacro``) so it needs no external checkout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WS = Path(__file__).parent / "fixtures" / "multipkg_ws"
+_ARM_XACRO = _WS / "robot_support" / "urdf" / "arm.urdf.xacro"
+
+
+def _xacrodoc_available() -> bool:
+    try:
+        import xacrodoc  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _xacrodoc_available(), reason="xacrodoc not installed")
+def test_process_xacro_resolves_sibling_package() -> None:
+    """``process_xacro`` auto-resolves ``$(find shared_resources)`` (a sibling
+    package) without any manual package-path configuration. The arm's joint
+    origin uses ``${link_len}`` defined in the sibling's common.xacro, so a
+    failed include would either raise or leave the property undefined."""
+    from ssik._urdf import process_xacro
+
+    urdf = process_xacro(_ARM_XACRO)
+    assert "<robot" in urdf
+    # 0.5 is the link_len property from the sibling package's common.xacro,
+    # substituted into the joint origin -> proves the include resolved.
+    assert "0.5" in urdf
+
+
+@pytest.mark.skipif(not _xacrodoc_available(), reason="xacrodoc not installed")
+def test_discover_package_roots_finds_workspace() -> None:
+    """The workspace root (parent of the source's own ROS package) is discovered
+    so xacrodoc's ``look_in`` finds every sibling package under it."""
+    from ssik._urdf import _discover_package_roots
+
+    roots = _discover_package_roots(_ARM_XACRO)
+    assert _WS.resolve() in [r.resolve() for r in roots]
+
+
+@pytest.mark.skipif(not _xacrodoc_available(), reason="xacrodoc not installed")
+def test_multipackage_xacro_loads_as_kinbody() -> None:
+    """End-to-end: a multi-package xacro flows through the ingestion path
+    (expand -> strip -> POE-normalize) to a usable KinBody."""
+    import tempfile
+
+    from ssik._urdf import _as_plain_urdf, load_urdf_kinbody_normalized, strip_urdf_to_fixture
+
+    with _as_plain_urdf(_ARM_XACRO) as plain:
+        stripped = Path(tempfile.mktemp(suffix=".urdf"))
+        strip_urdf_to_fixture(plain, stripped)
+    kb = load_urdf_kinbody_normalized(stripped, "base_link", "tool")
+    assert len(kb.joints) == 1
+    # link_len=0.5 from the sibling package landed in the joint offset.
+    assert abs(float(kb.joints[0].T_left[2, 3]) - 0.5) < 1e-12


### PR DESCRIPTION
## Why (gap surfaced onboarding Wave 2)

Industrial vendor descriptions (ABB, KUKA, FANUC via ros-industrial) split a robot across **sibling ROS packages**: `irb120_3_58.xacro` in `abb_irb120_support` does `<xacro:include filename="$(find abb_resources)/..."/>` for shared materials. xacrodoc can't resolve `$(find abb_resources)` unless told where the sibling packages live, so `process_xacro` — and thus `ssik add-arm` / `from_urdf` — failed on **every** multi-package vendor description with `PackageNotFoundError`. That's a hard block on all of Wave 2 (industrial Pieper flagships).

## What

`process_xacro` now **auto-discovers the source's workspace root** (the parent of its own ROS package, found by walking up to the nearest `package.xml`) and registers it with xacrodoc's `look_in`, so `$(find <sibling>)` resolves with **zero** manual `ROS_PACKAGE_PATH` / `--package-path`. Also accepts an explicit `package_paths` arg for the rare separate-checkout case.

## Verified end-to-end

ABB **IRB 120 / 1600 / 6700** + KUKA **KR6 R900 / KR210** all ingest → dispatch to `ikgeo.spherical_two_parallel` → 100% live coverage, no manual steps. IRB120 through the full `add-arm` pipeline: `✓ VALIDATED: coverage 100%, worst FK 1.2e-13`.

## Test plan

Self-contained two-package fixture (`robot_support` includes `$(find shared_resources)/common.xacro`, whose `${link_len}` property lands in the joint origin). 3 tests: sibling resolution, workspace discovery, end-to-end KinBody load. ruff / format / mypy (223 files) clean.

Advances #425 (one-click onboarding). Unblocks the Wave 2 batch (#292).