### PR TITLE
add-arm: warn when a new arm has a >1% in-limits coverage gap (#462)

### DIFF
--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -613,6 +613,26 @@ def _scaffold_fk_ceiling(solver_name: str) -> float:
     return _SCAFFOLD_FK_CEILING.get(solver_name, 1e-6)
 
 
+# In-limits (default-path) coverage thresholds for the onboarding gate.
+# Below FAIL: the arm is broken (0 sols / [0,0] locks / wrong ee) -- refuse.
+# FAIL..CLEAN: the arm works but drops >1% of reachable in-limits poses -- the
+# swivel-vs-limits / near-singular gap (#462); ship only with a tracked xfail.
+# >= CLEAN: gap-free.
+_COVERAGE_FAIL_FLOOR = 0.90
+_COVERAGE_CLEAN_FLOOR = 0.99
+
+
+def _coverage_band(coverage: float) -> str:
+    """Classify in-limits coverage: ``"fail"`` (broken arm, refuse),
+    ``"gap"`` (works but drops >1% of in-limits poses -- warn + require a tracked
+    xfail), or ``"clean"`` (gap-free)."""
+    if coverage < _COVERAGE_FAIL_FLOOR:
+        return "fail"
+    if coverage < _COVERAGE_CLEAN_FLOOR:
+        return "gap"
+    return "clean"
+
+
 def _fk_ceiling_from_worst(worst_fk: float) -> float:
     """A clean power-of-ten FK ceiling one decade above the measured worst-case
     residual, floored at 1e-9 (no ceiling tighter than closed-form 6R needs)."""
@@ -645,9 +665,16 @@ def _build_and_validate(args: argparse.Namespace, kb: KinBody, plan: DispatchPla
             return None
         mod = ilu.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        coverage, worst_fk = check_solve_coverage(mod, n_poses=64)
+        # 400 poses x 3 seeds, worst coverage: a ~1% in-limits gap is
+        # near-singular-pose specific and single-seed-noisy (a lucky seed can
+        # show 0 misses), so take the worst of 3 seeds to catch it reliably
+        # rather than lose it to sampling luck.
+        seed_results = [check_solve_coverage(mod, n_poses=400, seed=s) for s in range(3)]
+        coverage = min(c for c, _ in seed_results)
+        worst_fk = max(w for _, w in seed_results)
 
-    if coverage < 0.9:
+    band = _coverage_band(coverage)
+    if band == "fail":
         print(
             f"[ssik add-arm] ✗ VALIDATION FAILED: coverage {coverage:.0%} (worst FK {worst_fk:.1e})"
         )
@@ -655,6 +682,18 @@ def _build_and_validate(args: argparse.Namespace, kb: KinBody, plan: DispatchPla
         print("[ssik add-arm]   NOT ship as-is. Check --base/--ee, joint limits ([0,0] locks the")
         print("[ssik add-arm]   arm), and wrist-gauge. The fixture/test/stanza were still written.")
         return None
+    if band == "gap":
+        gap = (1.0 - coverage) * 100.0
+        print(
+            f"[ssik add-arm] ⚠ VALIDATED WITH A COVERAGE GAP: in-limits coverage {coverage:.0%} "
+            f"-- ~{gap:.0f}% of reachable in-limits poses return no IK."
+        )
+        print("[ssik add-arm]   This is the swivel-vs-limits / near-singular in-limits gap that")
+        print("[ssik add-arm]   hits some redundant 7R arms (srs_polished class, #462). The arm")
+        print("[ssik add-arm]   can ship, but it is NOT gap-free: add it to _LIMITS_GAP_7R (xfail)")
+        print("[ssik add-arm]   in tests/test_prebuilt_uniform_fuzz.py with a tracking issue, and")
+        print("[ssik add-arm]   note the limitation -- do not let it pass as clean.")
+        return worst_fk
     print(f"[ssik add-arm] ✓ VALIDATED: coverage {coverage:.0%}, worst FK {worst_fk:.1e}")
     return worst_fk
 

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -381,6 +381,19 @@ def test_add_arm_no_validate_runs_live_smoke(workspace: Path) -> None:
     assert "regen_artifacts.py --arm ur5_smoke_test" in result.stdout
 
 
+def test_coverage_band_thresholds() -> None:
+    """add-arm classifies in-limits coverage into fail / gap / clean bands so a
+    >1% in-limits coverage gap (near-singular swivel-vs-limits, #462) is warned,
+    not silently passed as clean."""
+    from ssik.cli import _coverage_band
+
+    assert _coverage_band(0.80) == "fail"  # broken arm (0 sols / locks / wrong ee)
+    assert _coverage_band(0.95) == "gap"  # ~5% gap -> warn + tracked xfail
+    assert _coverage_band(0.985) == "gap"  # >1% gap -> warn
+    assert _coverage_band(0.995) == "clean"  # <1% gap
+    assert _coverage_band(1.0) == "clean"
+
+
 def test_add_arm_missing_urdf_errors_cleanly(workspace: Path) -> None:
     """Pointing at a non-existent URDF errors instead of silently writing."""
     result = _run_cli(


### PR DESCRIPTION
## Why

Answers "if someone adds an arm with this coverage issue, will we warn them?" — previously **no**. `add-arm` *failed* a gross gap (<90%) but printed a clean `✓ VALIDATED` for the ~1% class, and sampled only 64 poses (too few to even see 1%).

## What

The onboarding coverage gate now has three bands (`_coverage_band`):
| Coverage | Verdict |
|---|---|
| < 90% | **FAIL** — broken arm (0 sols / `[0,0]` locks / wrong ee), refuse |
| 90-99% | **⚠ GAP** — works but drops >1% of reachable in-limits poses (swivel-vs-limits / near-singular, #462). Loud warning telling the contributor to add a tracked `_LIMITS_GAP_7R` xfail + note the limitation — not pass as clean |
| ≥ 99% | clean |

Detection is now **reliable**: 400 poses × 3 seeds, worst coverage — the gap is near-singular-pose-specific and single-seed-noisy (a lucky seed shows 0 misses). Verified: `yumi_left` (~1.5-2%) → **WARN**; `ur5` → clean; `j2s7` (~0.5-1%) → correctly clean (its gap is genuinely <1%). Band thresholds unit-tested.

## Fits the guard stack

- `#359` `@slow` test: exact 0-empty guarantee (local thorough run)
- `#463` non-slow CI floor: catches gross regressions at PR time
- **this**: warns the contributor at *add* time so a gappy arm isn't onboarded thinking it's clean

Test: `test_coverage_band_thresholds` + the existing clean-arm validate tests green. ruff / mypy clean.