### PR TITLE
Ship the native C++ solver extension in the wheel (#506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,3 +172,43 @@ jobs:
         # Bots arms). cpp legs skip when the ext is absent (the main pytest
         # matrix); here it is built, so they execute.
         run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py -q
+
+  native_wheel:
+    # Ships the native extension in the wheel (#506). cibuildwheel runs only on
+    # release tags, so this validates the wheel build + native bundling on PRs:
+    # build a wheel on Linux + macOS, install it, and native-solve through the
+    # shipped ssik._ssik_native. Without this the native ship is unexercised
+    # until a release tag.
+    name: Native wheel build — ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs git history
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Eigen (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libeigen3-dev
+
+      - name: Install Eigen (macOS)
+        if: runner.os == 'macOS'
+        run: brew install eigen
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Install wheel + native smoke
+        run: |
+          uv venv .wheelenv
+          uv pip install --python .wheelenv/bin/python dist/*.whl numpy
+          .wheelenv/bin/python scripts/native_smoke.py

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -125,8 +125,12 @@ py::tuple three_parallel_artifact_solve_py(
 
 }  // namespace
 
-PYBIND11_MODULE(ssik_cpp_ext, m) {
-  m.doc() = "Test-only native-solver binding for C++<->Python conformance (#499)";
+// Module name `_ssik_native`: the same source is compiled both as the test-only
+// extension (built into cpp/build by scripts/build_cpp_ext.py) and as the
+// shipped `ssik._ssik_native` extension in the wheel (hatch_build.py, #506).
+// The pybind init symbol is keyed on the leaf name, so both import paths work.
+PYBIND11_MODULE(_ssik_native, m) {
+  m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -38,6 +38,41 @@ CYTHON_TARGETS: tuple[str, ...] = (
     # call sites switch to typed memoryviews or scalar arguments.
 )
 
+# Native C++ solver extension (#506): the opt-in native backend (#501). The same
+# pybind source that powers the test conformance binding is compiled into the
+# wheel as ``ssik._ssik_native``. Header-only Eigen + C++20; shipped on Linux +
+# macOS. Windows falls back to the Python path (native deferred), so the wheel
+# still builds there without it.
+# Top-level Extension name so build_ext --inplace drops the .so at the repo root
+# (predictable, unlike a dotted name which setuptools resolves against src/); the
+# force_include below then maps it to ssik/ in the wheel, imported as
+# ``ssik._ssik_native`` (the pybind init symbol is keyed on the leaf name).
+NATIVE_EXT_MODULE = "_ssik_native"
+NATIVE_EXT_SOURCE = "cpp/bindings/three_parallel_py.cpp"
+NATIVE_SUPPORTED_PLATFORMS = ("linux", "darwin")
+
+
+def _native_supported() -> bool:
+    return sys.platform in NATIVE_SUPPORTED_PLATFORMS
+
+
+def _eigen_include(root: Path) -> str | None:
+    """Locate the Eigen headers: EIGEN_INCLUDE_DIR (set by CIBW_BEFORE_ALL) or
+    the standard system paths for local builds. Header-only, so no link step."""
+    import os
+
+    env = os.environ.get("EIGEN_INCLUDE_DIR")
+    candidates = [env] if env else []
+    candidates += [
+        "/opt/homebrew/include/eigen3",
+        "/usr/local/include/eigen3",
+        "/usr/include/eigen3",
+    ]
+    for c in candidates:
+        if c and (Path(c) / "Eigen" / "Dense").exists():
+            return c
+    return None
+
 
 class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
     PLUGIN_NAME = "cython"
@@ -51,7 +86,7 @@ class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         # Lazy imports: Cython + setuptools are build-time dependencies declared
         # in [build-system].requires.
         from Cython.Build import cythonize
-        from setuptools import setup  # type: ignore[import-untyped]
+        from setuptools import Extension, setup  # type: ignore[import-untyped]
 
         root = Path(self.root)
 
@@ -73,6 +108,28 @@ class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                 compiler_directives={"language_level": "3"},
                 annotate=False,
             )
+            # Append the native C++ solver extension on supported platforms.
+            native_built = False
+            if _native_supported():
+                import pybind11
+
+                eigen = _eigen_include(root)
+                if eigen is None:
+                    raise RuntimeError(
+                        "Eigen headers not found (set EIGEN_INCLUDE_DIR); required to build "
+                        f"{NATIVE_EXT_MODULE} on this platform ({sys.platform})."
+                    )
+                ext_modules = [
+                    *ext_modules,
+                    Extension(
+                        NATIVE_EXT_MODULE,
+                        sources=[str(root / NATIVE_EXT_SOURCE)],
+                        include_dirs=[str(root / "cpp" / "include"), pybind11.get_include(), eigen],
+                        language="c++",
+                        extra_compile_args=["-std=c++20", "-O2"],
+                    ),
+                ]
+                native_built = True
             setup(
                 name="ssik-cython-ext",
                 ext_modules=ext_modules,
@@ -98,6 +155,19 @@ class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
             # build_data["force_include"] is {source_abs_path: dest_in_wheel}.
             rel_dest = str(so_path.relative_to(root / "src"))
             force_include[str(so_path)] = rel_dest
+
+        # Force-include the native C++ extension (#506). setuptools infers
+        # package_dir[""]="src" from the Cython packages, so build_ext --inplace
+        # drops the top-level _ssik_native module at src/; ship it as
+        # ssik/_ssik_native.<abi>.so.
+        if native_built:
+            native_so = root / "src" / f"_ssik_native{so_suffix}"
+            if not native_so.exists():
+                raise RuntimeError(
+                    f"CythonBuildHook: expected native extension at {native_so} after "
+                    f"build_ext --inplace; got nothing."
+                )
+            force_include[str(native_so)] = f"ssik/_ssik_native{so_suffix}"
 
         # Mark wheel as platform-specific so the .so files (which are arch +
         # python-version + OS specific) only get installed on matching hosts.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -108,28 +108,41 @@ class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                 compiler_directives={"language_level": "3"},
                 annotate=False,
             )
-            # Append the native C++ solver extension on supported platforms.
+            # Append the native C++ solver extension on supported platforms when
+            # Eigen is available. If Eigen is absent (a dev/editable install that
+            # doesn't need native -- the test harness uses cpp/build), skip it
+            # rather than failing the build. Shipped wheels are still guaranteed
+            # to carry native by the wheel smoke gate ([tool.cibuildwheel]
+            # test-command asserts ssik._ssik_native imports) + the native_wheel
+            # CI job -- so a native-less wheel can never be published silently.
             native_built = False
             if _native_supported():
-                import pybind11
-
                 eigen = _eigen_include(root)
                 if eigen is None:
-                    raise RuntimeError(
-                        "Eigen headers not found (set EIGEN_INCLUDE_DIR); required to build "
-                        f"{NATIVE_EXT_MODULE} on this platform ({sys.platform})."
+                    print(
+                        f"[hatch_build] Eigen not found (set EIGEN_INCLUDE_DIR); skipping "
+                        f"{NATIVE_EXT_MODULE}. Fine for a dev install; shipped wheels require it "
+                        f"(enforced by the wheel smoke gate).",
+                        file=sys.stderr,
                     )
-                ext_modules = [
-                    *ext_modules,
-                    Extension(
-                        NATIVE_EXT_MODULE,
-                        sources=[str(root / NATIVE_EXT_SOURCE)],
-                        include_dirs=[str(root / "cpp" / "include"), pybind11.get_include(), eigen],
-                        language="c++",
-                        extra_compile_args=["-std=c++20", "-O2"],
-                    ),
-                ]
-                native_built = True
+                else:
+                    import pybind11
+
+                    ext_modules = [
+                        *ext_modules,
+                        Extension(
+                            NATIVE_EXT_MODULE,
+                            sources=[str(root / NATIVE_EXT_SOURCE)],
+                            include_dirs=[
+                                str(root / "cpp" / "include"),
+                                pybind11.get_include(),
+                                eigen,
+                            ],
+                            language="c++",
+                            extra_compile_args=["-std=c++20", "-O2"],
+                        ),
+                    ]
+                    native_built = True
             setup(
                 name="ssik-cython-ext",
                 ext_modules=ext_modules,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,8 +190,13 @@ test-command = [
 ]
 
 [tool.cibuildwheel.linux]
-# manylinux_2_28 ships GCC 14; sufficient for Cython 3.x.
+# manylinux_2_28 ships GCC 14; sufficient for Cython 3.x + the C++20 native ext.
 manylinux-x86_64-image = "manylinux_2_28"
+# Provide Eigen for the native extension (#506). The manylinux container has no
+# eigen package, so fetch a pinned header-only release once per build and point
+# hatch_build at it via EIGEN_INCLUDE_DIR (env is passed through to the build).
+before-all = "curl -sSL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz | tar xz -C /opt"
+environment = { EIGEN_INCLUDE_DIR = "/opt/eigen-3.4.0" }
 
 [tool.cibuildwheel.macos]
 # Build both arm64 (native) and x86_64 (cross-compiled) on the macos-latest
@@ -202,6 +207,10 @@ manylinux-x86_64-image = "manylinux_2_28"
 # same flags, just hosted on a different CPU). Test-skip above prevents
 # cibuildwheel from trying to RUN the x86_64 wheel on arm64.
 archs = ["arm64", "x86_64"]
+# Eigen for the native ext (#506); brew lands headers where hatch_build looks
+# (/opt/homebrew or /usr/local include/eigen3). Header-only, so the arm64 host
+# building the x86_64 cross-wheel still just needs the include path.
+before-all = "brew install eigen"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27", "hatch-vcs>=0.4", "cython>=3.1", "setuptools>=70"]
+requires = ["hatchling>=1.27", "hatch-vcs>=0.4", "cython>=3.1", "setuptools>=70", "pybind11>=2.12"]
 build-backend = "hatchling.build"
 
 [project]
@@ -178,6 +178,9 @@ test-command = [
     #    compiled .so, not the .py source. (Keep this list in sync with
     #    CYTHON_TARGETS; tests/test_perf_extensions.py fails if it drifts.)
     'python -c "import ssik.refinement, ssik.kinematics.poe_fk as _p; assert ssik.refinement.__file__.endswith((\".so\", \".pyd\")), \"ssik.refinement not compiled in wheel\"; assert _p.__file__.endswith((\".so\", \".pyd\")), \"ssik.kinematics.poe_fk not compiled in wheel\""',
+    # Native solver extension (#506) is bundled on Linux + macOS; Windows ships
+    # without it (Python fallback). Assert it imports where it should.
+    'python -c "import sys; sys.platform == \"win32\" or __import__(\"ssik._ssik_native\")"',
     'python -c "from ssik.prebuilt import iiwa14_ik; import numpy as np; q = np.array([0.3, 0.4, -0.5, 0.6, 0.2, -0.3, 0.4]); T = iiwa14_ik.fk(q); sols = iiwa14_ik.solve(T); assert sols and max(s.fk_residual for s in sols) < 1e-9, \"iiwa14_ik smoke failed\""',
     'python -c "from ssik.prebuilt import franka_panda_ik; import numpy as np; T = franka_panda_ik.fk(np.array([0.2, 0.3, -0.4, -1.2, 0.3, 1.4, 0.5])); sols = franka_panda_ik.solve(T); assert sols, \"franka_panda_ik returned no IK\""',
     # Vendor subpackages are in the wheel + the catalog works + the hierarchical

--- a/scripts/build_cpp_ext.py
+++ b/scripts/build_cpp_ext.py
@@ -2,7 +2,7 @@
 """Build the test-only native-solver Python extension (#499).
 
 Compiles ``cpp/bindings/three_parallel_py.cpp`` (which includes the header-only
-native solver) into ``ssik_cpp_ext`` so the existing Python test suite can drive
+native solver) into ``_ssik_native`` so the existing Python test suite can drive
 the C++ backend. This is NOT part of the shipped wheel -- it is a dev/CI test
 tool. The Python test suite skips the C++ backend when the extension is absent.
 
@@ -40,7 +40,7 @@ def _eigen_include() -> str:
 def build(out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
-    out = out_dir / f"ssik_cpp_ext{ext_suffix}"
+    out = out_dir / f"_ssik_native{ext_suffix}"
     src = _REPO / "cpp" / "bindings" / "three_parallel_py.cpp"
 
     cmd = [

--- a/scripts/native_smoke.py
+++ b/scripts/native_smoke.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Smoke-test the shipped native extension (#506).
+
+Imports ``ssik._ssik_native`` and runs one three_parallel solve through it,
+asserting the result matches the Python artifact. Used by the PR-CI wheel job
+and runnable against an installed wheel. Exits 0 on success, non-zero on any
+failure. On platforms where native isn't shipped (Windows, first cut) the
+extension is absent and this script reports that and exits 0 -- the Python
+fallback is the expected behaviour there.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+
+def main() -> int:
+    try:
+        from ssik import _ssik_native
+    except ImportError:
+        if sys.platform == "win32":
+            print("[native_smoke] native not shipped on Windows (Python fallback) -- OK")
+            return 0
+        print(f"[native_smoke] FAIL: ssik._ssik_native missing on {sys.platform}", file=sys.stderr)
+        return 1
+
+    from ssik.prebuilt import ur5_ik
+
+    kb = ur5_ik._KB
+    axes = np.array([j.axis for j in kb.joints], dtype=np.float64)
+    t_left = np.array([j.T_left for j in kb.joints], dtype=np.float64)
+    t_right = np.array([j.T_right for j in kb.joints], dtype=np.float64)
+    types = np.array([0 for _ in kb.joints], dtype=np.int32)
+    lo = np.array([j.limits[0] for j in kb.joints], dtype=np.float64)
+    hi = np.array([j.limits[1] for j in kb.joints], dtype=np.float64)
+    has_limits = np.array([1 for _ in kb.joints], dtype=np.int32)
+
+    q = np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2])
+    t_target = np.asarray(ur5_ik.fk(q), dtype=np.float64)
+
+    qs, resids, _refine = _ssik_native.three_parallel_artifact_solve(
+        axes,
+        t_left,
+        t_right,
+        types,
+        lo,
+        hi,
+        has_limits,
+        t_target,
+        True,
+        False,
+        np.zeros(6),
+        "wrap_linf",
+        False,
+        0.0,
+        -1,
+        True,
+        15,
+    )
+    py = ur5_ik.solve(t_target)
+
+    if len(qs) != len(py):
+        print(f"[native_smoke] FAIL: native returned {len(qs)}, Python {len(py)}", file=sys.stderr)
+        return 1
+    worst = float(max(resids)) if len(resids) else 0.0
+    if worst >= 1e-9:
+        print(f"[native_smoke] FAIL: worst native FK residual {worst:.2e}", file=sys.stderr)
+        return 1
+    print(f"[native_smoke] OK: {len(qs)} solutions, worst FK residual {worst:.2e}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/_cpp_backend.py
+++ b/tests/_cpp_backend.py
@@ -1,10 +1,10 @@
 """Adapter exposing the native C++ solver as a ``three_parallel.solve`` drop-in.
 
 Lets the existing Python test suite validate the C++ backend without re-writing
-any assertions (#499): the same tests run against ``{python, cpp}``. The C++
-extension (``ssik_cpp_ext``, built by ``scripts/build_cpp_ext.py`` into
-``cpp/build``) is test-only -- never shipped, never a runtime dependency. Tests
-skip the C++ backend when it isn't built.
+any assertions (#499): the same tests run against ``{python, cpp}``. Prefers the
+shipped ``ssik._ssik_native`` extension (#506) when installed, else falls back to
+the test-only build (``scripts/build_cpp_ext.py`` into ``cpp/build``). Tests skip
+the C++ backend when neither is available.
 """
 
 from __future__ import annotations
@@ -27,12 +27,22 @@ def _load_ext() -> Any:
     global _ext
     if _ext is not None:
         return _ext
+    # Prefer the shipped extension (ssik._ssik_native, #506) so tests exercise
+    # the wheel's native path when installed; fall back to the test-only build
+    # under cpp/build produced by scripts/build_cpp_ext.py.
+    try:
+        from ssik import _ssik_native  # type: ignore[attr-defined]
+
+        _ext = _ssik_native
+        return _ext
+    except ImportError:
+        pass
     if str(_BUILD) not in sys.path:
         sys.path.insert(0, str(_BUILD))
     try:
-        import ssik_cpp_ext  # type: ignore[import-not-found]
+        import _ssik_native  # type: ignore[import-not-found]
 
-        _ext = ssik_cpp_ext
+        _ext = _ssik_native
     except ImportError:
         _ext = False
     return _ext
@@ -69,7 +79,7 @@ def cpp_three_parallel_solve(
     """
     ext = _load_ext()
     if not ext:
-        raise RuntimeError("ssik_cpp_ext not built; run scripts/build_cpp_ext.py")
+        raise RuntimeError("_ssik_native not built; run scripts/build_cpp_ext.py")
     if len(kb.joints) != 6:
         raise ValueError(f"three_parallel requires a 6-DOF chain; got {len(kb.joints)} joints")
 
@@ -123,7 +133,7 @@ def cpp_artifact_solve(
     """
     ext = _load_ext()
     if not ext:
-        raise RuntimeError("ssik_cpp_ext not built; run scripts/build_cpp_ext.py")
+        raise RuntimeError("_ssik_native not built; run scripts/build_cpp_ext.py")
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
     if len(kb.joints) != 6:


### PR DESCRIPTION
Closes #506. First half of the opt-in native backend (#501) -- productionizes the previously test-only pybind extension into the shipped wheel so `native=True` (PR2, #507) has something to dispatch to.

## What

- **Rename** `ssik_cpp_ext` -> `_ssik_native` (leaf name works both as the test build and shipped `ssik._ssik_native`). The test harness now prefers the shipped ext, falling back to `cpp/build`.
- **`hatch_build.py`** builds `_ssik_native` from the same pybind source (C++20 + `cpp/include` + pybind11 + Eigen) alongside the Cython targets and force-includes it. **Linux + macOS ship it; Windows skips it** (wheel still builds → Python fallback). Eigen via `EIGEN_INCLUDE_DIR` (`CIBW_BEFORE_ALL`) or standard paths; header-only.
- **pyproject**: pybind11 in `[build-system].requires`; wheel smoke `test-command` asserts native imports on non-Windows.
- **`native_wheel` CI job (Linux + macOS)**: build wheel → install → native-solve via `scripts/native_smoke.py`. cibuildwheel runs only on release tags, so **this is what exercises the native ship on PRs**.

## Verified locally (macOS arm64)

- Wheel bundles `ssik/_ssik_native.cpython-*.so`.
- Clean-install import + native solve: **8 solutions, worst FK 2.7e-15**, matches Python.
- Cython extensions still compiled in the wheel (existing gate intact).
- 75 three_parallel tests green; ruff + mypy clean.

## Scope / deferred

- **Windows native** and **RR/HP-family native** are deferred. This PR is the *family-agnostic* ship + fallback machinery they plug into.
- `native=True` dispatch + silent fallback + docs are **PR2 (#507)**.

## CI note

The `native_wheel` job validates the Linux + macOS wheel build (the risky cross-platform bit) on this PR. The full cibuildwheel matrix (incl. manylinux + Windows-fallback + macOS x86 cross) still runs at release; `CIBW_BEFORE_ALL` will fetch a pinned Eigen there (follow-up in the release config if the runner images don't already provide it).