### PR TITLE
Add Manipulator.from_mjcf public entry point + MJCF auto-detect (#83)

### DIFF
--- a/src/ssik/_mjcf.py
+++ b/src/ssik/_mjcf.py
@@ -23,8 +23,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik._kinbody import JointType, KinBody, build_poe_kinbody
+from ssik._urdf import _GRIPPER_HINTS
 
-__all__ = ["load_mjcf_kinbody_normalized"]
+__all__ = ["load_mjcf_kinbody_normalized", "suggest_base_ee_mjcf"]
 
 
 def _import_mujoco() -> object:
@@ -36,6 +37,81 @@ def _import_mujoco() -> object:
             "`pip install ssik[mjcf]` (or `uv add mujoco`)."
         ) from err
     return mujoco
+
+
+def suggest_base_ee_mjcf(mjcf_path: str | Path) -> tuple[str, str, list[str]]:
+    """Suggest ``(base_body, ee_body)`` for the longest actuated chain in an MJCF,
+    plus human-readable notes about alternatives.
+
+    ``base_body`` is the parent body of the first actuated (hinge/slide) joint --
+    leading fixed bodies (e.g. ``world -> robot_base``) fold into the base.
+    ``ee_body`` is the body carrying the last actuated joint (the kinematic
+    flange); trailing gripper/tool bodies are reported as notes, not chosen. The
+    MJCF analogue of :func:`ssik._urdf.suggest_base_ee`. For multi-limb robots
+    (humanoids) only the single longest chain is returned -- pass an explicit
+    ``base``/``ee`` to select a different limb.
+
+    :returns: ``(base_body, ee_body, notes)``; ``notes`` empty for an
+        unambiguous single-chain arm.
+    :raises ValueError: if the MJCF has no hinge/slide joints.
+    """
+    mujoco = _import_mujoco()
+    model = mujoco.MjModel.from_xml_path(str(mjcf_path))  # type: ignore[attr-defined]
+    hinge = mujoco.mjtJoint.mjJNT_HINGE  # type: ignore[attr-defined]
+    slide = mujoco.mjtJoint.mjJNT_SLIDE  # type: ignore[attr-defined]
+
+    def name(bid: int) -> str:
+        return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, bid) or f"body{bid}"  # type: ignore[attr-defined]
+
+    def n_actuated(bid: int) -> int:
+        j0 = int(model.body_jntadr[bid])
+        return sum(
+            1
+            for j in range(j0, j0 + int(model.body_jntnum[bid]))
+            if int(model.jnt_type[j]) in (hinge, slide)
+        )
+
+    children: dict[int, list[int]] = {}
+    for b in range(1, model.nbody):  # skip world (body 0)
+        children.setdefault(int(model.body_parentid[b]), []).append(b)
+
+    # Longest chain by number of actuated joints, over every world-rooted branch.
+    best: tuple[int, list[int]] | None = None
+
+    def walk(bid: int, path: list[int], nact: int) -> None:
+        nonlocal best
+        na = nact + n_actuated(bid)
+        if best is None or na > best[0]:
+            best = (na, list(path))
+        for c in children.get(bid, []):
+            walk(c, [*path, c], na)
+
+    for root in children.get(0, []):
+        walk(root, [root], 0)
+
+    if best is None or best[0] == 0:
+        raise ValueError("suggest_base_ee_mjcf: no hinge/slide joints found in MJCF")
+
+    chain = best[1]
+    actuated = [b for b in chain if n_actuated(b) > 0]
+    base_body = name(int(model.body_parentid[actuated[0]]))
+
+    # Trim trailing gripper/tool bodies back to the kinematic flange.
+    ee_idx = chain.index(actuated[-1])
+    first_idx = chain.index(actuated[0])
+    while ee_idx > first_idx and any(h in name(chain[ee_idx]).lower() for h in _GRIPPER_HINTS):
+        ee_idx -= 1
+    ee_body = name(chain[ee_idx])
+
+    notes: list[str] = []
+    trailing = [
+        name(b)
+        for b in chain[ee_idx + 1 :]
+        if not any(h in name(b).lower() for h in _GRIPPER_HINTS)
+    ]
+    if trailing:
+        notes.append(f"frames past {ee_body!r}: {trailing} (pass ee= to use one)")
+    return base_body, ee_body, notes
 
 
 def load_mjcf_kinbody_normalized(

--- a/src/ssik/manipulator.py
+++ b/src/ssik/manipulator.py
@@ -192,6 +192,61 @@ class Manipulator:
         return cls(kb, policy=policy)
 
     @classmethod
+    def from_mjcf(
+        cls,
+        path: str | Path,
+        *,
+        base: str | None = None,
+        ee: str | None = None,
+        policy: TolerancePolicy = DEFAULT_TOLERANCE_POLICY,
+    ) -> Manipulator:
+        """Load a MuJoCo MJCF and build a :class:`Manipulator` for the chain
+        between two bodies.
+
+        The MJCF is compiled by ``mujoco`` (resolving ``<default>`` classes,
+        ``<compiler>`` angle/coordinate settings, ``<include>``, keyframes), and
+        the POE-normalised chain is read straight off the compiled model, so no
+        XML is hand-parsed. Solvers and the dispatcher are format-agnostic: the
+        resulting arm is identical in form to one from :meth:`from_urdf`.
+
+        Only single-DOF joints (``hinge`` -> revolute, ``slide`` -> prismatic)
+        are supported; ``ball`` / ``free`` joints raise. ``q=0`` corresponds to
+        MuJoCo's reference ``qpos0``.
+
+        :param path: path to the ``.xml`` / ``.mjcf`` model file.
+        :param base: name of the base body. When omitted, the base of the
+            longest actuated chain is auto-detected (for multi-limb robots pass
+            an explicit ``base``/``ee`` to select a limb).
+        :param ee: name of the end-effector body. When omitted, the flange of
+            the longest actuated chain is auto-detected (trailing gripper/tool
+            bodies are skipped).
+        :param policy: tolerance policy. Defaults to
+            :data:`~ssik.core.tolerances.DEFAULT_TOLERANCE_POLICY`.
+
+        :raises FileNotFoundError: if ``path`` doesn't exist.
+        :raises ValueError: if ``base``/``ee`` are not body names, or ``ee`` is
+            not a descendant of ``base``.
+        :raises NotImplementedError: on ball/free joints.
+        :raises ImportError: if the optional dependency ``mujoco`` is not
+            installed (``pip install ssik[mjcf]``).
+        """
+        # Imported lazily so the mujoco dependency is only required when
+        # from_mjcf is actually called (it's an optional extra).
+        from ssik._mjcf import load_mjcf_kinbody_normalized, suggest_base_ee_mjcf
+
+        path_obj = Path(path)
+        if not path_obj.exists():
+            raise FileNotFoundError(f"MJCF file not found: {path_obj}")
+
+        if base is None or ee is None:
+            det_base, det_ee, _notes = suggest_base_ee_mjcf(path)
+            base = base if base is not None else det_base
+            ee = ee if ee is not None else det_ee
+
+        kb = load_mjcf_kinbody_normalized(path, base, ee)
+        return cls(kb, policy=policy)
+
+    @classmethod
     def from_axes(
         cls,
         joint_axes: ArrayLike,

--- a/tests/test_mjcf.py
+++ b/tests/test_mjcf.py
@@ -6,15 +6,21 @@ group so CI runs these). The gold-standard oracle is mujoco's own ``mj_forward``
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 
 mujoco = pytest.importorskip("mujoco")
 
-from ssik._mjcf import load_mjcf_kinbody_normalized  # noqa: E402
+from ssik._mjcf import (  # noqa: E402
+    load_mjcf_kinbody_normalized,
+    suggest_base_ee_mjcf,
+)
 from ssik.kinematics.poe_fk import poe_forward_kinematics  # noqa: E402
+from ssik.manipulator import Manipulator  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 TOY = FIXTURES / "toy3r.xml"
@@ -78,3 +84,87 @@ def test_mjcf_rejects_ball_joint(tmp_path: Path) -> None:
     )
     with pytest.raises(NotImplementedError, match="hinge/slide"):
         load_mjcf_kinbody_normalized(ball, "base", "ee")
+
+
+def test_from_mjcf_missing_file() -> None:
+    with pytest.raises(FileNotFoundError, match="MJCF file not found"):
+        Manipulator.from_mjcf(FIXTURES / "does_not_exist.xml")
+
+
+# --- Real MuJoCo Menagerie arms (gated on robot_descriptions) --------------
+# The mujoco mj_forward pass is the gold-standard FK oracle: build the KinBody
+# via the public auto-detecting entry point, then confirm its FK matches mujoco
+# body poses at random q for the *same* chain joints.
+
+robot_descriptions = pytest.importorskip("robot_descriptions")
+
+# (module, expected auto-detected base, expected auto-detected ee, dof). The
+# ee assertions pin the gripper-trim (arx_l5 must stop at link7, not a finger).
+_REAL_MJCF_ARMS = [
+    ("gen3_mj_description", "base_link", "bracelet_link", 7),
+    ("iiwa14_mj_description", "base", "link7", 7),
+    ("fr3_mj_description", "fr3_link0", "fr3_link7", 7),
+    ("arx_l5_mj_description", "base_link", "link7", 7),
+]
+
+
+def _chain_jnt_ids(model: Any, base: str, ee: str) -> list[int]:
+    """mujoco joint ids on the base->ee chain, in chain order."""
+    hinge, slide = mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_SLIDE
+    bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, ee)
+    base_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, base)
+    chain: list[int] = []
+    while bid != base_id:
+        chain.append(bid)
+        bid = int(model.body_parentid[bid])
+    chain.reverse()
+    ids: list[int] = []
+    for body in chain:
+        j0 = int(model.body_jntadr[body])
+        ids += [
+            j
+            for j in range(j0, j0 + int(model.body_jntnum[body]))
+            if int(model.jnt_type[j]) in (hinge, slide)
+        ]
+    return ids
+
+
+@pytest.mark.parametrize(
+    ("module", "exp_base", "exp_ee", "dof"),
+    _REAL_MJCF_ARMS,
+    ids=[a[0] for a in _REAL_MJCF_ARMS],
+)
+def test_from_mjcf_real_arm_fk_matches_mujoco(
+    module: str, exp_base: str, exp_ee: str, dof: int
+) -> None:
+    path = importlib.import_module(f"robot_descriptions.{module}").MJCF_PATH
+
+    # Auto-detect picks the documented base/ee (gripper trimmed to the flange).
+    base, ee, _notes = suggest_base_ee_mjcf(path)
+    assert (base, ee) == (exp_base, exp_ee)
+
+    arm = Manipulator.from_mjcf(path)  # auto-detect
+    assert len(arm.kinbody.joints) == dof
+
+    model = mujoco.MjModel.from_xml_path(path)
+    data = mujoco.MjData(model)
+    jids = _chain_jnt_ids(model, base, ee)
+    assert len(jids) == dof
+    base_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, base)
+    ee_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, ee)
+
+    rng = np.random.default_rng(0)
+    worst = 0.0
+    for _ in range(50):
+        q = rng.uniform(-1.0, 1.0, size=dof)
+        data.qpos[:] = 0.0
+        for qi, jid in zip(q, jids, strict=True):
+            data.qpos[int(model.jnt_qposadr[jid])] = qi
+        mujoco.mj_forward(model, data)
+        r_base = data.xmat[base_id].reshape(3, 3)
+        p_base = data.xpos[base_id]
+        ref = np.eye(4)
+        ref[:3, :3] = r_base.T @ data.xmat[ee_id].reshape(3, 3)
+        ref[:3, 3] = r_base.T @ (data.xpos[ee_id] - p_base)
+        worst = max(worst, float(np.abs(arm.fk(q) - ref).max()))
+    assert worst < 1e-11, f"{module}: from_mjcf FK off from mujoco by {worst:.2e}"


### PR DESCRIPTION
## Why

The MJCF -> KinBody loader landed in #343/#344 but was only reachable via the internal `load_mjcf_kinbody_normalized(path, base, ee)`. This wires it into the public API so an MJCF-only arm is one call from IK, mirroring `from_urdf`.

## What

- **`suggest_base_ee_mjcf(path)`** — auto-detect `(base, ee)` for the longest actuated chain off the compiled mujoco model (parent of the first hinge/slide joint -> flange; trailing gripper/tool bodies trimmed via the shared `_GRIPPER_HINTS`).
- **`Manipulator.from_mjcf(path, base=None, ee=None)`** — compile via mujoco, read the POE-normalized chain, dispatch like any other arm. `base`/`ee` auto-detected when omitted; `FileNotFoundError` on a missing path; `mujoco` stays an optional `[mjcf]` extra (lazy import).

## Validation (real MuJoCo Menagerie arms via robot_descriptions)

| arm | auto base -> ee | FK vs mj_forward | MJCF -> solve |
|---|---|---|---|
| gen3 | base_link -> bracelet_link | 5.9e-15 | srs_polished, 73 sols @ 2.6e-16 |
| iiwa14 | base -> link7 | 3.9e-15 | srs, 94 sols @ 1.9e-15 |
| fr3 | fr3_link0 -> fr3_link7 | 6.2e-15 | — |
| arx_l5 | base_link -> **link7** (gripper trimmed) | 2.1e-15 | — |

Tests: 9 in `test_mjcf.py` (toy FK/limits/edge cases + 4 parametrized real arms round-tripping against mujoco's `mj_forward` at machine precision + auto-detect assertions + missing-file). ruff + mypy (247 files) clean.

## Scope

`ssik add-arm` MJCF support (vendoring a prebuilt artifact from an MJCF, including `<include>`/mesh assets) is a separate follow-up — the CLI is currently URDF-specific (fixture stripping, `.urdf` scaffold templates). This PR delivers the library ingestion path.

Refs #83. Builds on #343/#344.