### PR TITLE
add-arm: derive class metadata + sample_q + display_name (fewer manifest TODOs) (#425)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ The metadata for a shipped arm lives in `MANIFEST.toml`. The flow is now mostly 
 
    (Spec-transcribed arms still use a Python `*_specs()` builder + `fixture_kind = "specs"`. Xacro: expand to plain URDF first — modular-URDF support is #327.)
 
-2. **Paste the stanza into `MANIFEST.toml`** and fill the `TODO` fields (copy a same-class neighbour for `kinematic_class` / `class_tags`). Or pass `--write-manifest` to `add-arm` to append the stanza automatically (it refuses to clobber an existing entry unless `--force`); you still fill the curated `TODO` fields by hand.
+2. **Paste the stanza into `MANIFEST.toml`** (or pass `--write-manifest` to `add-arm` to append it automatically; it refuses to clobber an existing entry unless `--force`). `add-arm` derives most fields: `solver` / `tier` / `dof` / `platform_drift` / `fk_ceiling_fuzz` from dispatch + the validation smoke, `kinematic_class` / `short_class` / `class_tags` from the solver, `sample_q` from a verified-solvable pose, and a best-effort `display_name`. The only fields left to hand-fill are `fixture_source` (repo + license provenance) and confirming the marketing `display_name` / `short_name`. `regen_bench.py` fills `[bench]` / `[eaik]`.
 
 3. **Emit the artifact:**
 

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -566,8 +566,9 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     else:
         _live_smoke(kb, args.name)
 
+    sample_q = _pick_sample_q(kb)
     stanza = _render_manifest_stanza(
-        args.name, args.base, args.ee, len(kb.joints), plan, args.vendor, worst_fk
+        args.name, args.base, args.ee, len(kb.joints), plan, args.vendor, worst_fk, sample_q
     )
     print()
     if args.write_manifest:
@@ -728,6 +729,111 @@ def _strip_manifest_entry(text: str, name: str) -> str:
     return "\n".join(out).rstrip("\n") + "\n"
 
 
+# Class metadata is a function of the dispatched solver, not the individual arm,
+# so add-arm derives it instead of leaving three TODOs the user hand-copies from a
+# same-class neighbour (error-prone; class_tags is one distinct set per solver
+# across the whole roster). A human may still refine the per-arm parenthetical
+# color in ``kinematic_class`` (e.g. "(offset wrist)", "~1.4 m reach").
+_SOLVER_CLASS_META: dict[str, tuple[str, str, list[str]]] = {
+    "ikgeo.three_parallel": (
+        "three-parallel 6R (UR-class)",
+        "three-parallel 6R",
+        ["three-parallel", "6R", "Pieper"],
+    ),
+    "ikgeo.spherical_two_parallel": (
+        "Pieper 6R (spherical wrist)",
+        "Pieper 6R, spherical wrist",
+        ["spherical-wrist", "6R", "Pieper"],
+    ),
+    "ikgeo.spherical_two_intersecting": (
+        "Pieper 6R (spherical wrist, intersecting shoulder)",
+        "Pieper 6R, spherical wrist",
+        ["spherical-wrist", "6R", "Pieper"],
+    ),
+    "ikgeo.spherical": (
+        "Pieper 6R (spherical wrist, general shoulder)",
+        "Pieper 6R, spherical wrist",
+        ["spherical-wrist", "6R", "Pieper"],
+    ),
+    "ikgeo.general_6r": ("non-Pieper 6R", "non-Pieper 6R", ["non-Pieper", "6R"]),
+    "jointlock.seven_r": ("non-SRS 7R", "non-SRS 7R", ["non-SRS", "7R"]),
+    "seven_r.srs": ("SRS 7R", "SRS 7R", ["SRS", "7R"]),
+    "seven_r.srs_polished": (
+        "approximate-SRS 7R",
+        "approximate-SRS 7R",
+        ["approximate-SRS", "7R"],
+    ),
+    "seven_r.spherical_shoulder": (
+        "spherical-shoulder + offset-wrist 7R",
+        "spherical-shoulder + offset-wrist 7R",
+        ["non-SRS", "spherical-shoulder", "offset-wrist", "7R"],
+    ),
+    "seven_r.spherical_shoulder_polished": (
+        "approximately-spherical-shoulder 7R",
+        "approximately-spherical-shoulder 7R",
+        ["non-SRS", "spherical-shoulder", "approximate", "7R"],
+    ),
+}
+
+# Vendor slug -> display prefix for the auto-derived display_name (a starting
+# point the user refines with the marketing model string).
+_VENDOR_DISPLAY: dict[str, str] = {
+    "universal_robots": "Universal Robots",
+    "abb": "ABB",
+    "kuka": "KUKA",
+    "kinova": "Kinova",
+    "fanuc": "FANUC",
+    "franka": "Franka",
+    "flexiv": "Flexiv",
+    "kassow": "Kassow",
+    "standard_bots": "Standard Bots",
+    "agilex": "AgileX",
+    "unitree": "Unitree",
+    "yaskawa": "Yaskawa",
+    "staubli": "Staubli",
+    "kawasaki": "Kawasaki",
+    "doosan": "Doosan",
+}
+
+
+def _class_meta(solver_name: str) -> tuple[str, str, str]:
+    """(kinematic_class, short_class, class_tags-as-TOML) for a solver, or TODO
+    placeholders if the solver is unmapped (a new solver family)."""
+    meta = _SOLVER_CLASS_META.get(solver_name)
+    if meta is None:
+        return ("TODO", "TODO", '["TODO"]')
+    kc, sc, tags = meta
+    return kc, sc, "[" + ", ".join(f'"{t}"' for t in tags) + "]"
+
+
+def _default_display_name(vendor: str, name: str) -> str:
+    """A best-effort ``display_name`` from vendor + arm name (the user confirms
+    the marketing model string). e.g. ('abb', 'irb120_ik') -> 'ABB irb120'."""
+    prefix = _VENDOR_DISPLAY.get(vendor, vendor.replace("_", " ").title())
+    model = name.removesuffix("_ik")
+    return f"{prefix} {model}".strip()
+
+
+def _pick_sample_q(kb: KinBody) -> list[float]:
+    """A verified in-limits, live-solvable pose for the stanza's ``sample_q``
+    (which ``test_prebuilt_sanity`` solves). Returns the first random in-limits
+    pose whose live solve succeeds -- usually the first try -- so a near-home
+    singular default can't silently break sanity. Falls back to a small tilt."""
+    import numpy as np
+
+    from ssik.kinematics.poe_fk import poe_forward_kinematics
+    from ssik.manipulator import Manipulator
+
+    arm = Manipulator(kb)
+    rng = np.random.default_rng(0)
+    limits = [(j.limits if j.limits is not None else (-np.pi, np.pi)) for j in kb.joints]
+    for _ in range(20):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in limits])
+        if arm.solve(poe_forward_kinematics(kb, q)):
+            return [round(float(x), 3) for x in q]
+    return [0.1] * len(kb.joints)
+
+
 def _render_manifest_stanza(
     name: str,
     base: str,
@@ -736,29 +842,35 @@ def _render_manifest_stanza(
     plan: DispatchPlan,
     vendor: str,
     worst_fk: float | None = None,
+    sample_q: list[float] | None = None,
 ) -> str:
-    """A ready-to-paste MANIFEST.toml stanza: derived fields filled (solver,
-    tier, dof, platform_drift, fk_ceiling from the validation smoke), curated
-    fields left as ``TODO``. ``regen_bench.py`` fills ``[bench]`` and ``[eaik]``."""
-    sample = ", ".join("0.1" for _ in range(dof))
+    """A ready-to-paste MANIFEST.toml stanza. Derived fields filled: solver, tier,
+    dof, platform_drift, fk_ceiling (validation smoke), kinematic_class /
+    short_class / class_tags (from the solver), sample_q (a verified-solvable
+    pose), and a best-effort display_name. Human-provenance fields
+    (fixture_source, the marketing display strings) stay editable.
+    ``regen_bench.py`` fills ``[bench]`` and ``[eaik]``."""
+    sample = ", ".join(f"{q:.3g}" for q in (sample_q or [0.1] * dof))
+    display = _default_display_name(vendor, name)
+    kin_class, short_class, tags_toml = _class_meta(plan.solver_name)
     drift = plan.solver_name in _DRIFT_PRONE_SOLVERS
     fk_ceiling = _fk_ceiling_from_worst(worst_fk) if worst_fk is not None else 1e-4
     lines = [
         f"[arms.{name}]",
-        'display_name = "TODO"',
-        'short_name = "TODO"',
+        f'display_name = "{display}"  # verify the marketing model string',
+        f'short_name = "{display}"  # shorten for compact table cells',
         f'vendor = "{vendor}"',
         f'fixture = "{name}.urdf"',
         'fixture_kind = "urdf"',
-        'fixture_source = "TODO (e.g. robot_descriptions / <pkg>)"',
+        'fixture_source = "TODO: repo/source + license (e.g. robot_descriptions / <pkg>)"',
         f'base_link = "{base}"',
         f'ee_link = "{ee}"',
         f"dof = {dof}",
         f'solver = "{plan.solver_name}"',
         f"tier = {plan.tier}",
-        'kinematic_class = "TODO"',
-        'short_class = "TODO"',
-        'class_tags = ["TODO"]',
+        f'kinematic_class = "{kin_class}"',
+        f'short_class = "{short_class}"',
+        f"class_tags = {tags_toml}",
         "slow_build = false  # set true if the build is minutes (cached-RR 7R)",
         "build_time_sec = 1",
         "artifact_size_kb = 20",

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -75,6 +75,37 @@ def test_add_arm_builds_and_validates(workspace: Path) -> None:
     assert "fk_ceiling_fuzz = 1e-04" not in result.stdout
 
 
+def test_add_arm_derives_class_metadata(workspace: Path) -> None:
+    """The printed stanza derives kinematic_class / short_class / class_tags from
+    the dispatched solver (not TODO), a verified-solvable sample_q (not the
+    near-home [0.1, ...] placeholder), and a best-effort display_name -- so the
+    only hand-fill left is the fixture_source provenance. UR5 -> three_parallel."""
+    result = _run_cli(
+        "add-arm",
+        "--no-validate",
+        str(REPO_ROOT / "tests" / "fixtures" / "ur5.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "ee_link",
+        "--name",
+        "ur5_class_test",
+        "--vendor",
+        "universal_robots",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert 'kinematic_class = "three-parallel 6R (UR-class)"' in out
+    assert 'class_tags = ["three-parallel", "6R", "Pieper"]' in out
+    assert 'kinematic_class = "TODO"' not in out
+    assert 'class_tags = ["TODO"]' not in out
+    # sample_q was replaced by a verified pose, not the [0.1, 0.1, ...] default.
+    assert "sample_q = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]" not in out
+    assert 'display_name = "Universal Robots' in out
+
+
 def test_add_arm_generates_files(workspace: Path) -> None:
     """``ssik add-arm`` vendors the URDF and emits a test scaffold."""
     result = _run_cli(


### PR DESCRIPTION
## Why

Onboarding the ABB/KUKA Wave 2 batch (#453), I hand-filled `kinematic_class` / `short_class` / `class_tags` for all 5 arms by copying a same-class neighbour — pure mechanical work, since the class is a **function of the dispatched solver** (`class_tags` is exactly one distinct set per solver across the whole roster). `add-arm` already computes the solver via dispatch, so it can fill these.

## What

`add-arm` now derives the fields it can:

| Field | Derived from |
|---|---|
| `kinematic_class` / `short_class` / `class_tags` | solver → `_SOLVER_CLASS_META` (covers every shipped solver family) |
| `sample_q` | a verified in-limits, **live-solvable** pose (`_pick_sample_q`) — not the near-home `[0.1, ...]` placeholder, which can be shoulder/wrist-singular and silently break `test_prebuilt_sanity` |
| `display_name` / `short_name` | best-effort `"<Vendor> <model>"` the user confirms |

The stanza's only remaining hand-fill is **`fixture_source`** (repo + license provenance) and confirming the marketing display strings. **~6 TODOs → ~2.**

Example (UR5):
```
kinematic_class = "three-parallel 6R (UR-class)"
class_tags = ["three-parallel", "6R", "Pieper"]
sample_q = [1.72, -2.89, -2.88, -6.08, 3.94, 5.19]   # verified solvable
display_name = "Universal Robots ur5"  # verify the marketing model string
```

## Test plan

New `test_add_arm_derives_class_metadata` asserts the derived three-parallel class + non-placeholder sample_q + display_name. add-arm suite green; ruff / format / mypy (223 files) clean. CONTRIBUTING updated.

Advances #425 (one-click onboarding).