### PR TITLE
add-arm: auto-apply the '_ik' name convention (#474)

### DIFF
--- a/src/ssik/cli.py
+++ b/src/ssik/cli.py
@@ -148,10 +148,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--name",
         required=True,
         help=(
-            "Identifier for the arm (lowercase, underscore-separated). "
-            "Determines the fixture filename (tests/fixtures/<name>.urdf), "
-            "the test module (tests/test_<name>.py), and the Python helper "
-            "(_<name>_kinbody). Examples: 'kinova_gen3', 'flexiv_rizon4'."
+            "Identifier for the arm (lowercase, underscore-separated), by "
+            "convention ending in '_ik' -- appended automatically if omitted. "
+            "Determines the fixture filename (tests/fixtures/<name>.<ext>), the "
+            "test module (tests/test_<name>.py), and the manifest key. "
+            "Examples: 'gen3_ik', 'rizon4_ik', 'viperx300s_ik'."
         ),
     )
     add_arm_parser.add_argument(
@@ -505,6 +506,13 @@ def _fk_poe(kb: object, q: np.ndarray) -> np.ndarray:
 
 def _run_add_arm(args: argparse.Namespace) -> int:
     repo_root = args.repo_root or Path.cwd()
+    # Every shipped arm's manifest key + artifact basename ends in ``_ik`` (the
+    # roster test globs ``*/*_ik.py``), so auto-apply the convention: a bare
+    # --name like ``viperx300s`` otherwise silently produces non-conforming
+    # files that then fail the manifest/roster tests (#474).
+    if not args.name.endswith("_ik"):
+        args.name = f"{args.name}_ik"
+        print(f"[ssik add-arm] Using arm name {args.name!r} (applied the '_ik' convention)")
     fixtures_dir = repo_root / "tests" / "fixtures"
     tests_dir = repo_root / "tests"
     if not fixtures_dir.is_dir():

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -148,6 +148,56 @@ def test_add_arm_derives_class_metadata(workspace: Path) -> None:
     assert 'display_name = "Universal Robots' in out
 
 
+def test_add_arm_appends_ik_suffix(workspace: Path) -> None:
+    """A --name without the ``_ik`` convention gets it appended, so the emitted
+    fixture/test/manifest key conform to the roster glob (#474)."""
+    result = _run_cli(
+        "add-arm",
+        "--no-validate",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "rizon4_suffix_test",  # no _ik
+        "--vendor",
+        "flexiv",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    assert "applied the '_ik' convention" in result.stdout
+    # Files + manifest key carry the appended suffix, not the bare name.
+    assert (workspace / "tests" / "fixtures" / "rizon4_suffix_test_ik.urdf").exists()
+    assert (workspace / "tests" / "test_rizon4_suffix_test_ik.py").exists()
+    assert "[arms.rizon4_suffix_test_ik]" in result.stdout
+    assert (workspace / "tests" / "fixtures" / "rizon4_suffix_test.urdf").exists() is False
+
+
+def test_add_arm_keeps_existing_ik_suffix(workspace: Path) -> None:
+    """A --name already ending in ``_ik`` is left unchanged (no double suffix)."""
+    result = _run_cli(
+        "add-arm",
+        "--no-validate",
+        str(REPO_ROOT / "tests" / "fixtures" / "rizon4.urdf"),
+        "--base",
+        "base_link",
+        "--ee",
+        "flange",
+        "--name",
+        "rizon4_keep_ik",  # already ends in _ik
+        "--vendor",
+        "flexiv",
+        "--repo-root",
+        str(workspace),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "applied the '_ik' convention" not in result.stdout
+    assert (workspace / "tests" / "test_rizon4_keep_ik.py").exists()
+    assert (workspace / "tests" / "test_rizon4_keep_ik_ik.py").exists() is False
+
+
 def test_add_arm_generates_files(workspace: Path) -> None:
     """``ssik add-arm`` vendors the URDF and emits a test scaffold."""
     result = _run_cli(

--- a/tests/test_cli_add_arm.py
+++ b/tests/test_cli_add_arm.py
@@ -65,7 +65,7 @@ def test_add_arm_mjcf_end_to_end(workspace: Path) -> None:
         "add-arm",
         str(rd.MJCF_PATH),
         "--name",
-        "iiwa14_mjcf_test",
+        "iiwa14_mjcf_test_ik",
         "--vendor",
         "kuka",
         "--repo-root",
@@ -76,17 +76,17 @@ def test_add_arm_mjcf_end_to_end(workspace: Path) -> None:
     assert "Vendoring MuJoCo MJCF" in out
     assert "VALIDATED" in out, f"no validation verdict:\n{out}"
     assert 'fixture_kind = "mjcf"' in out
-    assert 'fixture = "iiwa14_mjcf_test.xml"' in out
+    assert 'fixture = "iiwa14_mjcf_test_ik.xml"' in out
 
     # Kinematics-only MJCF fixture (no meshes/assets), and the scaffold loads it
     # via the MJCF adapter.
-    fixture = workspace / "tests" / "fixtures" / "iiwa14_mjcf_test.xml"
+    fixture = workspace / "tests" / "fixtures" / "iiwa14_mjcf_test_ik.xml"
     assert fixture.is_file()
     text = fixture.read_text()
     assert text.lstrip().startswith("<mujoco")
     assert "<mesh" not in text
     assert "<asset" not in text
-    scaffold = (workspace / "tests" / "test_iiwa14_mjcf_test.py").read_text()
+    scaffold = (workspace / "tests" / "test_iiwa14_mjcf_test_ik.py").read_text()
     assert "from ssik._mjcf import load_mjcf_kinbody_normalized" in scaffold
     assert "load_mjcf_kinbody_normalized(FIXTURE_PATH" in scaffold
 
@@ -209,7 +209,7 @@ def test_add_arm_generates_files(workspace: Path) -> None:
         "--ee",
         "flange",
         "--name",
-        "rizon4_addarm_test",
+        "rizon4_addarm_test_ik",
         "--vendor",
         "flexiv",
         "--repo-root",
@@ -217,8 +217,8 @@ def test_add_arm_generates_files(workspace: Path) -> None:
     )
     assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
 
-    urdf_dest = workspace / "tests" / "fixtures" / "rizon4_addarm_test.urdf"
-    test_dest = workspace / "tests" / "test_rizon4_addarm_test.py"
+    urdf_dest = workspace / "tests" / "fixtures" / "rizon4_addarm_test_ik.urdf"
+    test_dest = workspace / "tests" / "test_rizon4_addarm_test_ik.py"
     assert urdf_dest.exists(), "URDF not vendored"
     assert test_dest.exists(), "test scaffold not written"
     # Vendored URDF is stripped to kinematics-only (no mesh/visual/collision)
@@ -244,7 +244,7 @@ def test_add_arm_generates_files(workspace: Path) -> None:
 
 def test_add_arm_refuses_overwrite_without_force(workspace: Path) -> None:
     """If the fixture already exists, the CLI refuses unless ``--force``."""
-    target = workspace / "tests" / "fixtures" / "preexisting_arm.urdf"
+    target = workspace / "tests" / "fixtures" / "preexisting_arm_ik.urdf"
     target.write_text("<robot/>")
     result = _run_cli(
         "add-arm",
@@ -255,7 +255,7 @@ def test_add_arm_refuses_overwrite_without_force(workspace: Path) -> None:
         "--ee",
         "flange",
         "--name",
-        "preexisting_arm",
+        "preexisting_arm_ik",
         "--vendor",
         "flexiv",
         "--repo-root",
@@ -269,8 +269,8 @@ def test_add_arm_refuses_overwrite_without_force(workspace: Path) -> None:
 
 def test_add_arm_force_overwrites(workspace: Path) -> None:
     """``--force`` overwrites the existing fixture."""
-    target_urdf = workspace / "tests" / "fixtures" / "force_test.urdf"
-    target_test = workspace / "tests" / "test_force_test.py"
+    target_urdf = workspace / "tests" / "fixtures" / "force_test_ik.urdf"
+    target_test = workspace / "tests" / "test_force_test_ik.py"
     target_urdf.write_text("<robot/>")
     target_test.write_text("# stale")
     result = _run_cli(
@@ -282,7 +282,7 @@ def test_add_arm_force_overwrites(workspace: Path) -> None:
         "--ee",
         "flange",
         "--name",
-        "force_test",
+        "force_test_ik",
         "--vendor",
         "flexiv",
         "--repo-root",
@@ -306,14 +306,14 @@ def test_add_arm_generated_test_is_valid_python(workspace: Path) -> None:
         "--ee",
         "flange",
         "--name",
-        "compile_test",
+        "compile_test_ik",
         "--vendor",
         "flexiv",
         "--repo-root",
         str(workspace),
     )
     assert result.returncode == 0
-    test_dest = workspace / "tests" / "test_compile_test.py"
+    test_dest = workspace / "tests" / "test_compile_test_ik.py"
     source = test_dest.read_text()
     # Plain compile: catches any syntax errors in the f-string templating.
     compile(source, str(test_dest), "exec")
@@ -327,7 +327,7 @@ def test_add_arm_generated_test_runs_passes(workspace: Path, monkeypatch) -> Non
     avoid collisions) and run pytest against it.
     """
     # Generate into the real repo (so URDF_PATH resolves).
-    name = "addarm_runtest"
+    name = "addarm_runtest_ik"
     result = _run_cli(
         "add-arm",
         "--no-validate",
@@ -393,18 +393,18 @@ def test_add_arm_write_manifest_appends_stanza(workspace: Path) -> None:
         "--ee",
         "ee_link",
         "--name",
-        "ur5_wm_test",
+        "ur5_wm_test_ik",
         "--vendor",
         "universal_robots",
         "--repo-root",
         str(workspace),
     )
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "Appended [arms.ur5_wm_test]" in result.stdout
+    assert "Appended [arms.ur5_wm_test_ik]" in result.stdout
     data = tomllib.loads(mf.read_text())
-    assert "ur5_wm_test" in data["arms"], "new stanza not written"
+    assert "ur5_wm_test_ik" in data["arms"], "new stanza not written"
     assert "existing_ik" in data["arms"], "existing entry clobbered"
-    assert data["arms"]["ur5_wm_test"]["dof"] == 6
+    assert data["arms"]["ur5_wm_test_ik"]["dof"] == 6
 
 
 def test_add_arm_write_manifest_refuses_duplicate(workspace: Path) -> None:
@@ -422,7 +422,7 @@ def test_add_arm_write_manifest_refuses_duplicate(workspace: Path) -> None:
         "--ee",
         "ee_link",
         "--name",
-        "ur5_dup_test",
+        "ur5_dup_test_ik",
         "--vendor",
         "universal_robots",
         "--repo-root",
@@ -436,7 +436,7 @@ def test_add_arm_write_manifest_refuses_duplicate(workspace: Path) -> None:
     assert second.returncode == 0
     text = mf.read_text()
     # Exactly one header table (with closing bracket; the .bench sub-table has a dot).
-    assert text.count("[arms.ur5_dup_test]") == 1, "force re-add duplicated the entry"
+    assert text.count("[arms.ur5_dup_test_ik]") == 1, "force re-add duplicated the entry"
     tomllib.loads(text)  # still valid TOML (raises on duplicate keys)
     # And without --force on an existing manifest entry, it errors.
     third = _run_cli(*args)


### PR DESCRIPTION
Every shipped arm's manifest key + artifact basename ends in `_ik` (the roster test globs `*/*_ik.py`), but `ssik add-arm --name viperx300s` (no suffix) silently produced `viperx300s.py` + manifest key `viperx300s`, which then fail the manifest/roster tests — this cost a redo while onboarding ViperX (#473). The `--name` help even suggested examples *without* `_ik`.

## Fix
- Append `_ik` when `--name` lacks it, printing `Using arm name '<name>_ik' (applied the '_ik' convention)`.
- A name already ending in `_ik` is left unchanged (no `_ik_ik`).
- Correct the `--name` help examples to `gen3_ik` / `rizon4_ik` / `viperx300s_ik` and note the convention.

## Tests
`test_add_arm_appends_ik_suffix` (bare name → suffixed fixture/test/manifest key, bare-named files absent) + `test_add_arm_keeps_existing_ik_suffix` (no double suffix). ruff + mypy clean.

Fixes #474.