### PR TITLE
Unify the polished-7R solver tail into _polish.polish_candidates (#467)

### DIFF
--- a/src/ssik/solvers/seven_r/_polish.py
+++ b/src/ssik/solvers/seven_r/_polish.py
@@ -1,0 +1,132 @@
+"""Shared LM-polish tail for the approximate/polished 7R solver family (#467).
+
+``srs_polished``, ``spherical_shoulder_polished``, and the approximate-SRS
+in-limits resolver (``_swivel_limits.resolve_in_limits``) all turn a batch of
+candidate seeds into FK-verified, deduplicated :class:`Solution` objects the
+same way: build the FK/Jacobian closures, batch-Newton-polish every seed, keep
+the rows that FK-close (and, when limits are given, land in-limits *after* the
+polish), then cluster-merge. This is that tail, factored out once.
+
+The completeness invariant lives here: seeds are polished first and limit-
+filtered second. A near-singular seed that starts a fraction of a radian
+out-of-limits but polishes inside is kept -- never discarded pre-polish (#462).
+Callers own only seed *generation* (their arm-specific redundancy sweep).
+
+This sits one layer below :func:`ssik.postprocess.finalize_solutions` (which
+takes already-computed Solutions through limits -> seed-rank -> truncate).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik.core.solution import Solution
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.refinement import (
+    dedup_by_wrap_close,
+    kinbody_fk_jacobian_batch,
+    kinbody_jacobian,
+    lm_refine_batch,
+)
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from ssik._kinbody import KinBody
+
+__all__ = ["polish_candidates"]
+
+_LIMIT_SLACK = 1e-9  # shared by every caller's in-limits acceptance test
+
+
+def _within_limits(q: NDArray[np.float64], limits: list[tuple[float, float]]) -> bool:
+    return all(limits[i][0] - _LIMIT_SLACK <= q[i] <= limits[i][1] + _LIMIT_SLACK for i in range(7))
+
+
+def polish_candidates(
+    kb: KinBody,
+    seeds: NDArray[np.float64] | Sequence[NDArray[np.float64]],
+    t_target: NDArray[np.float64],
+    *,
+    accept_fk_atol: float,
+    dedup_tol: float,
+    lm_fk_atol: float = 1e-9,
+    lm_max_iters: int = 30,
+    limits: list[tuple[float, float]] | None = None,
+    batched: bool = False,
+    solution_factory: Callable[[int, NDArray[np.float64], float], Solution] | None = None,
+    max_solutions: int | None = None,
+) -> list[Solution]:
+    """LM-polish a batch of candidate seeds into FK-verified, deduped Solutions.
+
+    :param kb: POE-normalized :class:`KinBody`.
+    :param seeds: ``(N, dof)`` array (or sequence of ``(dof,)`` vectors) of raw
+        candidate joint vectors from the caller's redundancy sweep. Empty in ->
+        empty out.
+    :param t_target: ``(4, 4)`` target pose.
+    :param accept_fk_atol: keep a polished candidate iff its FK residual is
+        ``<= accept_fk_atol``.
+    :param dedup_tol: cluster-merge gate (``policy.subproblem_dedup``).
+    :param lm_fk_atol: convergence threshold passed to :func:`lm_refine_batch`
+        (per-seed early stop); distinct from ``accept_fk_atol``, the acceptance
+        gate applied afterwards.
+    :param lm_max_iters: per-candidate Newton iteration cap.
+    :param limits: when given, drop any candidate that is out-of-limits *after*
+        the polish (never before). ``None`` skips the limit filter.
+    :param batched: use the vectorised :func:`kinbody_fk_jacobian_batch` inside
+        the polish (revolute-only; ~3-4x faster). ``False`` uses the scalar
+        per-candidate callables.
+    :param solution_factory: ``(i, q, res) -> Solution`` builder; defaults to a
+        fresh ``Solution(q, res, refinement_used="lm")``. Callers that carry
+        per-candidate metadata (e.g. ``srs_polished``'s branch fields) pass a
+        ``replace(raw[i], ...)`` factory.
+    :param max_solutions: optional cap applied after dedup.
+    :returns: FK-verified, in-limits (if requested), cluster-merged solutions.
+    """
+    q_seeds = np.asarray(seeds, dtype=np.float64)
+    if q_seeds.ndim != 2 or q_seeds.shape[0] == 0:
+        return []
+
+    def _fk(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        out: NDArray[np.float64] = poe_forward_kinematics(kb, q)
+        return out
+
+    def _jac(q: NDArray[np.float64]) -> NDArray[np.float64]:
+        out: NDArray[np.float64] = kinbody_jacobian(kb, q)
+        return out
+
+    batch_fn: (
+        Callable[[NDArray[np.float64]], tuple[NDArray[np.float64], NDArray[np.float64]]] | None
+    )
+    if batched:
+
+        def batch_fn(q: NDArray[np.float64]) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+            return kinbody_fk_jacobian_batch(kb, q)
+    else:
+        batch_fn = None
+
+    q_pol, res, _iters = lm_refine_batch(
+        q_seeds,
+        _fk,
+        _jac,
+        t_target,
+        fk_atol=lm_fk_atol,
+        max_iters=lm_max_iters,
+        fk_jac_batch_fn=batch_fn,
+    )
+
+    factory = solution_factory or (
+        lambda _i, q, r: Solution(q=q, fk_residual=r, refinement_used="lm")
+    )
+    out: list[Solution] = []
+    for i in range(q_pol.shape[0]):
+        if res[i] > accept_fk_atol:
+            continue
+        if limits is not None and not _within_limits(q_pol[i], limits):
+            continue
+        out.append(factory(i, q_pol[i], float(res[i])))
+
+    out = dedup_by_wrap_close(out, dedup_tol)
+    return out[:max_solutions] if max_solutions is not None else out

--- a/src/ssik/solvers/seven_r/_swivel_limits.py
+++ b/src/ssik/solvers/seven_r/_swivel_limits.py
@@ -41,12 +41,12 @@ from ssik.kinematics.predicates import (
     _classify_srs_7r_geometric,
     is_approximately_srs_7r,
 )
-from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian, lm_refine_batch
 from ssik.solvers.seven_r._feasible_param import (
     PARAM_GRID,
     feasible_arcs,
     to_limits,
 )
+from ssik.solvers.seven_r._polish import polish_candidates
 from ssik.solvers.seven_r.srs import (
     _arm_constants,
     _min_rotation,
@@ -268,11 +268,6 @@ def _joint_limits(kb: KinBody) -> list[tuple[float, float]]:
 _APPROX_MAX_DRIFT_M = 0.04  # matches seven_r.srs_polished's default gate
 _APPROX_FK_ATOL = 1e-8
 
-
-def _in_limits(q: NDArray[np.float64], limits: list[tuple[float, float]]) -> bool:
-    return all(lo - 1e-9 <= q[i] <= hi + 1e-9 for i, (lo, hi) in enumerate(limits))
-
-
 _APPROX_ARC_SAMPLES = 5  # interior samples per approximate feasible arc
 
 
@@ -354,20 +349,12 @@ def resolve_in_limits(
     seeds = _approx_grid_seeds(kb, approx.base, T)
     if not seeds:
         return []
-
-    def _fk(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        t: NDArray[np.float64] = poe_forward_kinematics(kb, q)
-        return t
-
-    def _jac(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        j: NDArray[np.float64] = kinbody_jacobian(kb, q)
-        return j
-
-    q_polished, residuals, _iters = lm_refine_batch(np.asarray(seeds), _fk, _jac, T)
-    polished: list[Solution] = [
-        Solution(q=q_polished[i], fk_residual=float(residuals[i]), refinement_used="lm")
-        for i in range(q_polished.shape[0])
-        if residuals[i] <= _APPROX_FK_ATOL and _in_limits(q_polished[i], limits)
-    ]
-    out = dedup_by_wrap_close(polished, policy.subproblem_dedup)
-    return out[:max_solutions] if max_solutions is not None else out
+    return polish_candidates(
+        kb,
+        seeds,
+        T,
+        accept_fk_atol=_APPROX_FK_ATOL,
+        dedup_tol=policy.subproblem_dedup,
+        limits=limits,
+        max_solutions=max_solutions,
+    )

--- a/src/ssik/solvers/seven_r/spherical_shoulder_polished.py
+++ b/src/ssik/solvers/seven_r/spherical_shoulder_polished.py
@@ -28,10 +28,9 @@ from numpy.typing import NDArray
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
 from ssik.kinematics._scalar3 import _se3_inv
-from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.reverse import reverse_kinematic_chain
-from ssik.refinement import dedup_by_wrap_close, kinbody_jacobian, lm_refine_batch
 from ssik.solvers.jointlock.seven_r import _lock_joint
+from ssik.solvers.seven_r._polish import polish_candidates
 from ssik.solvers.seven_r.spherical_shoulder import (
     _LOCK,
     _SAMPLE_GRID,
@@ -112,27 +111,15 @@ def _polished(
     if not cand:
         return []
 
-    def _fk(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        out: NDArray[np.float64] = poe_forward_kinematics(kb, q)
-        return out
-
-    def _jac(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        out: NDArray[np.float64] = kinbody_jacobian(kb, q)
-        return out
-
-    q_pol, res, _iters = lm_refine_batch(
-        np.asarray(cand), _fk, _jac, T, max_iters=_POLISH_MAX_ITERS
+    return polish_candidates(
+        kb,
+        cand,
+        T,
+        accept_fk_atol=_POLISH_FK_ATOL,
+        dedup_tol=policy.subproblem_dedup,
+        lm_max_iters=_POLISH_MAX_ITERS,
+        limits=limits if respect_limits else None,
     )
-    out: list[Solution] = []
-    for i in range(q_pol.shape[0]):
-        if res[i] > _POLISH_FK_ATOL:
-            continue
-        if respect_limits and not all(
-            limits[j][0] - 1e-9 <= q_pol[i][j] <= limits[j][1] + 1e-9 for j in range(7)
-        ):
-            continue
-        out.append(Solution(q=q_pol[i], fk_residual=float(res[i]), refinement_used="lm"))
-    return dedup_by_wrap_close(out, policy.subproblem_dedup)
 
 
 def solve(

--- a/src/ssik/solvers/seven_r/srs_polished.py
+++ b/src/ssik/solvers/seven_r/srs_polished.py
@@ -55,15 +55,9 @@ from numpy.typing import NDArray
 
 from ssik.core.solution import Solution
 from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY, TolerancePolicy
-from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.kinematics.predicates import is_approximately_srs_7r
-from ssik.refinement import (
-    dedup_by_wrap_close,
-    kinbody_fk_jacobian_batch,
-    kinbody_jacobian,
-    lm_refine_batch,
-)
 from ssik.solvers.seven_r import srs
+from ssik.solvers.seven_r._polish import polish_candidates
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
     from ssik._kinbody import KinBody
@@ -164,70 +158,33 @@ def solve(
         # SRS produced nothing even at huge fk_atol; truly unreachable.
         return [], True
 
-    # Step 3: batched LM polish for all candidates simultaneously (#205).
-    # Synchronises the Newton iter loop across the N raw seeds so per-iter
-    # ``np.linalg.{solve, inv, norm}`` dispatch overhead amortises over N.
-    # Empirically ~30-50% faster than the sequential ``lm_refine`` loop on
-    # Gen3 (where N is typically 75-128). Tighter divergence detection
-    # (factor=2.0, min_iters=2) inherited from #203 keeps dead-end seeds
-    # from wasting iter budget.
-    def fk_fn(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        out: NDArray[np.float64] = poe_forward_kinematics(kb, q)
-        return out
-
-    def jac_fn(q: NDArray[np.float64]) -> NDArray[np.float64]:
-        out: NDArray[np.float64] = kinbody_jacobian(kb, q)
-        return out
-
-    def fk_jac_batch_fn(
-        q: NDArray[np.float64],
-    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        # Batched FK + Jacobian over the whole active candidate set (all shipped
-        # arms are revolute; the primitive raises on prismatic and lm_refine_batch
-        # would fall back to the scalar callables above).
-        return kinbody_fk_jacobian_batch(kb, q)
-
-    q_seeds = np.array([c.q for c in raw], dtype=np.float64)
-    q_polished_arr, fk_residuals, _iters_used = lm_refine_batch(
-        q_seeds,
-        fk_fn,
-        jac_fn,
+    # Steps 3+4: batched LM polish for all candidates simultaneously (#205),
+    # then cluster-merge -- the shared polished-7R tail (#467). ``batched=True``
+    # runs the vectorised FK+Jacobian (~30-50% faster on Gen3, N=75-128); the
+    # divergence detection (factor=2.0, min_iters=2 from #203) is lm_refine_batch's
+    # default. Candidates carry SRS branch metadata, so preserve it via ``replace``
+    # rather than a fresh Solution.
+    deduped = polish_candidates(
+        kb,
+        np.array([c.q for c in raw], dtype=np.float64),
         T_target,
-        fk_atol=polish_fk_atol,
-        max_iters=polish_max_iters,
-        divergence_factor=2.0,
-        divergence_min_iters=2,
-        fk_jac_batch_fn=fk_jac_batch_fn,
+        accept_fk_atol=polish_fk_atol,
+        dedup_tol=policy.subproblem_dedup,
+        lm_fk_atol=polish_fk_atol,
+        lm_max_iters=polish_max_iters,
+        batched=True,
+        solution_factory=lambda i, q, r: replace(raw[i], q=q, fk_residual=r, refinement_used="lm"),
+        max_solutions=max_solutions,
     )
 
-    polished: list[Solution] = [
-        replace(
-            c,
-            q=q_polished_arr[i],
-            fk_residual=float(fk_residuals[i]),
-            refinement_used="lm",
-        )
-        for i, c in enumerate(raw)
-        if fk_residuals[i] < polish_fk_atol
-    ]
-
-    if not polished:
+    if not deduped:
         return [], True
 
-    # Step 4: cluster-merge. Different SRS branches may polish into
-    # the same true IK; dedup keeps one representative per cluster.
-    deduped = dedup_by_wrap_close(polished, policy.subproblem_dedup)
-
-    if max_solutions is not None and len(deduped) > max_solutions:
-        deduped = deduped[:max_solutions]
-
     _LOG.info(
-        "seven_r.srs_polished: drift_shoulder=%.4f m  drift_wrist=%.4f m  "
-        "raw=%d  polished=%d  deduped=%d",
+        "seven_r.srs_polished: drift_shoulder=%.4f m  drift_wrist=%.4f m  raw=%d  deduped=%d",
         cls.shoulder_drift_m,
         cls.wrist_drift_m,
         len(raw),
-        len(polished),
         len(deduped),
     )
 


### PR DESCRIPTION
## Why

Three solvers hand-rolled the *same* polish tail, and the #462 completeness invariant (filter limits **after** polish, never before) lived in only one copy:

- `seven_r/srs_polished.py`
- `seven_r/spherical_shoulder_polished.py`
- `seven_r/_swivel_limits.py` (approximate-SRS in-limits resolver)

Each built identical `_fk`/`_jac` closures around `poe_forward_kinematics`/`kinbody_jacobian`, called `lm_refine_batch`, kept rows with `res ≤ atol` (and, for two, in-limits), then `dedup_by_wrap_close`.

## What

Extract that tail once into `seven_r/_polish.polish_candidates(...)`. Each caller keeps only its arm-specific **seed generation** and delegates polish → FK-accept → (optional in-limits, after polish) → dedup. The invariant is documented and enforced in the one helper.

Sits one layer below `postprocess.finalize_solutions` (Solutions → limits → seed-rank → truncate); this is raw seeds → Solutions.

## Behavior-preserving

Each caller passes its exact prior params (`batched=True` + `replace`-factory for srs_polished; scalar + in-limits filter for the other two). Verified:

- Full SRS / 7R / polished / in-limits suite: **170 passed**.
- Fuzz miss counts **identical** to the #465 baseline: j2s7 0, yumi_left 8, yumi_right 3, gen3 0 (per 1000 default-path poses).
- ruff + mypy (247 files) clean.

## Scope

`jointlock.seven_r` is deliberately **out**: exact HP per locked-joint sample, no polish, in-sweep filter on exact configs. Its gap (#459) is sampling density, a separate fix.

## Payoff

Closing #460 (Booster) becomes a one-line change: feed `spherical_shoulder_polished` unfiltered dense seeds; the shared helper guarantees filter-after-polish. That lands next, on top of this.

Refs #467. Follow-up to #462 / #465.