### PR TITLE
add-arm auto-detect: don't trim a gripper-named body below 6 DOF (#470 follow-up)

### DIFF
--- a/src/ssik/_mjcf.py
+++ b/src/ssik/_mjcf.py
@@ -26,7 +26,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ssik._kinbody import JointType, KinBody, build_poe_kinbody
-from ssik._urdf import _GRIPPER_HINTS
+from ssik._urdf import _GRIPPER_HINTS, _MIN_ARM_DOF
 
 __all__ = [
     "load_mjcf_kinbody_normalized",
@@ -103,10 +103,25 @@ def suggest_base_ee_mjcf(mjcf_path: str | Path) -> tuple[str, str, list[str]]:
     actuated = [b for b in chain if n_actuated(b) > 0]
     base_body = name(int(model.body_parentid[actuated[0]]))
 
-    # Trim trailing gripper/tool bodies back to the kinematic flange.
+    # Cumulative actuated-joint count along the chain (dof if ee = chain[i]).
+    cum: list[int] = []
+    running = 0
+    for b in chain:
+        running += n_actuated(b)
+        cum.append(running)
+
+    # Trim trailing gripper/tool bodies back to the kinematic flange, but never
+    # below _MIN_ARM_DOF: a body named like a gripper can still carry a real arm
+    # DOF (Trossen ViperX/WidowX put the 6th joint, wrist-rotate, in
+    # ``gripper_link``), and since ssik only solves 6/7-DOF, trimming to <6 is
+    # never the intended flange -- it just fails dispatch (#470 follow-up).
     ee_idx = chain.index(actuated[-1])
     first_idx = chain.index(actuated[0])
-    while ee_idx > first_idx and any(h in name(chain[ee_idx]).lower() for h in _GRIPPER_HINTS):
+    while (
+        ee_idx > first_idx
+        and any(h in name(chain[ee_idx]).lower() for h in _GRIPPER_HINTS)
+        and (cum[-1] < _MIN_ARM_DOF or cum[ee_idx - 1] >= _MIN_ARM_DOF)
+    ):
         ee_idx -= 1
     ee_body = name(chain[ee_idx])
 
@@ -118,6 +133,12 @@ def suggest_base_ee_mjcf(mjcf_path: str | Path) -> tuple[str, str, list[str]]:
     ]
     if trailing:
         notes.append(f"frames past {ee_body!r}: {trailing} (pass ee= to use one)")
+    trimmed_grippers = [name(b) for b in chain[ee_idx + 1 :] if name(b) not in trailing]
+    if trimmed_grippers:
+        notes.append(
+            f"trimmed gripper/tool bodies past {ee_body!r}: {trimmed_grippers} "
+            "(pass ee= to include one if it's actually an arm DOF)"
+        )
     return base_body, ee_body, notes
 
 

--- a/src/ssik/_urdf.py
+++ b/src/ssik/_urdf.py
@@ -95,6 +95,12 @@ _GRIPPER_HINTS = (
     "flange",
 )
 
+# Never let the gripper-name trim drop the auto-detected chain below this many
+# actuated DOF: ssik only solves 6/7-DOF, so a shorter chain is never the
+# intended flange, and a body named like a gripper can still carry a real arm
+# joint (e.g. Trossen ViperX/WidowX's 6th DOF lives in ``gripper_link``).
+_MIN_ARM_DOF = 6
+
 
 def suggest_base_ee(
     source: str | Path, xacro_args: dict[str, str] | None = None
@@ -159,11 +165,20 @@ def suggest_base_ee(
     base_link = chain_links[active_idx[0]]
     ee_idx = active_idx[-1] + 1
 
+    # active joints to reach chain_links[k] = dof if ee = chain_links[k].
+    def _dof_at(k: int) -> int:
+        return sum(1 for t in chain_types[:k] if t in _ACTIVE_URDF_JOINTS)
+
     # Gripper joints (fingers) are active too, so the longest actuated chain
     # runs past the wrist into a finger. Back the EE up to the last link that
-    # isn't gripper-named -- the kinematic flange.
-    while ee_idx > active_idx[0] and any(
-        hint in chain_links[ee_idx].lower() for hint in _GRIPPER_HINTS
+    # isn't gripper-named -- the kinematic flange -- but never below
+    # _MIN_ARM_DOF: a gripper-named link can still carry a real arm DOF (Trossen
+    # ViperX/WidowX put the 6th joint in ``gripper_link``), and ssik only solves
+    # 6/7-DOF, so trimming to <6 is never the intended flange.
+    while (
+        ee_idx > active_idx[0]
+        and any(hint in chain_links[ee_idx].lower() for hint in _GRIPPER_HINTS)
+        and (n_active < _MIN_ARM_DOF or _dof_at(ee_idx - 1) >= _MIN_ARM_DOF)
     ):
         ee_idx -= 1
     ee_link = chain_links[ee_idx]

--- a/tests/test_mjcf.py
+++ b/tests/test_mjcf.py
@@ -131,6 +131,27 @@ def _chain_jnt_ids(model: Any, base: str, ee: str) -> list[int]:
 
 
 @pytest.mark.parametrize(
+    ("module", "exp_base", "exp_ee"),
+    [
+        ("viper_mj_description", "base_link", "gripper_link"),
+        ("widow_mj_description", "wx250s/base_link", "wx250s/gripper_link"),
+    ],
+)
+def test_suggest_base_ee_keeps_gripper_named_sixth_dof(
+    module: str, exp_base: str, exp_ee: str
+) -> None:
+    """Trossen ViperX/WidowX put the 6th arm DOF (wrist-rotate) in
+    ``gripper_link``. Auto-detect must keep it (6-DOF), not trim it as a gripper
+    (which would give a 5-DOF chain that fails dispatch) -- the never-below-6-DOF
+    guard (#470 follow-up)."""
+    rd = pytest.importorskip(f"robot_descriptions.{module}")
+    base, ee, _notes = suggest_base_ee_mjcf(rd.MJCF_PATH)
+    assert (base, ee) == (exp_base, exp_ee)
+    arm = Manipulator.from_mjcf(rd.MJCF_PATH)
+    assert len(arm.kinbody.joints) == 6
+
+
+@pytest.mark.parametrize(
     ("module", "exp_base", "exp_ee", "dof"),
     _REAL_MJCF_ARMS,
     ids=[a[0] for a in _REAL_MJCF_ARMS],

--- a/tests/test_urdf_ingestion.py
+++ b/tests/test_urdf_ingestion.py
@@ -121,3 +121,37 @@ def test_suggest_base_ee_skips_leading_fixed_and_gripper() -> None:
         base, ee, _ = suggest_base_ee(src)
         assert base == "base_link"
         assert ee == "wrist"
+
+
+# A 6-DOF arm whose 6th joint's link is *named* like a gripper (Trossen
+# ViperX/WidowX put the wrist-rotate DOF in ``gripper_link``). The gripper-name
+# trim must NOT eat that link -- doing so yields a 5-DOF chain that can't
+# dispatch. The guard: never trim below 6 DOF (#470 follow-up).
+_ARM_GRIPPER_NAMED_SIXTH = f"""<?xml version="1.0"?>
+<robot name="arm">
+  <link name="base_link"/><link name="l1"/><link name="l2"/><link name="l3"/>
+  <link name="l4"/><link name="l5"/><link name="gripper_link"/>
+  <link name="finger_left"/><link name="finger_right"/>
+  {_rev("j1", "base_link", "l1")}
+  {_rev("j2", "l1", "l2")}
+  {_rev("j3", "l2", "l3")}
+  {_rev("j4", "l3", "l4")}
+  {_rev("j5", "l4", "l5")}
+  {_rev("j6", "l5", "gripper_link")}
+  {_rev("fl", "gripper_link", "finger_left")}
+  {_rev("fr", "gripper_link", "finger_right")}
+</robot>
+"""
+
+
+def test_suggest_base_ee_keeps_gripper_named_sixth_dof() -> None:
+    """The gripper-name trim never drops the chain below 6 DOF, so a 6th arm
+    joint that lives in a ``gripper_link`` (ViperX/WidowX) is retained."""
+    from ssik._urdf import suggest_base_ee
+
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "arm.urdf"
+        src.write_text(_ARM_GRIPPER_NAMED_SIXTH)
+        base, ee, _notes = suggest_base_ee(src)
+        assert base == "base_link"
+        assert ee == "gripper_link"  # NOT trimmed to l5 (that would be 5-DOF)


### PR DESCRIPTION
## Why

`suggest_base_ee` (URDF + MJCF) backs the end-effector off trailing gripper/tool bodies **by name**. But a body *named* like a gripper can carry a real arm joint: Trossen **ViperX/WidowX put the 6th DOF (wrist-rotate) in `gripper_link`**, so the name-only trim returned a **5-DOF** chain that then fails dispatch (`got 5 joints`) — forcing a manual `--ee gripper_link`.

Surfaced while surveying what MJCF unlocks (the ViperX/WidowX are the canonical MJCF-only arms).

## Fix

Never let the gripper-name trim drop the chain below `_MIN_ARM_DOF` (6). Since ssik only solves 6/7-DOF, a shorter chain is never the intended flange. The guard only engages when the full chain already has ≥6 actuated DOF, so a genuine sub-6 arm + gripper (a 3-DOF toy) still trims to its flange exactly as before.

Trimmed gripper bodies are now also surfaced in the returned `notes`, so a wrong guess is visible instead of silent.

## Result

| arm | before | after |
|---|---|---|
| ViperX 300 (MJCF) | `wrist_link` (5-DOF, fails dispatch) | **`gripper_link` (6-DOF, spherical_two_parallel, 100%)** |
| WidowX 250 (MJCF) | `wrist_link` (5-DOF) | **`gripper_link` (6-DOF)** |
| iiwa14 / panda / ur5 / gen3 (URDF) | unchanged | unchanged |
| 3-DOF toy + gripper | `wrist` | `wrist` (unchanged) |

## Tests

- URDF: synthetic 6-DOF arm whose 6th joint's link is `gripper_link` → ee keeps it (not trimmed to 5-DOF).
- MJCF: real ViperX/WidowX → `gripper_link`, 6-DOF.
- The existing 3-DOF-toy trim still lands on the wrist (regression preserved).
- 66-test ingestion/CLI/manipulator sweep green; ruff + mypy clean.

Refs #470. Unblocks one-click onboarding of ViperX/WidowX.