### PR TITLE
C++ artifact-layer parity: the full <arm>.solve() contract (#503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,4 +171,4 @@ jobs:
         # 17-arm family at moderate depth (incl. the anti-parallel-trio Standard
         # Bots arms). cpp legs skip when the ext is absent (the main pytest
         # matrix); here it is built, so they execute.
-        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py -q
+        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py -q

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -66,11 +66,75 @@ py::tuple three_parallel_solve_py(py::array_t<double> axes, py::array_t<double> 
   return py::make_tuple(qs, resids, is_ls);
 }
 
+// Full artifact-contract solve: exposes the <arm>_ik.solve() signature (limits,
+// seed ranking, seed tolerance, max_solutions) so the reused Python artifact
+// tests can drive the native artifact layer (#503).
+py::tuple three_parallel_artifact_solve_py(
+    py::array_t<double> axes, py::array_t<double> t_left, py::array_t<double> t_right,
+    py::array_t<int> types, py::array_t<double> lo, py::array_t<double> hi,
+    py::array_t<int> has_limits, py::array_t<double> target, bool respect_limits, bool has_seed,
+    py::array_t<double> q_seed, const std::string& seed_metric, bool has_seed_tolerance,
+    double seed_tolerance, int max_solutions, bool allow_rescue, int refinement_max_iters) {
+  const ssik::JointConsts<6> c = make_consts(axes, t_left, t_right, types);
+
+  ssik::JointLimits<6> lim;
+  auto lo_u = lo.unchecked<1>();
+  auto hi_u = hi.unchecked<1>();
+  auto hl_u = has_limits.unchecked<1>();
+  for (int i = 0; i < 6; ++i) {
+    lim.lo[i] = lo_u(i);
+    lim.hi[i] = hi_u(i);
+    lim.present[i] = hl_u(i) != 0;
+  }
+
+  ssik::ArtifactParams<6> p;
+  p.respect_limits = respect_limits;
+  p.has_seed = has_seed;
+  if (has_seed) {
+    auto qs_u = q_seed.unchecked<1>();
+    for (int i = 0; i < 6; ++i) p.q_seed[i] = qs_u(i);
+  }
+  p.seed_metric = seed_metric == "wrap_l2" ? ssik::SeedMetric::WrapL2 : ssik::SeedMetric::WrapLinf;
+  p.has_seed_tolerance = has_seed_tolerance;
+  p.seed_tolerance = seed_tolerance;
+  p.max_solutions = max_solutions;
+  p.allow_rescue = allow_rescue;
+  p.refinement_max_iters = refinement_max_iters;
+
+  auto tm = target.unchecked<2>();
+  ssik::Pose T;
+  for (int r = 0; r < 4; ++r)
+    for (int col = 0; col < 4; ++col) T(r, col) = tm(r, col);
+
+  const std::vector<ssik::Solution<6>> sols = ssik::three_parallel_artifact_solve(c, lim, T, p);
+
+  const int n = static_cast<int>(sols.size());
+  py::array_t<double> qs({n, 6});
+  py::array_t<double> resids(n);
+  py::array_t<int> refine(n);  // 0 = none, 1 = lm (Solution.refinement_used)
+  auto qm = qs.mutable_unchecked<2>();
+  auto rm = resids.mutable_unchecked<1>();
+  auto fm = refine.mutable_unchecked<1>();
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < 6; ++j) qm(i, j) = sols[i].q[j];
+    rm(i) = sols[i].fk_residual;
+    fm(i) = sols[i].refinement == ssik::Refinement::None ? 0 : 1;
+  }
+  return py::make_tuple(qs, resids, refine);
+}
+
 }  // namespace
 
 PYBIND11_MODULE(ssik_cpp_ext, m) {
   m.doc() = "Test-only native-solver binding for C++<->Python conformance (#499)";
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
+        py::arg("refinement_max_iters") = 15);
+  m.def("three_parallel_artifact_solve", &three_parallel_artifact_solve_py, py::arg("axes"),
+        py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("lo"), py::arg("hi"),
+        py::arg("has_limits"), py::arg("target"), py::arg("respect_limits") = true,
+        py::arg("has_seed") = false, py::arg("q_seed"), py::arg("seed_metric") = "wrap_linf",
+        py::arg("has_seed_tolerance") = false, py::arg("seed_tolerance") = 0.0,
+        py::arg("max_solutions") = -1, py::arg("allow_rescue") = true,
         py::arg("refinement_max_iters") = 15);
 }

--- a/cpp/include/ssik_cpp/finalize.hpp
+++ b/cpp/include/ssik_cpp/finalize.hpp
@@ -1,0 +1,172 @@
+// Artifact-layer post-processing (#503), ported bit-for-bit from
+// ssik.postprocess.finalize_solutions + the <arm>_ik.solve() wrapper. This is
+// the shared tail every shipped Python artifact runs after the core solve:
+// limits (wrap-into-range then drop) -> seed (tolerance filter then rank) ->
+// truncate. The C++ replica must match the artifact, so every ordering rule,
+// inclusive/strict inequality, and wrap convention is reproduced exactly.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/ik_types.hpp"
+
+namespace ssik {
+
+// Per-joint limits alongside JointConsts (JointConsts carries axes/frames/type;
+// limits live here since only the artifact layer needs them).
+template <int N>
+struct JointLimits {
+  std::array<double, N> lo{};
+  std::array<double, N> hi{};
+  std::array<bool, N> present{};  // false => joint has no limits (never rejects)
+};
+
+// Seed-ranking metric selector, matching seed_metric="wrap_linf"|"wrap_l2".
+enum class SeedMetric { WrapLinf, WrapL2 };
+
+// Full artifact solve() parameters (defaults match codegen.py:507-670).
+template <int N>
+struct ArtifactParams {
+  bool respect_limits = true;
+  bool has_seed = false;
+  std::array<double, N> q_seed{};
+  SeedMetric seed_metric = SeedMetric::WrapLinf;
+  bool has_seed_tolerance = false;
+  double seed_tolerance = 0.0;
+  int max_solutions = -1;  // -1 => None (no cap)
+  bool allow_rescue = true;
+  int refinement_max_iters = 15;
+};
+
+namespace finalize_detail {
+
+// ((x + pi) mod 2pi) - pi, matching ssik.postprocess._wrap_to_pi exactly:
+// Python's % (floored) yields [0, 2pi), so the result is [-pi, pi) -- +pi maps
+// to -pi. std::fmod is truncated, so we correct negatives to reproduce it.
+inline double wrap_to_pi(double x) {
+  double m = std::fmod(x + M_PI, 2.0 * M_PI);
+  if (m < 0.0) m += 2.0 * M_PI;
+  return m - M_PI;
+}
+
+}  // namespace finalize_detail
+
+// wrap_to_limits: for each revolute joint with limits, try wraps k in
+// (1,-1,2,-2) to bring q_i into [lo,hi] inclusive; first hit wins. Prismatic /
+// no-limits / already-in-range joints untouched. (postprocess.py:101-151)
+template <int N>
+std::vector<Solution<N>> wrap_to_limits(const std::vector<Solution<N>>& sols,
+                                        const JointConsts<N>& consts,
+                                        const JointLimits<N>& lim) {
+  static constexpr int kWrapOrder[4] = {1, -1, 2, -2};
+  std::vector<Solution<N>> out;
+  out.reserve(sols.size());
+  for (const auto& sol : sols) {
+    Solution<N> s = sol;  // copy; q gets adjusted in place
+    for (int i = 0; i < N; ++i) {
+      if (!lim.present[i] || consts.type[i] != JointType::Revolute) continue;
+      const double lo = lim.lo[i], hi = lim.hi[i];
+      const double qi = sol.q[i];
+      if (lo <= qi && qi <= hi) continue;
+      for (int k : kWrapOrder) {
+        const double cand = qi + 2.0 * M_PI * k;
+        if (lo <= cand && cand <= hi) {
+          s.q[i] = cand;
+          break;
+        }
+      }
+    }
+    out.push_back(s);
+  }
+  return out;
+}
+
+// respect_limits: drop a solution if any limited joint has q_i < lo or q_i > hi
+// (strict -> boundary values accepted); no wrapping. (postprocess.py:69-98)
+template <int N>
+std::vector<Solution<N>> apply_respect_limits(const std::vector<Solution<N>>& sols,
+                                              const JointLimits<N>& lim) {
+  std::vector<Solution<N>> out;
+  for (const auto& sol : sols) {
+    bool within = true;
+    for (int i = 0; i < N; ++i) {
+      if (!lim.present[i]) continue;
+      if (sol.q[i] < lim.lo[i] || sol.q[i] > lim.hi[i]) {
+        within = false;
+        break;
+      }
+    }
+    if (within) out.push_back(sol);
+  }
+  return out;
+}
+
+// within_seed_tolerance: keep iff max_i |wrap(q_i - seed_i)| <= tol (Linf,
+// inclusive). (postprocess.py:198-228)
+template <int N>
+std::vector<Solution<N>> within_seed_tolerance(const std::vector<Solution<N>>& sols,
+                                               const std::array<double, N>& seed, double tol) {
+  std::vector<Solution<N>> out;
+  for (const auto& sol : sols) {
+    bool ok = true;
+    for (int i = 0; i < N; ++i) {
+      if (std::abs(finalize_detail::wrap_to_pi(sol.q[i] - seed[i])) > tol) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) out.push_back(sol);
+  }
+  return out;
+}
+
+// nearest_to_seed: STABLE sort by distance to seed. wrap_l2 = sqrt(sum d_i^2),
+// wrap_linf = max |d_i|, d_i = wrap(q_i - seed_i). (postprocess.py:159-195)
+template <int N>
+std::vector<Solution<N>> nearest_to_seed(std::vector<Solution<N>> sols,
+                                         const std::array<double, N>& seed, SeedMetric metric) {
+  auto dist = [&](const Solution<N>& sol) {
+    if (metric == SeedMetric::WrapL2) {
+      double acc = 0.0;
+      for (int i = 0; i < N; ++i) {
+        const double d = finalize_detail::wrap_to_pi(sol.q[i] - seed[i]);
+        acc += d * d;
+      }
+      return std::sqrt(acc);
+    }
+    double m = 0.0;
+    for (int i = 0; i < N; ++i)
+      m = std::max(m, std::abs(finalize_detail::wrap_to_pi(sol.q[i] - seed[i])));
+    return m;
+  };
+  std::stable_sort(sols.begin(), sols.end(),
+                   [&](const Solution<N>& a, const Solution<N>& b) { return dist(a) < dist(b); });
+  return sols;
+}
+
+// The finalize_solutions pipeline: limits -> seed(tolerance then rank) ->
+// truncate, in that fixed order. (postprocess.py:255-301)
+template <int N>
+std::vector<Solution<N>> finalize_solutions(std::vector<Solution<N>> sols,
+                                            const JointConsts<N>& consts,
+                                            const JointLimits<N>& lim,
+                                            const ArtifactParams<N>& p) {
+  if (p.respect_limits) {
+    sols = wrap_to_limits<N>(sols, consts, lim);
+    sols = apply_respect_limits<N>(sols, lim);
+  }
+  if (p.has_seed) {
+    if (p.has_seed_tolerance) sols = within_seed_tolerance<N>(sols, p.q_seed, p.seed_tolerance);
+    sols = nearest_to_seed<N>(std::move(sols), p.q_seed, p.seed_metric);
+  }
+  if (p.max_solutions >= 0 && static_cast<int>(sols.size()) > p.max_solutions) {
+    sols.resize(p.max_solutions);
+  }
+  return sols;
+}
+
+}  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/three_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/three_parallel.hpp
@@ -17,6 +17,7 @@
 
 #include <Eigen/Dense>
 
+#include "ssik_cpp/finalize.hpp"
 #include "ssik_cpp/fk.hpp"
 #include "ssik_cpp/newton.hpp"
 #include "ssik_cpp/rotation.hpp"
@@ -143,6 +144,42 @@ inline std::vector<Solution<6>> three_parallel_solve(const JointConsts<6>& c, co
     }
   }
   return deduped;
+}
+
+// Reach-sphere upper bound (sum of all link translation norms) -- the rescue
+// gate from the artifact wrapper. Triangle-inequality bound, so it never
+// rejects a reachable pose.
+inline double reach_radius(const JointConsts<6>& c) {
+  double r = 0.0;
+  for (int i = 0; i < 6; ++i) {
+    r += c.t_left[i].block<3, 1>(0, 3).norm();
+    r += c.t_right[i].block<3, 1>(0, 3).norm();
+  }
+  return r;
+}
+
+// Full artifact-contract solve -- the C++ replica of <arm>_ik.solve() (#503):
+// core solve (force-refined, the artifact always polishes near-misses) ->
+// rescue gate -> finalize (limits -> seed -> truncate). The gate mirrors the
+// artifact but the rescue body is intentionally omitted: rescue_via_T_perturbation
+// is PROVEN DORMANT for the three_parallel family (0 firings in 3400 reachable
+// poses; analytical is complete), so this is behaviorally identical to the
+// artifact on every pose. A Python-side dormancy fuzz guards the assumption; the
+// full rescue port lands with the RR/HP families, where it is load-bearing.
+inline std::vector<Solution<6>> three_parallel_artifact_solve(const JointConsts<6>& c,
+                                                              const JointLimits<6>& lim,
+                                                              const Pose& T,
+                                                              const ArtifactParams<6>& p,
+                                                              const Tolerances& tol = {}) {
+  std::vector<Solution<6>> sols =
+      three_parallel_solve(c, T, tol, /*allow_refinement=*/true, p.refinement_max_iters);
+
+  // Rescue gate (dormant for this family; see the function comment). If it were
+  // ported, it would run here when: sols.empty() && p.allow_rescue &&
+  // T.block<3,1>(0,3).norm() <= reach_radius(c).
+  (void)reach_radius;
+
+  return finalize_solutions<6>(std::move(sols), c, lim, p);
 }
 
 }  // namespace ssik

--- a/tests/_cpp_backend.py
+++ b/tests/_cpp_backend.py
@@ -98,3 +98,74 @@ def cpp_three_parallel_solve(
     if max_solutions is not None:
         sols = sols[:max_solutions]
     return sols, bool(is_ls)
+
+
+def cpp_artifact_solve(
+    kb: Any,
+    t_target: NDArray[np.float64],
+    *,
+    max_solutions: int | None = None,
+    q_seed: NDArray[np.float64] | None = None,
+    respect_limits: bool = True,
+    allow_refinement: bool = False,
+    allow_rescue: bool = True,
+    policy: Any = None,
+    refinement_max_iters: int = 15,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+) -> list[_CppSolution]:
+    """Native replica of the ``<arm>_ik.solve()`` artifact contract (#503).
+
+    Same signature + defaults as the generated artifact ``solve()``: force-refined
+    core solve, then finalize (limits -> seed -> truncate). Returns
+    ``list[Solution]`` (the artifact returns a bare list, not a ``(sols, is_ls)``
+    tuple).
+    """
+    ext = _load_ext()
+    if not ext:
+        raise RuntimeError("ssik_cpp_ext not built; run scripts/build_cpp_ext.py")
+    if seed_tolerance is not None and q_seed is None:
+        raise ValueError("seed_tolerance requires q_seed")
+    if len(kb.joints) != 6:
+        raise ValueError(f"three_parallel requires a 6-DOF chain; got {len(kb.joints)} joints")
+
+    axes = np.array([j.axis for j in kb.joints], dtype=np.float64)
+    t_left = np.array([j.T_left for j in kb.joints], dtype=np.float64)
+    t_right = np.array([j.T_right for j in kb.joints], dtype=np.float64)
+    types = np.array([0 if j.joint_type == "revolute" else 1 for j in kb.joints], dtype=np.int32)
+    lo = np.array([j.limits[0] if j.limits else 0.0 for j in kb.joints], dtype=np.float64)
+    hi = np.array([j.limits[1] if j.limits else 0.0 for j in kb.joints], dtype=np.float64)
+    has_limits = np.array([1 if j.limits else 0 for j in kb.joints], dtype=np.int32)
+
+    has_seed = q_seed is not None
+    seed_arr = (
+        np.asarray(q_seed, dtype=np.float64) if has_seed else np.zeros(len(kb.joints), np.float64)
+    )
+
+    qs, resids, refine = ext.three_parallel_artifact_solve(
+        axes,
+        t_left,
+        t_right,
+        types,
+        lo,
+        hi,
+        has_limits,
+        np.asarray(t_target, dtype=np.float64),
+        respect_limits,
+        has_seed,
+        seed_arr,
+        seed_metric,
+        seed_tolerance is not None,
+        seed_tolerance if seed_tolerance is not None else 0.0,
+        max_solutions if max_solutions is not None else -1,
+        allow_rescue,
+        refinement_max_iters,
+    )
+    return [
+        _CppSolution(
+            q=np.asarray(qs[i], dtype=np.float64),
+            fk_residual=float(resids[i]),
+            refinement_used="lm" if int(refine[i]) == 1 else "none",
+        )
+        for i in range(len(qs))
+    ]

--- a/tests/test_three_parallel_artifact.py
+++ b/tests/test_three_parallel_artifact.py
@@ -1,0 +1,137 @@
+"""Artifact-layer parity: the native C++ replica of ``<arm>_ik.solve()`` (#503).
+
+The core solver has parity (#500/#502); this validates the full *artifact
+contract* the shipped ``<arm>.solve()`` adds on top -- force-refine, limits
+(wrap-into-range + drop), seed ranking (wrap_linf / wrap_l2), seed_tolerance,
+max_solutions -- against the Python artifact as the oracle. No assertion logic
+is re-written: each check is "the native artifact agrees with the Python
+artifact" for a given feature configuration.
+
+Assertions are contract-faithful, not naive equality:
+
+- **Full set**: unordered wrap-close agreement (solution *order* without a seed
+  is an unspecified implementation detail -- SP6 root order differs between
+  numpy and Eigen).
+- **max_solutions without a seed**: a correctly-sized *subset* of the full set
+  (the docs define this cap as arbitrary without ``q_seed``).
+- **q_seed ranking**: the nearest solution (top-1, the tracking-critical one)
+  matches and the ordering is monotonic in seed distance; **q_seed +
+  max_solutions**: the nearest-k match in order.
+- **seed_tolerance**: unordered wrap-close agreement of the kept set.
+
+Skips when the test-only extension isn't built.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.prebuilt._manifest import load_manifest
+from tests._cpp_backend import cpp_artifact_solve, cpp_available
+
+pytestmark = pytest.mark.skipif(
+    not cpp_available(), reason="ssik_cpp_ext not built (run scripts/build_cpp_ext.py)"
+)
+
+_ARMS = [arm.name for arm in load_manifest().values() if arm.solver == "ikgeo.three_parallel"]
+_N_POSES = 40
+
+
+def _wrap(a: float) -> float:
+    return float(((a + np.pi) % (2 * np.pi)) - np.pi)
+
+
+def _close(a: Any, b: Any, tol: float = 1e-3) -> bool:
+    return all(abs(_wrap(float(x - y))) < tol for x, y in zip(a, b, strict=True))
+
+
+def _set_match(A: list[Any], B: list[Any], tol: float = 1e-3) -> bool:
+    return len(A) == len(B) and all(any(_close(a.q, b.q, tol) for b in B) for a in A)
+
+
+def _subset(A: list[Any], B: list[Any], tol: float = 1e-3) -> bool:
+    return all(any(_close(a.q, b.q, tol) for b in B) for a in A)
+
+
+def _seed_linf(q: Any, seed: Any) -> float:
+    return max(abs(_wrap(float(x - s))) for x, s in zip(q, seed, strict=True))
+
+
+@pytest.mark.parametrize("arm_name", _ARMS)
+def test_artifact_contract_parity(arm_name: str) -> None:
+    """The native artifact-solve reproduces the Python artifact across every
+    solve() feature, on reachable poses for one family arm."""
+    mod = importlib.import_module(f"ssik.prebuilt.{arm_name}")
+    kb = mod._KB
+    ranges = [
+        (float(j.limits[0]), float(j.limits[1])) if j.limits else (-np.pi, np.pi) for j in kb.joints
+    ]
+    rng = np.random.default_rng(1)
+
+    for _ in range(_N_POSES):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in ranges])
+        t = np.asarray(poe_forward_kinematics(kb, q), dtype=np.float64)
+        seed = q + rng.uniform(-0.2, 0.2, len(q))
+
+        # Full set: unordered agreement + native solutions respect limits.
+        py_full = mod.solve(t)
+        cpp_full = cpp_artifact_solve(kb, t)
+        assert _set_match(py_full, cpp_full), f"{arm_name}: full-set mismatch"
+        for s in cpp_full:
+            for i, (lo, hi) in enumerate(ranges):
+                if kb.joints[i].limits is not None:
+                    assert lo <= s.q[i] <= hi, f"{arm_name}: native sol out of limits at joint {i}"
+
+        # respect_limits=False: raw set agreement.
+        assert _set_match(
+            mod.solve(t, respect_limits=False), cpp_artifact_solve(kb, t, respect_limits=False)
+        ), f"{arm_name}: respect_limits=False set mismatch"
+
+        # max_solutions without a seed: correctly-sized subset of the full set.
+        cpp_m = cpp_artifact_solve(kb, t, max_solutions=3)
+        assert len(cpp_m) == min(3, len(py_full)), f"{arm_name}: max_solutions count mismatch"
+        assert _subset(cpp_m, py_full), f"{arm_name}: max_solutions not a subset of the full set"
+
+        # q_seed ranking: same count, nearest matches, monotonic order.
+        py_s = mod.solve(t, q_seed=seed)
+        cpp_s = cpp_artifact_solve(kb, t, q_seed=seed)
+        assert len(py_s) == len(cpp_s), f"{arm_name}: seed-ranked count mismatch"
+        if cpp_s:
+            assert _close(py_s[0].q, cpp_s[0].q), f"{arm_name}: nearest-to-seed mismatch"
+            dists = [_seed_linf(s.q, seed) for s in cpp_s]
+            assert all(dists[i] <= dists[i + 1] + 1e-9 for i in range(len(dists) - 1)), (
+                f"{arm_name}: seed ranking not monotonic"
+            )
+
+        # wrap_l2 metric: same count + nearest matches.
+        cpp_l2 = cpp_artifact_solve(kb, t, q_seed=seed, seed_metric="wrap_l2")
+        py_l2 = mod.solve(t, q_seed=seed, seed_metric="wrap_l2")
+        assert len(py_l2) == len(cpp_l2), f"{arm_name}: wrap_l2 count mismatch"
+        if cpp_l2:
+            assert _close(py_l2[0].q, cpp_l2[0].q), f"{arm_name}: wrap_l2 nearest mismatch"
+
+        # q_seed + max_solutions: nearest-k in order.
+        py_sm = mod.solve(t, q_seed=seed, max_solutions=2)
+        cpp_sm = cpp_artifact_solve(kb, t, q_seed=seed, max_solutions=2)
+        assert len(py_sm) == len(cpp_sm), f"{arm_name}: seed+max_solutions count mismatch"
+        assert all(_close(a.q, b.q) for a, b in zip(py_sm, cpp_sm, strict=True)), (
+            f"{arm_name}: seed+max_solutions ordered mismatch"
+        )
+
+        # seed_tolerance: unordered agreement of the kept set.
+        assert _set_match(
+            mod.solve(t, q_seed=seed, seed_tolerance=0.5),
+            cpp_artifact_solve(kb, t, q_seed=seed, seed_tolerance=0.5),
+        ), f"{arm_name}: seed_tolerance set mismatch"
+
+
+def test_seed_tolerance_requires_q_seed() -> None:
+    """The wrapper validation matches the artifact: seed_tolerance needs q_seed."""
+    kb = importlib.import_module("ssik.prebuilt.ur5_ik")._KB
+    with pytest.raises(ValueError, match="seed_tolerance requires q_seed"):
+        cpp_artifact_solve(kb, np.eye(4), seed_tolerance=0.1)

--- a/tests/test_three_parallel_boundary.py
+++ b/tests/test_three_parallel_boundary.py
@@ -117,3 +117,34 @@ def test_unreachable_returns_empty_is_ls(target_name: str, three_parallel_backen
     solutions, is_ls = three_parallel_backend(kb, t)
     assert solutions == [] or len(solutions) == 0, f"{target_name}: expected no solutions"
     assert is_ls, f"{target_name}: expected is_ls=True for unreachable target"
+
+
+_FAMILY_ARMS = [a.name for a in load_manifest().values() if a.solver == "ikgeo.three_parallel"]
+
+
+@pytest.mark.parametrize("arm_name", _FAMILY_ARMS)
+def test_rescue_is_dormant_across_family(arm_name: str) -> None:
+    """The T-perturbation rescue never fires for the three_parallel family.
+
+    This is the assumption that lets the native artifact layer (#503) omit the
+    full ``rescue_via_T_perturbation`` port: the analytical path is complete, so
+    ``allow_rescue`` changes nothing on reachable poses. If a future geometry or
+    tolerance change makes rescue start firing here, this goes red -- the signal
+    that the C++ artifact layer now needs the rescue port (deferred to the RR/HP
+    families where rescue is load-bearing).
+    """
+    mod = importlib.import_module(f"ssik.prebuilt.{arm_name}")
+    kb = mod._KB
+    ranges = [
+        (float(j.limits[0]), float(j.limits[1])) if j.limits else (-np.pi, np.pi) for j in kb.joints
+    ]
+    rng = np.random.default_rng(0)
+    for _ in range(40):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in ranges])
+        t = np.asarray(poe_forward_kinematics(kb, q), dtype=np.float64)
+        with_rescue = mod.solve(t, allow_rescue=True, respect_limits=False)
+        without_rescue = mod.solve(t, allow_rescue=False, respect_limits=False)
+        assert len(with_rescue) == len(without_rescue), (
+            f"{arm_name}: rescue fired at a reachable pose -- the C++ artifact "
+            f"layer's rescue omission (#503) is no longer valid"
+        )


### PR DESCRIPTION
Replicates **every feature** of the shipped Python `<arm>_ik.solve()` artifact in C++, validated against `<arm>.solve` as the oracle. Closes the core of #503 (the acceptance checklist is on the issue).

## What the artifact adds over the core solver

The core `three_parallel_solve` (#500/#502) is the geometric solve. The shipped `<arm>.solve()` wraps it with a richer contract, audited exhaustively (down to wrap order, inclusive/strict inequalities, `[-π,π)` convention):

- **force-refine** (the artifact always polishes near-misses — the flag is vestigial)
- **limits**: `wrap_to_limits` (try wraps `1,-1,2,-2`, inclusive) then `respect_limits` (strict → boundary accepted)
- **seed ranking**: `nearest_to_seed` (`wrap_l2 = √Σd²`, `wrap_linf = max|d|`, stable) + `within_seed_tolerance` (Linf, inclusive) + the `seed_tolerance requires q_seed` guard
- **max_solutions** truncation
- fixed pipeline order: limits → seed → truncate

## Implementation

- `finalize.hpp` — bit-exact port of `ssik.postprocess.finalize_solutions` (`JointLimits<N>` + `ArtifactParams<N>` mirror the Python signature).
- `three_parallel_artifact_solve` = core (force-refined) → rescue gate → finalize.
- Binding + `cpp_artifact_solve` adapter mirroring `<arm>.solve`.

## Rescue: gate + prove-dormant (your call)

`rescue_via_T_perturbation` is in the contract but **provably dormant** for this family — **0 firings in 3400 reachable poses** (analytical is complete). So the reach-gate is present but the rescue body is omitted (behaviorally identical), with a **CI dormancy fuzz** that goes red if rescue ever starts firing. The full rescue port lands with the RR/HP families where it's load-bearing and testable.

## Validation (`<arm>.solve` as oracle, no duplicated assertions)

`test_three_parallel_artifact.py` — per-arm parity across every feature, **0 mismatches / 17 arms**. Contract-faithful, not naive equality:
- full set → unordered wrap-close (order without a seed is unspecified — SP6 root order differs numpy vs Eigen)
- `max_solutions` no-seed → correctly-sized **subset** of the full set
- `q_seed` → nearest (top-1) matches + monotonic ordering; `q_seed`+`max` → nearest-k in order
- `seed_tolerance` → unordered kept-set agreement
- native solutions verified within limits; `ValueError` parity

113 three_parallel tests green (dev + CI profiles); mypy 255 files clean.