### PR TITLE
Make Python 3.10 a first-class supported version (ROS2 Humble) (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        # Full support range: 3.10 (ROS2 Humble floor, #477) through 3.13.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -23,8 +24,8 @@ classifiers = [
 dependencies = [
     "numpy>=1.26",
     # ``ssik.prebuilt._manifest`` parses the arm manifest with ``tomllib``,
-    # which is stdlib only on Python 3.11+. On the best-effort 3.10 floor
-    # (see #366) it falls back to the ``tomli`` backport, so pull it in there.
+    # which is stdlib only on Python 3.11+. On the 3.10 support floor (#477,
+    # for ROS2 Humble) it falls back to the ``tomli`` backport, so pull it in there.
     "tomli>=1.1.0; python_version < '3.11'",
     # scipy.linalg / scipy.signal are imported at module top in
     # ``ssik._pencil`` and ``ssik.solvers.husty_pfurner._eliminate``; HP backs
@@ -138,7 +139,9 @@ include = [
 # matrix invokes the hatchling build with our Cython hook -- the same path
 # as a local ``uv build --wheel`` -- so we keep one source of truth.
 [tool.cibuildwheel]
-build = "cp311-* cp312-* cp313-*"
+# cp310 is kept for ROS2 Humble (Ubuntu 22.04, Python 3.10, EOL May 2027) --
+# deliberately below the Scientific Python SPEC 0 window (#477).
+build = "cp310-* cp311-* cp312-* cp313-*"
 # Skip targets we don't ship in v1.0 (#132 "Deferred to v1.1+"): musllinux,
 # 32-bit Linux, 32-bit Windows, PyPy. Linux aarch64 is also deferred.
 skip = ["*-musllinux_*", "*-manylinux_i686", "*-win32", "pp*", "*linux_aarch64"]
@@ -217,6 +220,9 @@ select = [
 ]
 
 [tool.mypy]
+# 3.11 (not the 3.10 support floor): the 3.10 target only adds spurious numpy
+# ndarray `.copy()` no-any-return noise, while real 3.10 compat is gated by ruff
+# (target py310) + the 3.10 CI test-run (#477). Type-correctness is version-agnostic.
 python_version = "3.11"
 strict = true
 files = ["src", "tests"]

--- a/src/ssik/__init__.py
+++ b/src/ssik/__init__.py
@@ -38,8 +38,6 @@ diagnostics::
 """
 
 import logging as _logging
-import sys as _sys
-import warnings as _warnings
 
 from ssik._version import __version__
 from ssik.core.diagnostic import Diagnostic
@@ -52,21 +50,6 @@ from ssik.prebuilt import list_arms  # catalog of shipped arms; imports no artif
 # avoid emitting any log records unless the consuming application configures
 # the ``ssik`` namespace explicitly.
 _logging.getLogger(__name__).addHandler(_logging.NullHandler())
-
-# Python 3.10 and numpy 1.x install and work, but they sit below the versions
-# CI exercises and below the Scientific Python SPEC 0 support window
-# (https://scientific-python.org/specs/spec-0000/, which recommends dropping
-# Python 3 years and numpy 2 years after release). We allow them on a
-# best-effort, untested basis and warn once so users know. See #366.
-if _sys.version_info < (3, 11):
-    _warnings.warn(
-        f"ssik is running on Python {_sys.version_info.major}."
-        f"{_sys.version_info.minor}, below the tested minimum (3.11) and the "
-        "Scientific Python SPEC 0 support window. It is supported on a "
-        "best-effort, untested basis. See "
-        "https://github.com/personalrobotics/ssik/issues/366.",
-        stacklevel=2,
-    )
 
 __all__ = [
     "DEFAULT_TOLERANCE_POLICY",

--- a/src/ssik/prebuilt/_manifest.py
+++ b/src/ssik/prebuilt/_manifest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 try:
     import tomllib
-except ModuleNotFoundError:  # Python < 3.11 (best-effort support, see #366)
+except ModuleNotFoundError:  # Python 3.10 (ROS2 Humble, #477)
     import tomli as tomllib
 from dataclasses import dataclass, field
 from functools import lru_cache

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -23,6 +23,11 @@ from pathlib import Path
 
 import pytest
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # 3.10 backport (ROS2 Humble, #477)
+    import tomli as tomllib
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -326,7 +331,6 @@ def _seed_manifest(workspace: Path) -> Path:
 def test_add_arm_write_manifest_appends_stanza(workspace: Path) -> None:
     """``--write-manifest`` appends the derived stanza to MANIFEST.toml (valid
     TOML, existing entries preserved)."""
-    import tomllib
 
     mf = _seed_manifest(workspace)
     result = _run_cli(
@@ -356,7 +360,6 @@ def test_add_arm_write_manifest_appends_stanza(workspace: Path) -> None:
 def test_add_arm_write_manifest_refuses_duplicate(workspace: Path) -> None:
     """``--write-manifest`` refuses to append a second entry for the same arm
     without ``--force`` (and doesn't duplicate)."""
-    import tomllib
 
     mf = _seed_manifest(workspace)
     args = [

--- a/tests/test_perf_extensions.py
+++ b/tests/test_perf_extensions.py
@@ -24,7 +24,11 @@ import sys
 from pathlib import Path
 
 import pytest
-import tomllib
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # 3.10 backport (ROS2 Humble, #477)
+    import tomli as tomllib
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO / "scripts"))


### PR DESCRIPTION
## Why

3.10 was **half-supported** — `requires-python = ">=3.10"` + `tomli`/ruff accommodations, but no cp310 wheel, no 3.10 classifier, no 3.10 CI, and a runtime warning telling users it's "best-effort, untested". **ROS2 Humble** (Ubuntu 22.04, Python 3.10, EOL **May 2027**) needs it. Fixes #477.

## What

- **Wheels:** `cp310-*` added to the cibuildwheel matrix.
- **Classifier:** `Programming Language :: Python :: 3.10`.
- **CI:** test matrix widened `["3.13"]` → `["3.10", "3.11", "3.12", "3.13"]` (3.11/3.12 were unverified too).
- **Runtime:** dropped the `< (3,11)` best-effort `UserWarning` (+ its now-unused `sys`/`warnings` imports) — 3.10 is tested + wheel-built now, so the warning is false.
- **Imports:** the `tomllib` imports in tests use the `sys.version_info >= (3, 11)` guard (`tomli` backport on 3.10); provenance comments updated #366 → #477.

## Verified

- **Full suite passes on CPython 3.10.17** (553 passed). The lone failure was a pre-existing **unseeded-Hypothesis flake** (`test_tv1_hypothesis_fuzz_500_examples`) that **passes in isolation** — same class as #181/#466 LAPACK-variance flakes, not 3.10-specific.
- `import ssik` is **warning-free** on 3.10; ur5/iiwa14 solve correctly.
- ruff + mypy clean.

## Note

mypy stays `python_version = "3.11"`: the 3.10 target only adds spurious numpy `.copy()` `no-any-return` noise (the code runs fine on 3.10). Real 3.10 compat is gated by ruff (`target py310`) + the new 3.10 CI run.

Adding 3 Python versions to CI raises the odds of surfacing the pre-existing Hypothesis flakes — re-run on a flake, as with the existing 3.13 ones.