### PR TITLE
Close approximate-SRS in-limits gap via unfiltered seed union (#462)

### DIFF
--- a/src/ssik/solvers/seven_r/_swivel_limits.py
+++ b/src/ssik/solvers/seven_r/_swivel_limits.py
@@ -232,32 +232,25 @@ def feasible_in_limits_solutions(
     limits: list[tuple[float, float]],
     *,
     max_solutions: int | None = None,
-    samples_per_arc: int = 1,
 ) -> list[NDArray[np.float64]]:
     """In-limits IK solutions via feasible-swivel resolution.
 
-    Returns wrapped-to-limits joint vectors. ``samples_per_arc=1`` (the exact-SRS
-    default) takes each arc's centre (maximum joint-limit margin); >1 spreads
-    that many interior samples per arc -- used by the approximate-SRS path, where
-    each seed is LM-polished and only some stay in-limits after the polish shift.
-    Empty iff no in-limits solution exists (target unreachable-in-limits).
+    Returns wrapped-to-limits joint vectors, one per feasible arc taken at the
+    arc's centre (maximum joint-limit margin). Exact for concurrent-axis SRS
+    chains, where ``q(psi)`` is closed-form; the approximate-SRS path seeds LM
+    from the full swivel grid instead (see :func:`_approx_grid_seeds`). Empty iff
+    no in-limits solution exists (target unreachable-in-limits).
     """
     T = np.asarray(T, dtype=np.float64)
     out: list[NDArray[np.float64]] = []
     for branch in _enumerate_branches(kb, cls, T):
         for a, b in _branch_arcs(branch, limits):
-            psis = (
-                [0.5 * (a + b)]
-                if samples_per_arc == 1
-                else np.linspace(a, b, samples_per_arc + 2)[1:-1].tolist()
+            q = branch.q(0.5 * (a + b))
+            out.append(
+                np.array([to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)])
             )
-            for psi in psis:
-                q = branch.q(float(psi))
-                out.append(
-                    np.array([to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)])
-                )
-                if max_solutions is not None and len(out) >= max_solutions:
-                    return out
+            if max_solutions is not None and len(out) >= max_solutions:
+                return out
     return out
 
 
@@ -273,12 +266,50 @@ def _joint_limits(kb: KinBody) -> list[tuple[float, float]]:
 
 
 _APPROX_MAX_DRIFT_M = 0.04  # matches seven_r.srs_polished's default gate
-_APPROX_SAMPLES_PER_ARC = 5  # LM shift can push the arc centre out of limits
 _APPROX_FK_ATOL = 1e-8
 
 
 def _in_limits(q: NDArray[np.float64], limits: list[tuple[float, float]]) -> bool:
     return all(lo - 1e-9 <= q[i] <= hi + 1e-9 for i, (lo, hi) in enumerate(limits))
+
+
+_APPROX_ARC_SAMPLES = 5  # interior samples per approximate feasible arc
+
+
+def _approx_grid_seeds(
+    kb: KinBody, cls: SrsClassification, T: NDArray[np.float64]
+) -> list[NDArray[np.float64]]:
+    """LM seeds for the approximate-SRS in-limits fallback (#370), *unfiltered*.
+
+    The fallback must not discard swivels using limits on the *approximate*
+    ``q(psi)`` -- near-singular arcs put the true in-limits swivel >0.5 rad out on
+    the best-fit geometry, so a pre-polish limit filter drops the very solution an
+    LM polish would pull inside (#462). We hand LM raw swivel seeds and filter on
+    the *polished, true-geometry* joint vectors afterwards. Two complementary
+    sources, unioned (more seeds can only widen post-polish coverage):
+
+    * the whole swivel sweep -- every branch x the shared ``PARAM_GRID`` -- which
+      seeds arcs the approximate arc-detection *mislocates* (yumi);
+    * interior samples of each approximate feasible arc, which seed arcs narrower
+      than the grid's 2 deg spacing that the uniform sweep steps over (j2s7).
+    """
+    limits = _joint_limits(kb)
+
+    def _boxed(psi: float, branch: _Branch) -> NDArray[np.float64]:
+        # Wrap each joint into its limit box (mod 2*pi) so LM starts from the
+        # in-limits pre-image rather than a 2*pi-shifted twin that polishes to an
+        # out-of-limits solution.
+        q = branch.q(psi)
+        return np.array([to_limits(float(q[i]), limits[i][0], limits[i][1]) for i in range(7)])
+
+    seeds: list[NDArray[np.float64]] = []
+    for branch in _enumerate_branches(kb, cls, T):
+        for psi in PARAM_GRID:
+            seeds.append(_boxed(float(psi), branch))
+        for a, b in _branch_arcs(branch, limits):
+            for psi in np.linspace(a, b, _APPROX_ARC_SAMPLES + 2)[1:-1]:
+                seeds.append(_boxed(float(psi), branch))
+    return seeds
 
 
 def resolve_in_limits(
@@ -320,9 +351,7 @@ def resolve_in_limits(
     approx = is_approximately_srs_7r(kb, max_drift_m=_APPROX_MAX_DRIFT_M, policy=policy)
     if approx is None:
         return []
-    seeds = feasible_in_limits_solutions(
-        kb, approx.base, T, limits, samples_per_arc=_APPROX_SAMPLES_PER_ARC
-    )
+    seeds = _approx_grid_seeds(kb, approx.base, T)
     if not seeds:
         return []
 

--- a/tests/test_prebuilt_uniform_fuzz.py
+++ b/tests/test_prebuilt_uniform_fuzz.py
@@ -265,11 +265,14 @@ def test_prebuilt_7r_tight_policy_machine_precision(arm_name: str, q_star: np.nd
 # Arms with a known residual in-limits-swivel gap on the default path, xfailed
 # with a tracking issue (never silently). Most shipped 7R arms hold the guarantee
 # via the closed-form feasible-swivel resolver (#359 exact-SRS, #370 approximate-
-# SRS). yumi_left / j2s7s300 (both srs_polished) drop ~0.5-1% of in-limits poses:
-# the best-fit-pivot approximation shifts the feasible swivel arc slightly so a
-# thin sliver is missed (the true in-limits IK exists; a 200-swivel sweep finds
-# it, production density doesn't). Tracked + root-caused in #462.
-_LIMITS_GAP_7R: set[str] = {"yumi_left_ik", "j2s7s300_ik"}
+# SRS). The #462 seed-union fix (unfiltered full-swivel-grid + arc-interior seeds,
+# wrapped into the limit box, filtered only after the LM polish) closed j2s7s300
+# fully and more than halved yumi's gap. yumi_left retains a ~0.5% residual: for a
+# thin near-singular sliver the true in-limits IK lives on a *disconnected*
+# self-motion-manifold component that the best-fit-SRS branches don't seed and
+# null-space continuation can't cross to -- only brute global random-restart finds
+# it (verified), which is not a principled closed-form path. Tracked in #462.
+_LIMITS_GAP_7R: set[str] = {"yumi_left_ik"}
 
 
 def _joint_ranges(kb: object) -> list[tuple[float, float]]:


### PR DESCRIPTION
## Why

The approximate-SRS in-limits fallback (#370, `srs_polished` arms: yumi, j2s7) dropped ~0.5-2% of reachable in-limits poses on the default `respect_limits=True` path. The generating `q` is always an in-limits witness, so every such miss is a genuine gap.

**Root cause:** seeds came from `feasible_in_limits_solutions`, which filters swivels by the joint limits evaluated on the *approximate* `q(psi)` **before** the LM polish. Near-singular arcs put the true in-limits swivel >0.5 rad out on the best-fit geometry, so the pre-polish filter discarded the very swivel the polish would have pulled inside.

## What

Seed LM from the full swivel sweep with **no pre-polish limit filter**; keep only the polished, true-geometry vectors that land in-limits (the post-polish mask already existed). Two complementary seed sources, unioned:

- the whole `PARAM_GRID` sweep, which recovers arcs the approximate arc-detection *mislocates* (yumi);
- interior samples of each approximate feasible arc, which recover arcs narrower than the grid's 2 deg spacing (j2s7).

Seeds are wrapped into the limit box so LM starts from the in-limits pre-image, not a 2π-shifted twin that polishes back out (this wrapping was the difference between 4/1000 and 0/1000 on j2s7).

## Result (5000 fuzz poses/arm, default `respect_limits=True` path)

| arm | before | after |
|---|---|---|
| j2s7s300 | 2/1000 | **0/1000** (fully closed) |
| yumi_left | 14/1000 | 8/1000 |
| yumi_right | 8/1000 | 3/1000 |
| rm75 / gen3 / iiwa | 0 | 0 (no regression) |

j2s7 is removed from `_LIMITS_GAP_7R`. The **exact-SRS closed-form path is untouched** (`feasible_in_limits_solutions` still emits one arc-centre per feasible arc; only the dead `samples_per_arc` knob was removed).

## Honest residual (kept tracked, not papered over)

yumi retains a ~0.5% residual. For a thin near-singular sliver the true in-limits IK lives on a **disconnected** self-motion-manifold component that the best-fit-SRS branches don't seed and null-space continuation can't cross to (both verified experimentally). Only brute global random-restart finds it, which is not a principled closed-form path, so it stays xfailed and tracked in #462.

## Test plan

- `test_prebuilt_7r_in_limits_default_path` (@slow): 18 passed (j2s7 now un-xfailed and passing), yumi_left xfailed as documented.
- `test_prebuilt_7r_in_limits_coverage_floor` + full `-k in_limits`: 19 passed.
- SRS/swivel/7R/polished unit suite: 126 passed (exact-SRS + srs_polished intact).
- ruff check + ruff format + mypy (whole repo, 246 files): clean.
- Perf gate: unaffected (benchmarks `respect_limits=False`, never enters this fallback).

Fixes #462 (except the documented near-singular residual, which #462 stays open to track).