### PR TITLE
add-arm: onboard MuJoCo MJCF arms via a pluggable format-adapter registry (#470)

### DIFF
--- a/scripts/regen_artifacts.py
+++ b/scripts/regen_artifacts.py
@@ -32,8 +32,8 @@ import sys
 import time
 from pathlib import Path
 
+from ssik import _formats as formats
 from ssik._kinbody import build_kinbody
-from ssik._urdf import load_urdf_kinbody_normalized
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import dispatch
 from ssik.prebuilt._manifest import Arm, load_manifest
@@ -116,9 +116,7 @@ def _regen_prebuilt_init(manifest: dict[str, Arm]) -> None:
 def _emit_arm(arm: Arm) -> None:
     """Build + emit one prebuilt artifact from its manifest entry."""
     t = time.perf_counter()
-    if arm.fixture_kind == "urdf":
-        kb = load_urdf_kinbody_normalized(FIXTURES / arm.fixture, arm.base_link, arm.ee_link)
-    else:
+    if arm.fixture_kind == "specs":
         # specs: a Python builder module under tests/fixtures
         mod = __import__(arm.fixture)
         specs_fn_name = arm.specs_fn
@@ -127,6 +125,11 @@ def _emit_arm(arm: Arm) -> None:
             getattr(mod, specs_fn_name)(),
             base_link_name=arm.base_link,
             ee_link_name=arm.ee_link,
+        )
+    else:
+        # A registered source format (urdf, mjcf, ...): one loader, no branch.
+        kb = formats.get(arm.fixture_kind).load(
+            FIXTURES / arm.fixture, arm.base_link, arm.ee_link, {}
         )
     plan = dispatch(kb)
     # Vendor subpackage layout (#421): src/ssik/prebuilt/<vendor>/<basename>.py

--- a/src/ssik/_formats.py
+++ b/src/ssik/_formats.py
@@ -1,0 +1,164 @@
+"""Pluggable robot-description format adapters (#470).
+
+``ssik``'s :class:`~ssik._kinbody.KinBody` is the universal internal form;
+solvers never see the source format. Ingestion of a concrete format (URDF,
+MuJoCo MJCF, and -- in future -- USD/SDF, #83) is captured by one
+:class:`FormatAdapter`, and every format-agnostic consumer (``Manipulator``
+factories, ``ssik add-arm``, ``regen_artifacts``, the MANIFEST schema) goes
+through the registry here instead of branching on the format itself.
+
+Adding a format is therefore: write its loader/vendor functions, build a
+:class:`FormatAdapter`, and :func:`register` it. No edits to the CLI, the
+artifact regenerator, or the manifest validator.
+
+The two built-in adapters live next to their parsers (``_urdf.py``, ``_mjcf.py``)
+and self-register on import; :func:`_ensure_builtins` imports those modules
+lazily on first registry access so importing this module stays dependency-free
+(``urchin`` / ``mujoco`` are only pulled in when a format is actually used).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover -- typing only
+    from ssik._kinbody import KinBody
+
+__all__ = [
+    "FormatAdapter",
+    "detect",
+    "detect_kind",
+    "get",
+    "kinds",
+    "register",
+]
+
+
+@dataclass(frozen=True)
+class FormatAdapter:
+    """Everything the format-agnostic pipeline needs for one source format.
+
+    :param kind: the ``fixture_kind`` tag written to MANIFEST.toml and matched by
+        :func:`get` (e.g. ``"urdf"``, ``"mjcf"``).
+    :param label: human name for CLI messages (e.g. ``"URDF"``).
+    :param extensions: source-file suffixes this format claims, lowercase with the
+        dot (e.g. ``(".urdf", ".xacro")``). Used by :func:`detect`.
+    :param fixture_suffix: extension of the vendored kinematics-only fixture
+        (e.g. ``".urdf"``, ``".xml"``).
+    :param scaffold_loader_module: module the generated test/artifact imports the
+        normalized loader from (e.g. ``"ssik._urdf"``).
+    :param scaffold_loader_func: normalized-loader function name in that module
+        (e.g. ``"load_urdf_kinbody_normalized"``).
+    :param load: ``(path, base, ee, options) -> KinBody`` -- load a source or
+        vendored fixture into a POE-normalized KinBody. ``options`` carries
+        format-specific knobs (e.g. ``xacro_args`` for URDF); adapters ignore
+        keys they don't use.
+    :param suggest_base_ee: ``(source_path, options) -> (base, ee, notes)``.
+    :param vendor: ``(source_path, dest_path, options) -> (n_a, n_b)`` -- write a
+        kinematics-only fixture to ``dest_path`` and return two element counts
+        (links/bodies, joints) for the CLI summary.
+    :param root_tags: optional XML root element names that positively identify
+        this format when the extension is ambiguous (``.xml`` is shared by MJCF
+        and others); e.g. ``("robot",)`` for URDF, ``("mujoco",)`` for MJCF.
+    """
+
+    kind: str
+    label: str
+    extensions: tuple[str, ...]
+    fixture_suffix: str
+    scaffold_loader_module: str
+    scaffold_loader_func: str
+    load: Callable[[Path, str, str, Mapping[str, Any]], KinBody]
+    suggest_base_ee: Callable[[Path, Mapping[str, Any]], tuple[str, str, list[str]]]
+    vendor: Callable[[Path, Path, Mapping[str, Any]], tuple[int, int]]
+    root_tags: tuple[str, ...] = field(default=())
+
+
+_REGISTRY: dict[str, FormatAdapter] = {}
+_BUILTINS_LOADED = False
+
+
+def register(adapter: FormatAdapter) -> None:
+    """Register a format adapter under its ``kind`` (idempotent overwrite)."""
+    _REGISTRY[adapter.kind] = adapter
+
+
+def _ensure_builtins() -> None:
+    global _BUILTINS_LOADED
+    if _BUILTINS_LOADED:
+        return
+    # Import for side-effect registration. Lazy so this module has no hard
+    # dependency on urchin/mujoco; the loaders themselves import those on use.
+    _BUILTINS_LOADED = True
+    import ssik._mjcf
+    import ssik._urdf  # noqa: F401
+
+
+def kinds() -> tuple[str, ...]:
+    """All registered format kinds (sorted)."""
+    _ensure_builtins()
+    return tuple(sorted(_REGISTRY))
+
+
+def get(kind: str) -> FormatAdapter:
+    """Look up an adapter by its ``fixture_kind``.
+
+    :raises ValueError: if no adapter is registered for ``kind``.
+    """
+    _ensure_builtins()
+    try:
+        return _REGISTRY[kind]
+    except KeyError:
+        raise ValueError(
+            f"unknown format kind {kind!r}; registered: {', '.join(kinds())}"
+        ) from None
+
+
+def _sniff_root_tag(path: Path) -> str | None:
+    """Local root element name of an XML file, or ``None`` if unreadable."""
+    try:
+        import xml.etree.ElementTree as ET
+
+        for _event, elem in ET.iterparse(path, events=("start",)):
+            tag = elem.tag
+            return tag.rsplit("}", 1)[-1] if isinstance(tag, str) else None
+    except (OSError, ET.ParseError):
+        return None
+    return None
+
+
+def detect(path: str | Path) -> FormatAdapter:
+    """Pick the adapter for a source file by extension, disambiguating shared
+    extensions (``.xml``) by the XML root element.
+
+    :raises ValueError: if no registered format claims the file.
+    """
+    _ensure_builtins()
+    p = Path(path)
+    suffix = p.suffix.lower()
+
+    by_ext = [a for a in _REGISTRY.values() if suffix in a.extensions]
+    if len(by_ext) == 1:
+        return by_ext[0]
+    if len(by_ext) > 1:
+        # Ambiguous extension (e.g. .xml): disambiguate by XML root tag.
+        root = _sniff_root_tag(p)
+        for a in by_ext:
+            if root is not None and root in a.root_tags:
+                return a
+        # Fall back to the first claimant with no root-tag opinion.
+        return by_ext[0]
+
+    exts = sorted({e for a in _REGISTRY.values() for e in a.extensions})
+    raise ValueError(
+        f"no registered format for {p.name!r} (suffix {suffix!r}); "
+        f"known extensions: {', '.join(exts)}"
+    )
+
+
+def detect_kind(path: str | Path) -> str:
+    """The ``fixture_kind`` of the format that claims ``path``."""
+    return detect(path).kind

--- a/src/ssik/_mjcf.py
+++ b/src/ssik/_mjcf.py
@@ -17,7 +17,10 @@ solvers and the dispatcher are format-agnostic.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
+from xml.sax.saxutils import quoteattr
 
 import numpy as np
 from numpy.typing import NDArray
@@ -25,7 +28,11 @@ from numpy.typing import NDArray
 from ssik._kinbody import JointType, KinBody, build_poe_kinbody
 from ssik._urdf import _GRIPPER_HINTS
 
-__all__ = ["load_mjcf_kinbody_normalized", "suggest_base_ee_mjcf"]
+__all__ = [
+    "load_mjcf_kinbody_normalized",
+    "strip_mjcf_to_fixture",
+    "suggest_base_ee_mjcf",
+]
 
 
 def _import_mujoco() -> object:
@@ -202,3 +209,112 @@ def load_mjcf_kinbody_normalized(
     final_t_right = final_t_right @ rot4
 
     return build_poe_kinbody(records, final_t_right, base_body, ee_body)
+
+
+def strip_mjcf_to_fixture(source: Path, dest: Path) -> tuple[int, int]:
+    """Vendor a kinematics-only, self-contained MJCF from ``source`` to ``dest``.
+
+    The MJCF analogue of :func:`ssik._urdf.strip_urdf_to_fixture`: ``mujoco``
+    compiles the source (resolving ``<include>`` / ``<default>`` / assets), then
+    we *reconstruct* a minimal nested-``<body>`` model from the compiled kinematic
+    tree -- body ``pos``/``quat``, each hinge/slide joint's ``pos``/``axis``/
+    ``range``, and a unit placeholder ``<inertial>`` -- with no ``<geom>`` /
+    ``<asset>`` / mesh references. The result is self-contained (no mesh files
+    needed on disk) and recompiles to the *identical* kinematics, so a vendored
+    fixture never drags along an ``assets/`` tree.
+
+    :returns: ``(n_bodies, n_joints)`` in the reconstructed model.
+    """
+    mujoco = _import_mujoco()
+    model = mujoco.MjModel.from_xml_path(str(source))  # type: ignore[attr-defined]
+    jtype_xml = {
+        int(mujoco.mjtJoint.mjJNT_HINGE): "hinge",  # type: ignore[attr-defined]
+        int(mujoco.mjtJoint.mjJNT_SLIDE): "slide",  # type: ignore[attr-defined]
+        int(mujoco.mjtJoint.mjJNT_BALL): "ball",  # type: ignore[attr-defined]
+        int(mujoco.mjtJoint.mjJNT_FREE): "free",  # type: ignore[attr-defined]
+    }
+
+    def bname(i: int) -> str:
+        return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i) or f"body{i}"  # type: ignore[attr-defined]
+
+    def jname(i: int) -> str:
+        return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) or f"joint{i}"  # type: ignore[attr-defined]
+
+    children: dict[int, list[int]] = {}
+    for b in range(1, model.nbody):
+        children.setdefault(int(model.body_parentid[b]), []).append(b)
+
+    def _vec(v: NDArray[np.float64]) -> str:
+        return " ".join(f"{float(x):.12g}" for x in v)
+
+    model_name = Path(source).stem
+    lines = [
+        f"<mujoco model={quoteattr(model_name)}>",
+        '  <compiler angle="radian"/>',
+        "  <worldbody>",
+    ]
+    n_bodies = 0
+    n_joints = 0
+
+    def emit(bid: int, indent: int) -> None:
+        nonlocal n_bodies, n_joints
+        n_bodies += 1
+        pad = "  " * indent
+        lines.append(
+            f"{pad}<body name={quoteattr(bname(bid))} "
+            f'pos="{_vec(model.body_pos[bid])}" quat="{_vec(model.body_quat[bid])}">'
+        )
+        lines.append(f'{pad}  <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>')
+        j0 = int(model.body_jntadr[bid])
+        for j in range(j0, j0 + int(model.body_jntnum[bid])):
+            n_joints += 1
+            jt = jtype_xml.get(int(model.jnt_type[j]), "hinge")
+            attrs = (
+                f"name={quoteattr(jname(j))} type={quoteattr(jt)} "
+                f'pos="{_vec(model.jnt_pos[j])}" axis="{_vec(model.jnt_axis[j])}"'
+            )
+            if bool(model.jnt_limited[j]):
+                attrs += f' range="{_vec(model.jnt_range[j])}"'
+            lines.append(f"{pad}  <joint {attrs}/>")
+        for c in children.get(bid, []):
+            emit(c, indent + 1)
+        lines.append(f"{pad}</body>")
+
+    for root in children.get(0, []):
+        emit(root, 2)
+    lines += ["  </worldbody>", "</mujoco>", ""]
+
+    dest.write_text("\n".join(lines))
+    return n_bodies, n_joints
+
+
+def _mjcf_adapter() -> object:
+    """Build the MJCF :class:`~ssik._formats.FormatAdapter` (registered on import)."""
+    from ssik._formats import FormatAdapter
+
+    def _load(path: Path, base: str, ee: str, _options: Mapping[str, Any]) -> KinBody:
+        return load_mjcf_kinbody_normalized(path, base, ee)
+
+    def _suggest(path: Path, _options: Mapping[str, Any]) -> tuple[str, str, list[str]]:
+        return suggest_base_ee_mjcf(path)
+
+    def _vendor(source: Path, dest: Path, _options: Mapping[str, Any]) -> tuple[int, int]:
+        return strip_mjcf_to_fixture(source, dest)
+
+    return FormatAdapter(
+        kind="mjcf",
+        label="MuJoCo MJCF",
+        extensions=(".mjcf", ".xml"),
+        fixture_suffix=".xml",
+        scaffold_loader_module="ssik._mjcf",
+        scaffold_loader_func="load_mjcf_kinbody_normalized",
+        load=_load,
+        suggest_base_ee=_suggest,
+        vendor=_vendor,
+        root_tags=("mujoco",),
+    )
+
+
+from ssik._formats import register as _register  # noqa: E402
+
+_register(_mjcf_adapter())  # type: ignore[arg-type]

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import os
 import tempfile
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -605,3 +606,39 @@ def load_urdf_kinbody_robust(
         else:
             strip_urdf_to_fixture(src, stripped)
         return load_urdf_kinbody_normalized(stripped, base_link, ee_link)
+
+
+def _urdf_adapter() -> object:
+    """Build the URDF :class:`~ssik._formats.FormatAdapter` (registered on import)."""
+    from ssik._formats import FormatAdapter
+
+    def _load(path: Path, base: str, ee: str, options: Mapping[str, Any]) -> KinBody:
+        return load_urdf_kinbody_normalized(path, base, ee, xacro_args=options.get("xacro_args"))
+
+    def _suggest(path: Path, options: Mapping[str, Any]) -> tuple[str, str, list[str]]:
+        return suggest_base_ee(path, options.get("xacro_args"))
+
+    def _vendor(source: Path, dest: Path, options: Mapping[str, Any]) -> tuple[int, int]:
+        xacro_args = options.get("xacro_args")
+        if needs_xacro_expansion(source):
+            with _as_plain_urdf(source, xacro_args) as plain:
+                return strip_urdf_to_fixture(plain, dest)
+        return strip_urdf_to_fixture(source, dest)
+
+    return FormatAdapter(
+        kind="urdf",
+        label="URDF",
+        extensions=(".urdf", ".xacro", ".xml"),
+        fixture_suffix=".urdf",
+        scaffold_loader_module="ssik._urdf",
+        scaffold_loader_func="load_urdf_kinbody_normalized",
+        load=_load,
+        suggest_base_ee=_suggest,
+        vendor=_vendor,
+        root_tags=("robot",),
+    )
+
+
+from ssik._formats import register as _register  # noqa: E402
+
+_register(_urdf_adapter())  # type: ignore[arg-type]

--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -29,14 +29,8 @@ from pathlib import Path
 
 import numpy as np
 
+from ssik import _formats as formats
 from ssik._kinbody import KinBody
-from ssik._urdf import (
-    _as_plain_urdf,
-    load_urdf_kinbody_normalized,
-    needs_xacro_expansion,
-    strip_urdf_to_fixture,
-    suggest_base_ee,
-)
 from ssik.core.codegen import emit_artifact
 from ssik.core.dispatcher import DispatchPlan, dispatch
 from ssik.subproblems._rotation import rotation_matrix
@@ -211,7 +205,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _add_common_kinbody_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("urdf", type=Path, help="Path to the URDF or xacro file.")
+    parser.add_argument(
+        "urdf",
+        type=Path,
+        metavar="model",
+        help="Path to the robot description: URDF / xacro or MuJoCo MJCF (.xml/.mjcf).",
+    )
     parser.add_argument(
         "--base",
         default=None,
@@ -249,7 +248,8 @@ def _resolve_base_ee(args: argparse.Namespace) -> None:
     correctness risk."""
     if args.base and args.ee:
         return
-    base, ee, notes = suggest_base_ee(args.urdf, _parse_xacro_args(args))
+    adapter = formats.detect(args.urdf)
+    base, ee, notes = adapter.suggest_base_ee(args.urdf, {"xacro_args": _parse_xacro_args(args)})
     if not args.base:
         args.base = base
         print(f"[ssik]   auto-detected --base {base}")
@@ -308,8 +308,8 @@ def _configure_logging(verbose_count: int) -> None:
 def _run_classify(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
     _resolve_base_ee(args)
-    kb = load_urdf_kinbody_normalized(
-        args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
+    kb = formats.detect(args.urdf).load(
+        args.urdf, args.base, args.ee, {"xacro_args": _parse_xacro_args(args)}
     )
     print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
     plan = dispatch(kb)
@@ -325,8 +325,8 @@ def _run_classify(args: argparse.Namespace) -> int:
 def _run_build(args: argparse.Namespace) -> int:
     print(f"[ssik] Loading {args.urdf}")
     _resolve_base_ee(args)
-    kb = load_urdf_kinbody_normalized(
-        args.urdf, args.base, args.ee, xacro_args=_parse_xacro_args(args)
+    kb = formats.detect(args.urdf).load(
+        args.urdf, args.base, args.ee, {"xacro_args": _parse_xacro_args(args)}
     )
     print(f"[ssik]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
 
@@ -512,36 +512,39 @@ def _run_add_arm(args: argparse.Namespace) -> int:
         print("[ssik add-arm]   Pass --repo-root to point at the ssik repository.")
         return 1
 
-    urdf_dest = fixtures_dir / f"{args.name}.urdf"
+    print(f"[ssik add-arm] Loading {args.urdf}")
+    if not args.urdf.is_file():
+        print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
+        return 1
+    # Pick the source-format adapter (URDF, MJCF, ...) from the file; everything
+    # downstream (vendoring, loading, scaffold loader, manifest fixture_kind) is
+    # driven by it, so a new format needs no edit here (#470).
+    adapter = formats.detect(args.urdf)
+    fixture_dest = fixtures_dir / f"{args.name}{adapter.fixture_suffix}"
     test_dest = tests_dir / f"test_{args.name}.py"
     if not args.force:
-        for p in (urdf_dest, test_dest):
+        for p in (fixture_dest, test_dest):
             if p.exists():
                 print(f"[ssik add-arm] ERROR: {p} already exists.")
                 print("[ssik add-arm]   Pass --force to overwrite.")
                 return 1
 
-    print(f"[ssik add-arm] Loading {args.urdf}")
-    if not args.urdf.is_file():
-        print(f"[ssik add-arm] ERROR: {args.urdf} not found.")
-        return 1
     _resolve_base_ee(args)
-    # Vendor a mesh-free, kinematics-only fixture FIRST, then load + classify
-    # from THAT (never the mesh-laden source). Stripping meshes up front drops
-    # every ``package://`` reference, so vendor URDFs that declare xmlns:xacro
-    # but reference meshes by ROS package (ABB YuMi, FANUC) load without a ROS
-    # workspace. Only genuinely-macro'd xacro is expanded first.
-    rel = urdf_dest.relative_to(repo_root)
-    print(f"[ssik add-arm] Vendoring URDF (kinematics-only) -> {rel}")
-    if needs_xacro_expansion(args.urdf):
-        with _as_plain_urdf(args.urdf, _parse_xacro_args(args)) as plain_urdf:
-            n_links, n_joints = strip_urdf_to_fixture(plain_urdf, urdf_dest)
-    else:
-        n_links, n_joints = strip_urdf_to_fixture(args.urdf, urdf_dest)
-    kb_bytes = urdf_dest.stat().st_size
-    print(f"[ssik add-arm]   stripped to {n_links} links, {n_joints} joints, {kb_bytes:,} bytes")
+    # Vendor a kinematics-only fixture FIRST, then load + classify from THAT
+    # (never the mesh-laden source). Each adapter strips its format to a
+    # self-contained, mesh-free fixture: URDF drops every ``package://`` mesh
+    # reference (so ABB YuMi / FANUC load without a ROS workspace) and expands
+    # macro'd xacro first; MJCF reconstructs a minimal model from the compiled
+    # kinematic tree (no ``assets/`` tree).
+    rel = fixture_dest.relative_to(repo_root)
+    print(f"[ssik add-arm] Vendoring {adapter.label} (kinematics-only) -> {rel}")
+    n_bodies, n_joints = adapter.vendor(
+        args.urdf, fixture_dest, {"xacro_args": _parse_xacro_args(args)}
+    )
+    kb_bytes = fixture_dest.stat().st_size
+    print(f"[ssik add-arm]   stripped to {n_bodies} links, {n_joints} joints, {kb_bytes:,} bytes")
 
-    kb = load_urdf_kinbody_normalized(urdf_dest, args.base, args.ee)
+    kb = adapter.load(fixture_dest, args.base, args.ee, {})
     print(f"[ssik add-arm]   {len(kb.joints)} joints, {len(kb.links)} links — POE-normalized OK")
     print("[ssik add-arm] Classifying topology")
     plan = dispatch(kb)
@@ -550,7 +553,10 @@ def _run_add_arm(args: argparse.Namespace) -> int:
     print(f"[ssik add-arm] Generating test scaffold -> {test_dest.relative_to(repo_root)}")
     test_source = _render_test_scaffold(
         arm_name=args.name,
-        urdf_filename=urdf_dest.name,
+        fixture_filename=fixture_dest.name,
+        loader_module=adapter.scaffold_loader_module,
+        loader_func=adapter.scaffold_loader_func,
+        source_label=adapter.label,
         base_link=args.base,
         ee_link=args.ee,
         dof=len(kb.joints),
@@ -568,7 +574,16 @@ def _run_add_arm(args: argparse.Namespace) -> int:
 
     sample_q = _pick_sample_q(kb)
     stanza = _render_manifest_stanza(
-        args.name, args.base, args.ee, len(kb.joints), plan, args.vendor, worst_fk, sample_q
+        args.name,
+        args.base,
+        args.ee,
+        len(kb.joints),
+        plan,
+        args.vendor,
+        fixture_dest.name,
+        adapter.kind,
+        worst_fk,
+        sample_q,
     )
     print()
     if args.write_manifest:
@@ -892,6 +907,8 @@ def _render_manifest_stanza(
     dof: int,
     plan: DispatchPlan,
     vendor: str,
+    fixture_filename: str,
+    fixture_kind: str,
     worst_fk: float | None = None,
     sample_q: list[float] | None = None,
 ) -> str:
@@ -919,8 +936,8 @@ def _render_manifest_stanza(
         f'display_name = "{display}"  # verify the marketing model string',
         f'short_name = "{display}"  # shorten for compact table cells',
         f'vendor = "{vendor}"',
-        f'fixture = "{name}.urdf"',
-        'fixture_kind = "urdf"',
+        f'fixture = "{fixture_filename}"',
+        f'fixture_kind = "{fixture_kind}"',
         'fixture_source = "TODO: repo/source + license (e.g. robot_descriptions / <pkg>)"',
         f'base_link = "{base}"',
         f'ee_link = "{ee}"',
@@ -963,7 +980,10 @@ def _render_manifest_stanza(
 def _render_test_scaffold(
     *,
     arm_name: str,
-    urdf_filename: str,
+    fixture_filename: str,
+    loader_module: str,
+    loader_func: str,
+    source_label: str,
     base_link: str,
     ee_link: str,
     dof: int,
@@ -973,14 +993,16 @@ def _render_test_scaffold(
 
     The generated test file contains:
 
-    1. URDF load + DOF / joint-type sanity.
+    1. Fixture load + DOF / joint-type sanity.
     2. Dispatcher routing (asserts the solver name selected by the
        current dispatcher).
     3. ``@pytest.mark.slow`` hand-picked seeded recovery (4 q*).
     4. ``@pytest.mark.slow`` Hypothesis fuzz (10 random reachable poses).
 
     Tests assert FK closure ≤ 1e-10 on the BEST IK per pose (matching
-    the bulletproof-validation contract).
+    the bulletproof-validation contract). ``loader_module``/``loader_func`` and
+    ``source_label`` come from the source format's :class:`~ssik._formats.
+    FormatAdapter`, so the scaffold is format-agnostic (URDF, MJCF, ...).
     """
     arm_label = arm_name
     kb_helper = f"_{arm_name}_kinbody"
@@ -997,7 +1019,7 @@ current ``ssik.core.dispatcher``. The scaffold below verifies, against the
 **shipped artifact** (``ssik.prebuilt.{arm_name}`` -- build it with
 ``uv run python scripts/regen_artifacts.py --arm {arm_name}`` first):
 
-- URDF loads as a {dof}-DOF chain (revolute / continuous joints).
+- {source_label} loads as a {dof}-DOF chain (revolute / continuous joints).
 - Dispatcher routing is stable.
 - **Coverage:** poses sampled across the arm's real joint limits return at
   least one IK for at least ``_MIN_COVERAGE`` of them. This is the gate a
@@ -1010,7 +1032,7 @@ If the arm has a genuine structural coverage gap (redundant-7R near-
 singular poses, etc.), lower ``_MIN_COVERAGE`` here AND add a
 ``[arms.{arm_name}.known_gaps]`` entry in MANIFEST.toml documenting why.
 
-Source URDF: ``tests/fixtures/{urdf_filename}`` (vendored via ``ssik add-arm``).
+Source {source_label}: ``tests/fixtures/{fixture_filename}`` (vendored via ``ssik add-arm``).
 """
 
 from __future__ import annotations
@@ -1022,10 +1044,10 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from ssik._urdf import load_urdf_kinbody_normalized
+from {loader_module} import {loader_func}
 from ssik.core.dispatcher import dispatch
 
-URDF_PATH = Path(__file__).parent / "fixtures" / "{urdf_filename}"
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "{fixture_filename}"
 
 # Fraction of reachable poses that must return >= 1 IK. A broken arm
 # returns few/none; this is the coverage floor the gate enforces.
@@ -1037,7 +1059,7 @@ _FK_CEILING = {fk_ceiling:.0e}
 
 
 def {kb_helper}():
-    return load_urdf_kinbody_normalized(URDF_PATH, "{base_link}", "{ee_link}")
+    return {loader_func}(FIXTURE_PATH, "{base_link}", "{ee_link}")
 
 
 def _joint_bounds():

--- a/src/ssik/prebuilt/_manifest.py
+++ b/src/ssik/prebuilt/_manifest.py
@@ -18,7 +18,8 @@ except ModuleNotFoundError:  # Python < 3.11 (best-effort support, see #366)
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+
+from ssik import _formats as formats
 
 _MANIFEST_PATH = Path(__file__).resolve().parent / "MANIFEST.toml"
 
@@ -73,7 +74,10 @@ class Arm:
     short_name: str
     table_name: str  # compact form for README / quickstart prebuilt tables
     fixture: str
-    fixture_kind: Literal["urdf", "specs"]
+    # A registered source-format kind (``ssik._formats``: "urdf", "mjcf", ...) or
+    # "specs" (a Python KinBody-builder module). Validated against the registry so
+    # a new format needs no edit here.
+    fixture_kind: str
     base_link: str
     ee_link: str
     dof: int
@@ -172,16 +176,19 @@ def _coerce_arm(name: str, body: dict[str, object]) -> Arm:
         known_gaps = ArmKnownGap(xfail_reason=str(gaps_dict["xfail_reason"]))
 
     fixture_kind = body["fixture_kind"]
-    if fixture_kind not in ("urdf", "specs"):
+    valid_kinds = (*formats.kinds(), "specs")
+    if fixture_kind not in valid_kinds:
         raise ValueError(
-            f"arm {name!r}: fixture_kind must be 'urdf' or 'specs', got {fixture_kind!r}"
+            f"arm {name!r}: fixture_kind must be one of {valid_kinds}, got {fixture_kind!r}"
         )
-    # ``specs_fn`` is required when fixture_kind == "specs"; absent for urdf.
+    # ``specs_fn`` is required when fixture_kind == "specs"; absent for a file format.
     specs_fn = body.get("specs_fn")
     if fixture_kind == "specs" and not specs_fn:
         raise ValueError(f"arm {name!r}: fixture_kind='specs' requires specs_fn")
-    if fixture_kind == "urdf" and specs_fn:
-        raise ValueError(f"arm {name!r}: fixture_kind='urdf' but specs_fn is set; remove specs_fn")
+    if fixture_kind != "specs" and specs_fn:
+        raise ValueError(
+            f"arm {name!r}: fixture_kind={fixture_kind!r} but specs_fn is set; remove specs_fn"
+        )
 
     return Arm(
         name=name,

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -49,6 +49,43 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def test_add_arm_mjcf_end_to_end(workspace: Path) -> None:
+    """``ssik add-arm`` onboards a MuJoCo MJCF arm (#470): format auto-detected,
+    a kinematics-only ``.xml`` fixture vendored (no assets tree), the scaffold
+    wired to the MJCF loader, the manifest stanza tagged ``fixture_kind = "mjcf"``,
+    and the build+coverage gate passing on the MuJoCo source."""
+    pytest.importorskip("mujoco")
+    rd = pytest.importorskip("robot_descriptions.iiwa14_mj_description")
+    result = _run_cli(
+        "add-arm",
+        str(rd.MJCF_PATH),
+        "--name",
+        "iiwa14_mjcf_test",
+        "--vendor",
+        "kuka",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    out = result.stdout
+    assert "Vendoring MuJoCo MJCF" in out
+    assert "VALIDATED" in out, f"no validation verdict:\n{out}"
+    assert 'fixture_kind = "mjcf"' in out
+    assert 'fixture = "iiwa14_mjcf_test.xml"' in out
+
+    # Kinematics-only MJCF fixture (no meshes/assets), and the scaffold loads it
+    # via the MJCF adapter.
+    fixture = workspace / "tests" / "fixtures" / "iiwa14_mjcf_test.xml"
+    assert fixture.is_file()
+    text = fixture.read_text()
+    assert text.lstrip().startswith("<mujoco")
+    assert "<mesh" not in text
+    assert "<asset" not in text
+    scaffold = (workspace / "tests" / "test_iiwa14_mjcf_test.py").read_text()
+    assert "from ssik._mjcf import load_mjcf_kinbody_normalized" in scaffold
+    assert "load_mjcf_kinbody_normalized(FIXTURE_PATH" in scaffold
+
+
 def test_add_arm_builds_and_validates(workspace: Path) -> None:
     """Default (no ``--no-validate``): add-arm builds the emitted artifact and
     runs the coverage gate locally, reporting a verdict, and the printed stanza

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,58 @@
+"""Format-adapter registry (#470): detection + the two built-in adapters.
+
+The registry (:mod:`ssik._formats`) is what makes ingestion pluggable -- a new
+source format (URDF, MJCF, future USD/SDF) is one ``register(FormatAdapter(...))``
+call, and every format-agnostic consumer (``ssik add-arm``, ``regen_artifacts``,
+the manifest validator) resolves through it. These tests pin the contract those
+consumers rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ssik import _formats as formats
+
+
+def test_builtin_kinds_registered() -> None:
+    assert set(formats.kinds()) >= {"urdf", "mjcf"}
+
+
+def test_get_unknown_kind_raises() -> None:
+    with pytest.raises(ValueError, match="unknown format kind"):
+        formats.get("usd")
+
+
+def test_detect_by_extension() -> None:
+    assert formats.detect("arm.urdf").kind == "urdf"
+    assert formats.detect("arm.xacro").kind == "urdf"
+    assert formats.detect("arm.mjcf").kind == "mjcf"
+
+
+def test_detect_unknown_extension_raises() -> None:
+    with pytest.raises(ValueError, match="no registered format"):
+        formats.detect("arm.step")
+
+
+def test_detect_xml_disambiguated_by_root_tag(tmp_path: Path) -> None:
+    """``.xml`` is claimed by both URDF and MJCF; the XML root element decides."""
+    robot = tmp_path / "r.xml"
+    robot.write_text('<robot name="x"><link name="a"/></robot>')
+    mujoco = tmp_path / "m.xml"
+    mujoco.write_text('<mujoco model="x"><worldbody/></mujoco>')
+    assert formats.detect(robot).kind == "urdf"
+    assert formats.detect(mujoco).kind == "mjcf"
+
+
+def test_adapter_fields_present() -> None:
+    for kind in ("urdf", "mjcf"):
+        a = formats.get(kind)
+        assert a.kind == kind
+        assert a.fixture_suffix.startswith(".")
+        assert a.scaffold_loader_module
+        assert a.scaffold_loader_func
+        assert callable(a.load)
+        assert callable(a.vendor)
+        assert callable(a.suggest_base_ee)

--- a/tests/test_mjcf.py
+++ b/tests/test_mjcf.py
@@ -17,6 +17,7 @@ mujoco = pytest.importorskip("mujoco")
 
 from ssik._mjcf import (  # noqa: E402
     load_mjcf_kinbody_normalized,
+    strip_mjcf_to_fixture,
     suggest_base_ee_mjcf,
 )
 from ssik.kinematics.poe_fk import poe_forward_kinematics  # noqa: E402
@@ -127,6 +128,48 @@ def _chain_jnt_ids(model: Any, base: str, ee: str) -> list[int]:
             if int(model.jnt_type[j]) in (hinge, slide)
         ]
     return ids
+
+
+@pytest.mark.parametrize(
+    ("module", "exp_base", "exp_ee", "dof"),
+    _REAL_MJCF_ARMS,
+    ids=[a[0] for a in _REAL_MJCF_ARMS],
+)
+def test_strip_mjcf_to_fixture_preserves_kinematics(
+    module: str, exp_base: str, exp_ee: str, dof: int, tmp_path: Path
+) -> None:
+    """The vendored kinematics-only MJCF is self-contained (no mesh/asset refs)
+    and FK-identical to the source (#470)."""
+    src = importlib.import_module(f"robot_descriptions.{module}").MJCF_PATH
+    dest = tmp_path / "vendored.xml"
+    # strip vendors the WHOLE model tree (so base/ee selection still works on the
+    # fixture), so its joint count is >= the base->ee chain's dof (arx_l5 also has
+    # a gripper joint).
+    n_bodies, n_joints = strip_mjcf_to_fixture(Path(src), dest)
+    assert n_bodies >= dof
+    assert n_joints >= dof
+
+    text = dest.read_text()
+    assert "<mesh" not in text  # no asset tree needed
+    assert "<asset" not in text
+
+    base, ee, _ = suggest_base_ee_mjcf(dest)
+    assert (base, ee) == (exp_base, exp_ee)
+    kb_src = load_mjcf_kinbody_normalized(src, exp_base, exp_ee)
+    kb_vendored = load_mjcf_kinbody_normalized(dest, base, ee)
+    rng = np.random.default_rng(1)
+    worst = 0.0
+    for _ in range(30):
+        q = rng.uniform(-1.5, 1.5, size=dof)
+        worst = max(
+            worst,
+            float(
+                np.abs(
+                    poe_forward_kinematics(kb_src, q) - poe_forward_kinematics(kb_vendored, q)
+                ).max()
+            ),
+        )
+    assert worst < 1e-11, f"{module}: vendored MJCF FK drifted by {worst:.2e}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

`ssik add-arm` (and `ssik build`/`dispatch`, `regen_artifacts`, the MANIFEST schema) was URDF-specific. This makes source-format ingestion **pluggable** so an MJCF-only arm onboards as a shipped prebuilt, and — per @'s note — a future format (USD/SDF, #83) is one adapter module with **no edits to the CLI, the artifact regenerator, or the manifest validator**.

Closes #470. Builds on #469 (the `from_mjcf` library path).

## The registry (`ssik._formats`)

`FormatAdapter` bundles everything a format must provide:
- **detect** — by extension, disambiguating shared `.xml` via the XML root tag (`<robot>` → URDF, `<mujoco>` → MJCF)
- **suggest_base_ee**, **load**, **vendor** (source → kinematics-only fixture)
- the **scaffold loader** (module + func) and the manifest **`fixture_kind`**

URDF and MJCF adapters live next to their parsers and self-register on import; the registry lazily imports them so `urchin`/`mujoco` stay optional extras.

## MJCF vendoring (`strip_mjcf_to_fixture`)

mujoco compiles the source (resolving `<include>`/`<default>`/assets), then we **reconstruct** a minimal self-contained MJCF from the compiled kinematic tree (bodies + joints + placeholder inertials, no geoms/assets). No `assets/` mesh tree is dragged along, and it recompiles to the **identical** kinematics (FK parity 0 on iiwa14/gen3/fr3/arx_l5, ~2.2KB fixtures).

## Consumers, de-branched

`add-arm` detects the format and drives vendoring/loading/scaffold/stanza off the adapter; `regen_artifacts` and `_manifest` validate `fixture_kind` against the registered kinds (+ `"specs"`). The test scaffold and manifest stanza are format-parametrized.

## Validation

- **End-to-end**: `ssik add-arm <iiwa14.xml>` (real MuJoCo Menagerie) → auto-detect MJCF, vendor a 2.2KB kinematics-only fixture, dispatch to `seven_r.srs`, **build + coverage-gate at 100% coverage / worst FK 1.9e-12**.
- **URDF behavior-preserving**: artifact snapshots **byte-identical**; full URDF / manifest / CLI / fixture-parity suite (319 tests) green.
- New tests: `test_formats.py` (registry + `.xml` disambiguation), `test_mjcf.py::test_strip_mjcf_to_fixture_preserves_kinematics` (4 real arms), `test_cli_add_arm.py::test_add_arm_mjcf_end_to_end`.
- ruff + mypy (249 files) clean.

## Adding a format later

Write its loader/vendor, build a `FormatAdapter`, `register()` it. That's it.