### PR TITLE
Wire native=True opt-in dispatch for the three_parallel family (#507)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,19 +159,21 @@ jobs:
       - name: ctest (FK + Newton golden conformance)
         run: ctest --test-dir cpp/build --output-on-failure
 
-      - name: Build native test extension (pybind11)
-        # Compiles the C++ solver into a Python module so the reused suite below
-        # drives the native backend directly (#499). Test-only, never shipped.
-        run: uv run python scripts/build_cpp_ext.py
+      - name: Build native extension into the package (pybind11)
+        # Compiles the C++ solver as ssik._ssik_native (the shipped import path,
+        # #506/#507) so the reused suite drives the native backend AND the
+        # artifact solve(native=True) dispatch resolves it. cpp/build isn't used;
+        # src/ssik/_ssik_native.so is what `from ssik import _ssik_native` finds.
+        run: uv run python scripts/build_cpp_ext.py --out-dir src/ssik
 
       - name: Reused Python suite vs the C++ backend
-        # The SAME Python tests run against the native solver via the binding --
-        # no assertion logic duplicated in C++. test_three_parallel: deep 500-pose
-        # fuzz + singular + #56 on UR5. test_three_parallel_family: the whole
-        # 17-arm family at moderate depth (incl. the anti-parallel-trio Standard
-        # Bots arms). cpp legs skip when the ext is absent (the main pytest
-        # matrix); here it is built, so they execute.
-        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py -q
+        # The SAME Python tests run against the native solver -- no assertion
+        # logic duplicated in C++. test_three_parallel: deep 500-pose fuzz +
+        # singular + #56 on UR5. test_three_parallel_family: the 17-arm family.
+        # test_native_dispatch: solve(native=True) parity + fallback (#507). cpp
+        # legs / native tests skip when the ext is absent (the main matrix); here
+        # it is built, so they execute.
+        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py tests/test_native_dispatch.py -q
 
   native_wheel:
     # Ships the native extension in the wheel (#506). cibuildwheel runs only on

--- a/README.md
+++ b/README.md
@@ -599,6 +599,19 @@ sols = take_first(sols, k=4)                                 # top-k after ranki
 
 By default `solve()` already runs `wrap_to_limits` + `respect_limits` (and, when `q_seed`/`seed_tolerance`/`seed_metric` are passed, the seed filter + ranking); the standalone helpers exist for callers who want a different order, a different metric, or to add their own filters (collision-aware filtering, dexterity scoring) between the layers.
 
+### Native (C++) backend: `solve(native=True)`
+
+For the three-parallel 6R family (the UR sizes, CR5, Nova5, Z1, Standard Bots core/spark/thor), `solve()` accepts an opt-in `native=True` that runs a bundled C++ implementation of the full `solve()` contract — roughly **50× faster** on these arms:
+
+```python
+sols = ur5_ik.solve(T_target, native=True)                   # same API, native speed
+sols = ur5_ik.solve(T_target, native=True, q_seed=q_current, max_solutions=1)
+```
+
+- **Same answers.** It reproduces the Python result's solution *set*. The *order* (without a seed) and the near-singular *representative* may differ (numpy vs Eigen); with a seed the nearest solution is stable.
+- **Silent fallback.** `native=True` is a hint: where the native extension isn't bundled (Windows wheels, source installs) or the arm's solver isn't native-capable, it transparently uses the Python path — it never fails for unavailability.
+- **Opt-in only.** The default (`native=False`) is unchanged. The native artifact is validated against the Python `solve()` as the oracle across the whole family and every option (limits / seed / max / tolerance).
+
 Out of scope: collision filtering (use FCL or similar at the application layer) and continuous-trajectory smoothness (typically a separate planner concern).
 
 ## How it compares

--- a/src/ssik/_native.py
+++ b/src/ssik/_native.py
@@ -1,0 +1,131 @@
+"""Opt-in native (C++) solver dispatch for the artifact ``solve()`` (#507).
+
+Best-effort: :func:`try_native_solve` returns a ``list[Solution]`` when the
+shipped native extension (``ssik._ssik_native``, #506) can handle the arm's
+solver family, else ``None`` so the caller silently falls back to the Python
+path. Native is available only where the wheel bundled the extension (Linux +
+macOS) and only for solver families with a native implementation
+(``ikgeo.three_parallel`` today).
+
+The generated artifacts call this from ``solve(..., native=True)``; passing
+``native=True`` never fails for unavailability -- it is a performance hint.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ssik.core.solution import Solution
+
+# Solver families with a native implementation in _ssik_native.
+_NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel"})
+
+_ext: Any = None
+_ext_tried = False
+
+
+def _load_ext() -> Any:
+    global _ext, _ext_tried
+    if _ext_tried:
+        return _ext
+    _ext_tried = True
+    try:
+        from ssik import _ssik_native  # type: ignore[attr-defined]
+
+        _ext = _ssik_native
+    except ImportError:
+        _ext = None
+    return _ext
+
+
+def native_available() -> bool:
+    """True when the native extension is importable (shipped for this platform)."""
+    return _load_ext() is not None
+
+
+# Marshalled per-KinBody constants, cached: each artifact has one long-lived _KB,
+# so keying on id(kb) is stable and avoids re-marshalling on every solve (which
+# would erode the native speedup).
+_consts_cache: dict[int, tuple[Any, ...]] = {}
+
+
+def _consts(kb: Any) -> tuple[Any, ...]:
+    cached = _consts_cache.get(id(kb))
+    if cached is not None:
+        return cached
+    joints = kb.joints
+    marshalled = (
+        np.array([j.axis for j in joints], dtype=np.float64),
+        np.array([j.T_left for j in joints], dtype=np.float64),
+        np.array([j.T_right for j in joints], dtype=np.float64),
+        np.array([0 if j.joint_type == "revolute" else 1 for j in joints], dtype=np.int32),
+        np.array([j.limits[0] if j.limits else 0.0 for j in joints], dtype=np.float64),
+        np.array([j.limits[1] if j.limits else 0.0 for j in joints], dtype=np.float64),
+        np.array([1 if j.limits else 0 for j in joints], dtype=np.int32),
+    )
+    _consts_cache[id(kb)] = marshalled
+    return marshalled
+
+
+def try_native_solve(
+    solver_name: str,
+    kb: Any,
+    t_target: NDArray[np.float64],
+    *,
+    respect_limits: bool = True,
+    q_seed: NDArray[np.float64] | None = None,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+    max_solutions: int | None = None,
+    allow_rescue: bool = True,
+    refinement_max_iters: int = 15,
+) -> list[Solution] | None:
+    """Native artifact solve for a supported family, or ``None`` to fall back.
+
+    Mirrors the ``<arm>_ik.solve()`` contract (limits -> seed -> truncate, force
+    refinement); parity with the Python artifact is validated in
+    ``tests/test_native_dispatch.py`` + ``tests/test_three_parallel_artifact.py``.
+    """
+    if solver_name not in _NATIVE_SOLVERS:
+        return None
+    ext = _load_ext()
+    if ext is None:
+        return None
+    if len(kb.joints) != 6:
+        return None
+
+    axes, t_left, t_right, types, lo, hi, has_limits = _consts(kb)
+    has_seed = q_seed is not None
+    seed_arr = (
+        np.asarray(q_seed, dtype=np.float64) if has_seed else np.zeros(len(kb.joints), np.float64)
+    )
+    qs, resids, refine = ext.three_parallel_artifact_solve(
+        axes,
+        t_left,
+        t_right,
+        types,
+        lo,
+        hi,
+        has_limits,
+        np.asarray(t_target, dtype=np.float64),
+        respect_limits,
+        has_seed,
+        seed_arr,
+        seed_metric,
+        seed_tolerance is not None,
+        seed_tolerance if seed_tolerance is not None else 0.0,
+        max_solutions if max_solutions is not None else -1,
+        allow_rescue,
+        refinement_max_iters,
+    )
+    return [
+        Solution(
+            q=np.asarray(qs[i], dtype=np.float64),
+            fk_residual=float(resids[i]),
+            refinement_used="lm" if int(refine[i]) == 1 else "none",
+        )
+        for i in range(len(qs))
+    ]

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -241,6 +241,11 @@ def _render_specialised(
         "rescue_via_T_perturbation as _rescue_via_T_perturbation\n"
     )
     buf.write("from ssik.postprocess import finalize_solutions as _ps_finalize\n")
+    # Opt-in native (C++) dispatch (#507), emitted only for families with a
+    # native implementation: solve(..., native=True) tries ssik._ssik_native and
+    # silently falls back to the Python path below when it is unavailable.
+    if plan.solver_name == "ikgeo.three_parallel":
+        buf.write("from ssik._native import try_native_solve as _try_native_solve\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -269,6 +274,7 @@ def _render_specialised(
             _render_specialised_solve_orchestrator(
                 _spec.fk_atol_expr,
                 force_refine=_spec.force_refine,
+                emit_native=plan.solver_name == "ikgeo.three_parallel",
             )
         )
     buf.write(_render_fk_alias())
@@ -276,9 +282,42 @@ def _render_specialised(
     return buf.getvalue()
 
 
+# Injected into the 6R orchestrator's solve() for native-capable families (#507):
+# a `native: bool = False` kwarg plus an early dispatch to the shipped C++
+# extension that silently falls back (returns None -> continue) when unavailable.
+_NATIVE_HOOK = """\
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
+"""
+
+# Docstring entry for the injected `native` kwarg (dedented base indent).
+_NATIVE_DOC = """\
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
+"""
+
+
 def _render_specialised_solve_orchestrator(
     fk_atol_expr: str = "policy.subproblem_numerical",
     force_refine: bool = False,
+    emit_native: bool = False,
 ) -> str:
     """Render the public ``solve()`` for specialised artifacts.
 
@@ -675,6 +714,24 @@ def _render_specialised_solve_orchestrator(
         # the gate when set, so non-forced artifacts stay byte-identical.
         template = template.replace(
             "if not allow_refinement:", "if not (allow_refinement or True):"
+        )
+    if emit_native:
+        # Add the `native` kwarg + early native dispatch. Only native-capable
+        # families opt in, so every other artifact stays byte-identical.
+        template = template.replace(
+            "    seed_tolerance: float | None = None,\n):",
+            "    seed_tolerance: float | None = None,\n    native: bool = False,\n):",
+        )
+        template = template.replace(
+            '        raise ValueError("seed_tolerance requires q_seed")\n'
+            "    T = np.asarray(T_target, dtype=np.float64)",
+            '        raise ValueError("seed_tolerance requires q_seed")\n'
+            + _NATIVE_HOOK
+            + "    T = np.asarray(T_target, dtype=np.float64)",
+        )
+        template = template.replace(
+            "    :returns: list of :class:`Solution`; empty list iff no IK",
+            _NATIVE_DOC + "    :returns: list of :class:`Solution`; empty list iff no IK",
         )
     return template
 

--- a/src/ssik/prebuilt/dobot/cr5_ik.py
+++ b/src/ssik/prebuilt/dobot/cr5_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -528,6 +529,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -583,6 +585,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/dobot/nova5_ik.py
+++ b/src/ssik/prebuilt/dobot/nova5_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -522,6 +523,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -577,6 +579,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/standard_bots/core_ik.py
+++ b/src/ssik/prebuilt/standard_bots/core_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -473,6 +474,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -522,12 +524,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/standard_bots/spark_ik.py
+++ b/src/ssik/prebuilt/standard_bots/spark_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -467,6 +468,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -516,12 +518,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/standard_bots/thor_ik.py
+++ b/src/ssik/prebuilt/standard_bots/thor_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -467,6 +468,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -516,12 +518,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/unitree/z1_ik.py
+++ b/src/ssik/prebuilt/unitree/z1_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -469,6 +470,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -518,12 +520,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur10e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur10e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur12e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur12e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -576,6 +578,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur15_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur15_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -576,6 +578,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur16e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur16e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur18_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur18_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -576,6 +578,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur20_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur20_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur30_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur30_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur3e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur3e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur5_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur5_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -479,6 +480,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -528,12 +530,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur5e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur5e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -570,12 +572,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/universal_robots/ur7e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur7e_ik.py
@@ -54,6 +54,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.three_parallel"
@@ -521,6 +522,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -576,6 +578,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/tests/test_native_dispatch.py
+++ b/tests/test_native_dispatch.py
@@ -1,0 +1,110 @@
+"""Opt-in native dispatch on the artifact solve() (#507).
+
+Two things:
+
+1. **Fallback** (runs everywhere): with the native extension unavailable,
+   ``solve(native=True)`` returns exactly the Python result. Forced by
+   monkeypatching the loader, so it holds even where the ext *is* built.
+2. **Native-active parity** (runs where ``ssik._ssik_native`` is importable --
+   the cpp CI job builds it into ``src/ssik``): ``solve(native=True)`` reproduces
+   ``solve()`` across the three_parallel family and its feature matrix. The
+   extension's own correctness is covered by ``test_three_parallel_artifact``;
+   this validates the wiring (dispatch + constant marshalling in ssik._native).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from ssik import _native
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.prebuilt._manifest import load_manifest
+
+_ARMS = [arm.name for arm in load_manifest().values() if arm.solver == "ikgeo.three_parallel"]
+
+
+def _wrap(a: float) -> float:
+    return float(((a + np.pi) % (2 * np.pi)) - np.pi)
+
+
+def _close(a: Any, b: Any, tol: float = 1e-3) -> bool:
+    return all(abs(_wrap(float(x - y))) < tol for x, y in zip(a, b, strict=True))
+
+
+def _set_match(A: list[Any], B: list[Any], tol: float = 1e-3) -> bool:
+    return len(A) == len(B) and all(any(_close(a.q, b.q, tol) for b in B) for a in A)
+
+
+def _subset(A: list[Any], B: list[Any], tol: float = 1e-3) -> bool:
+    return all(any(_close(a.q, b.q, tol) for b in B) for a in A)
+
+
+def test_native_true_falls_back_when_unavailable(monkeypatch: Any) -> None:
+    """native=True silently returns the Python result when the ext is absent."""
+    monkeypatch.setattr(_native, "_ext", None)
+    monkeypatch.setattr(_native, "_ext_tried", True)
+    assert not _native.native_available()
+
+    mod = importlib.import_module("ssik.prebuilt.ur5_ik")
+    t = mod.fk(np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2]))
+    py = mod.solve(t)
+    nat = mod.solve(t, native=True)
+    assert len(py) == len(nat)
+    assert all(_close(a.q, b.q) for a, b in zip(py, nat, strict=True)), "fallback must be identical"
+
+
+def test_native_kwarg_accepted() -> None:
+    """The native kwarg exists on three_parallel artifacts (accepts True/False)."""
+    mod = importlib.import_module("ssik.prebuilt.ur5_ik")
+    t = mod.fk(np.zeros(6))
+    assert mod.solve(t, native=False) is not None
+    assert mod.solve(t, native=True) is not None  # True is safe even without the ext
+
+
+@pytest.mark.skipif(
+    not _native.native_available(),
+    reason="ssik._ssik_native not built (see scripts/build_cpp_ext.py --out-dir src/ssik)",
+)
+@pytest.mark.parametrize("arm_name", _ARMS)
+def test_native_matches_python(arm_name: str) -> None:
+    """solve(native=True) reproduces solve() across the feature matrix."""
+    mod = importlib.import_module(f"ssik.prebuilt.{arm_name}")
+    kb = mod._KB
+    ranges = [
+        (float(j.limits[0]), float(j.limits[1])) if j.limits else (-np.pi, np.pi) for j in kb.joints
+    ]
+    rng = np.random.default_rng(2)
+    for _ in range(25):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in ranges])
+        t = np.asarray(poe_forward_kinematics(kb, q), dtype=np.float64)
+        seed = q + rng.uniform(-0.2, 0.2, len(q))
+
+        assert _set_match(mod.solve(t), mod.solve(t, native=True)), f"{arm_name}: full-set"
+        assert _set_match(
+            mod.solve(t, respect_limits=False), mod.solve(t, native=True, respect_limits=False)
+        ), f"{arm_name}: respect_limits=False"
+
+        py_full = mod.solve(t)
+        cpp_m = mod.solve(t, native=True, max_solutions=3)
+        assert len(cpp_m) == min(3, len(py_full)), f"{arm_name}: max count"
+        assert _subset(cpp_m, py_full), f"{arm_name}: max subset"
+
+        py_s = mod.solve(t, q_seed=seed)
+        nat_s = mod.solve(t, q_seed=seed, native=True)
+        assert len(py_s) == len(nat_s), f"{arm_name}: seed count"
+        if nat_s:
+            assert _close(py_s[0].q, nat_s[0].q), f"{arm_name}: nearest-to-seed"
+
+        # seed + max: same count and the nearest (top-1, the tracking guarantee)
+        # matches. Deeper ordering is not asserted -- at a near-singular pose two
+        # solutions can be near-equidistant to the seed, so which lands k-th flips
+        # by BLAS backend (the #56 representative ambiguity).
+        py_sm = mod.solve(t, q_seed=seed, max_solutions=2)
+        nat_sm = mod.solve(t, q_seed=seed, max_solutions=2, native=True)
+        assert len(py_sm) == len(nat_sm), f"{arm_name}: seed+max count"
+        if nat_sm:
+            assert _close(py_sm[0].q, nat_sm[0].q), f"{arm_name}: seed+max nearest"

--- a/tests/test_three_parallel_artifact.py
+++ b/tests/test_three_parallel_artifact.py
@@ -115,13 +115,16 @@ def test_artifact_contract_parity(arm_name: str) -> None:
         if cpp_l2:
             assert _close(py_l2[0].q, cpp_l2[0].q), f"{arm_name}: wrap_l2 nearest mismatch"
 
-        # q_seed + max_solutions: nearest-k in order.
+        # seed + max: same count and the nearest (top-1) matches. Deeper ordering
+        # isn't asserted -- near-equidistant solutions at a near-singular pose can
+        # swap which lands k-th by BLAS backend (the #56 representative ambiguity).
         py_sm = mod.solve(t, q_seed=seed, max_solutions=2)
         cpp_sm = cpp_artifact_solve(kb, t, q_seed=seed, max_solutions=2)
         assert len(py_sm) == len(cpp_sm), f"{arm_name}: seed+max_solutions count mismatch"
-        assert all(_close(a.q, b.q) for a, b in zip(py_sm, cpp_sm, strict=True)), (
-            f"{arm_name}: seed+max_solutions ordered mismatch"
-        )
+        if cpp_sm:
+            assert _close(py_sm[0].q, cpp_sm[0].q), (
+                f"{arm_name}: seed+max_solutions nearest mismatch"
+            )
 
         # seed_tolerance: unordered agreement of the kept set.
         assert _set_match(


### PR DESCRIPTION
Closes #507. Second half of the opt-in native backend (#501) -- exposes the shipped extension (#506) via `solve(native=True)`.

## What

- **`ssik._native.try_native_solve`** -- best-effort dispatch to `ssik._ssik_native.three_parallel_artifact_solve`, returning `None` (→ Python fallback) when the ext isn't importable or the family isn't native-capable. Marshalled KinBody constants cached per-arm so the ~50x isn't eroded.
- **Codegen**: emits a `native: bool = False` kwarg + early dispatch + docstring, **gated on `solver_name == ikgeo.three_parallel`**. The import/hook/doc are injected only for native-capable families, so **every other artifact stays byte-identical** (no slow RR/HP re-derive). Regenerated the 17 three_parallel artifacts.
- **README**: opt-in native backend section.
- **cpp CI job** builds the ext into `src/ssik` (the shipped import path) and runs the dispatch test.

## Contract

```python
sols = ur5_ik.solve(T, native=True)                       # ~50x, same solution set
sols = ur5_ik.solve(T, native=True, q_seed=q, max_solutions=1)
```

- `native=False` default unchanged; `native=True` **never fails for unavailability** -- silent fallback to Python (Windows wheels, source installs, non-native families).
- Same solution *set*; *order* without a seed and near-singular *representative* may differ (numpy vs Eigen) -- documented.

## Validation

- **`test_native_dispatch`**: fallback correctness (monkeypatched-absent ext, runs everywhere) + native-active parity across the 17 arms × feature matrix (skips where the ext isn't built).
- Contract-faithful assertions; `seed+max` asserts count + nearest only (the k-th flips at near-singular ties by BLAS backend, #56) -- softened the same assertion in `test_three_parallel_artifact`.
- **Snapshot + live-parity green**: only the 17 three_parallel artifacts changed, byte-identical elsewhere.
- mypy 257 files clean; ruff clean.

## Scope

Native runs only for `ikgeo.three_parallel` (falls back elsewhere). Default-flip (native-by-default) remains the deferred, gated MAJOR (#501). RR/HP native follows those families' C++ work.