### PR TITLE
C++ Phase 1b: native spherical_two_parallel (Pieper 6R, 18 arms) (#510)

### DIFF
--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -11,6 +11,7 @@
 #include <pybind11/pybind11.h>
 
 #include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace py = pybind11;
@@ -66,15 +67,45 @@ py::tuple three_parallel_solve_py(py::array_t<double> axes, py::array_t<double> 
   return py::make_tuple(qs, resids, is_ls);
 }
 
-// Full artifact-contract solve: exposes the <arm>_ik.solve() signature (limits,
-// seed ranking, seed tolerance, max_solutions) so the reused Python artifact
-// tests can drive the native artifact layer (#503).
-py::tuple three_parallel_artifact_solve_py(
-    py::array_t<double> axes, py::array_t<double> t_left, py::array_t<double> t_right,
-    py::array_t<int> types, py::array_t<double> lo, py::array_t<double> hi,
-    py::array_t<int> has_limits, py::array_t<double> target, bool respect_limits, bool has_seed,
-    py::array_t<double> q_seed, const std::string& seed_metric, bool has_seed_tolerance,
-    double seed_tolerance, int max_solutions, bool allow_rescue, int refinement_max_iters) {
+// Core spherical_two_parallel solve (#510), for the beachhead validation against
+// the Python solver. Caller passes CANONICAL constants.
+py::tuple spherical_two_parallel_solve_py(py::array_t<double> axes, py::array_t<double> t_left,
+                                          py::array_t<double> t_right, py::array_t<int> types,
+                                          py::array_t<double> target, bool allow_refinement,
+                                          int refinement_max_iters) {
+  const ssik::JointConsts<6> c = make_consts(axes, t_left, t_right, types);
+  auto tm = target.unchecked<2>();
+  ssik::Pose T;
+  for (int r = 0; r < 4; ++r)
+    for (int col = 0; col < 4; ++col) T(r, col) = tm(r, col);
+
+  const std::vector<ssik::Solution<6>> sols =
+      ssik::spherical_two_parallel_solve(c, T, {}, allow_refinement, refinement_max_iters);
+  const int n = static_cast<int>(sols.size());
+  py::array_t<double> qs({n, 6});
+  py::array_t<double> resids(n);
+  auto qm = qs.mutable_unchecked<2>();
+  auto rm = resids.mutable_unchecked<1>();
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < 6; ++j) qm(i, j) = sols[i].q[j];
+    rm(i) = sols[i].fk_residual;
+  }
+  return py::make_tuple(qs, resids, n == 0);
+}
+
+// Full artifact-contract solve, family-dispatched (#503/#507/#510): exposes the
+// <arm>_ik.solve() signature (limits, seed ranking, seed tolerance,
+// max_solutions) so the reused Python tests + the shipped native=True path drive
+// the native artifact layer. `family` selects the core solver; the force-refine
+// + finalize (limits -> seed -> truncate) tail is shared. New geometric families
+// are one more dispatch case here.
+py::tuple native_artifact_solve_py(
+    const std::string& family, py::array_t<double> axes, py::array_t<double> t_left,
+    py::array_t<double> t_right, py::array_t<int> types, py::array_t<double> lo,
+    py::array_t<double> hi, py::array_t<int> has_limits, py::array_t<double> target,
+    bool respect_limits, bool has_seed, py::array_t<double> q_seed, const std::string& seed_metric,
+    bool has_seed_tolerance, double seed_tolerance, int max_solutions, bool allow_rescue,
+    int refinement_max_iters) {
   const ssik::JointConsts<6> c = make_consts(axes, t_left, t_right, types);
 
   ssik::JointLimits<6> lim;
@@ -106,7 +137,16 @@ py::tuple three_parallel_artifact_solve_py(
   for (int r = 0; r < 4; ++r)
     for (int col = 0; col < 4; ++col) T(r, col) = tm(r, col);
 
-  const std::vector<ssik::Solution<6>> sols = ssik::three_parallel_artifact_solve(c, lim, T, p);
+  // Core solve (force-refined, as the artifact always polishes), family-selected;
+  // rescue is dormant for these geometric families (guarded on the Python side).
+  std::vector<ssik::Solution<6>> core;
+  if (family == "ikgeo.spherical_two_parallel") {
+    core = ssik::spherical_two_parallel_solve(c, T, {}, /*allow_refinement=*/true,
+                                              refinement_max_iters);
+  } else {
+    core = ssik::three_parallel_solve(c, T, {}, /*allow_refinement=*/true, refinement_max_iters);
+  }
+  const std::vector<ssik::Solution<6>> sols = ssik::finalize_solutions<6>(core, c, lim, p);
 
   const int n = static_cast<int>(sols.size());
   py::array_t<double> qs({n, 6});
@@ -134,7 +174,10 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);
-  m.def("three_parallel_artifact_solve", &three_parallel_artifact_solve_py, py::arg("axes"),
+  m.def("spherical_two_parallel_solve", &spherical_two_parallel_solve_py, py::arg("axes"),
+        py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("target"),
+        py::arg("allow_refinement") = false, py::arg("refinement_max_iters") = 15);
+  m.def("native_artifact_solve", &native_artifact_solve_py, py::arg("family"), py::arg("axes"),
         py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("lo"), py::arg("hi"),
         py::arg("has_limits"), py::arg("target"), py::arg("respect_limits") = true,
         py::arg("has_seed") = false, py::arg("q_seed"), py::arg("seed_metric") = "wrap_linf",

--- a/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
@@ -1,0 +1,130 @@
+// Spherical-wrist two-parallel 6R analytical IK (#510), ported verbatim from
+// ssik.solvers.ikgeo.spherical_two_parallel.solve. Pieper 6R: a spherical wrist
+// (intersecting axes at joints 3,4,5) plus two parallel shoulder axes (1,2).
+// SP4 isolates q1, SP3/SP1 solve the shoulder, SP4/SP1/SP1 solve the wrist.
+//
+// The caller must pass CANONICAL constants (canonicalize_spherical_wrist applied
+// in the Python dispatch, cached per-arm) -- the p[3] wrist-collapse assumes the
+// canonical form. Canonicalization is FK-identical, so verification here is valid
+// with the canonical constants and the returned q are physical joint values.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/newton.hpp"
+#include "ssik_cpp/rotation.hpp"
+#include "ssik_cpp/sp6.hpp"  // detail::wrap_pi
+#include "ssik_cpp/subproblems.hpp"
+
+namespace ssik {
+
+inline constexpr double kSphericalTwoParallelFkAtol = 1e-7;
+
+// Core analytical solve. Returns FK-verified, deduped joint solutions. With
+// allow_refinement, near-misses are Newton-polished (the artifact's force_refine
+// path). `tol` mirrors the Python policy.
+inline std::vector<Solution<6>> spherical_two_parallel_solve(const JointConsts<6>& c, const Pose& T,
+                                                             const Tolerances& tol = {},
+                                                             bool allow_refinement = false,
+                                                             int refinement_max_iters = 15) {
+  std::array<Eigen::Vector3d, 6> axes;
+  for (int i = 0; i < 6; ++i) axes[i] = c.axis[i];
+
+  // p[]: consolidated shoulder-to-wrist offset at p[3] (sum of T_left[3..5]);
+  // p[4],p[5] unused (wrist-collapse). p[6] = tool translation.
+  std::array<Eigen::Vector3d, 7> p;
+  for (int i = 0; i < 6; ++i) p[i] = c.t_left[i].block<3, 1>(0, 3);
+  p[3] = c.t_left[3].block<3, 1>(0, 3) + c.t_left[4].block<3, 1>(0, 3) +
+         c.t_left[5].block<3, 1>(0, 3);
+  p[4].setZero();
+  p[5].setZero();
+  p[6] = c.t_right[5].block<3, 1>(0, 3);
+
+  const Eigen::Matrix3d r_home = c.t_right[5].block<3, 3>(0, 0);
+  const Eigen::Matrix3d r_06 = T.block<3, 3>(0, 0) * r_home.transpose();
+  const Eigen::Vector3d p_0t = T.block<3, 1>(0, 3);
+
+  // SP4 isolates q1: axes[1] . Rot(-axes[0], q1) (p_0t - r_06 p[6] - p[0]) =
+  // axes[1] . (p[1]+p[2]+p[3]).
+  const auto [t1_solutions, ls1] =
+      sp4(axes[1], -axes[0], p_0t - r_06 * p[6] - p[0], axes[1].dot(p[1] + p[2] + p[3]), tol);
+  (void)ls1;
+
+  std::vector<std::array<double, 6>> candidates;
+  for (double q1 : t1_solutions) {
+    const Eigen::Vector3d shoulder =
+        rotation_matrix(-axes[0], q1) * (-p_0t + r_06 * p[6] + p[0]) + p[1];
+
+    const auto [t3_solutions, ls3] = sp3(axes[2], -p[3], p[2], shoulder.norm(), tol);
+    (void)ls3;
+
+    for (double q3 : t3_solutions) {
+      const auto [q2, ls2] =
+          sp1(axes[1], -p[2] - rotation_matrix(axes[2], q3) * p[3], shoulder, tol);
+      (void)ls2;
+
+      const Eigen::Matrix3d r_36 = rotation_matrix(-axes[2], q3) * rotation_matrix(-axes[1], q2) *
+                                   rotation_matrix(-axes[0], q1) * r_06;
+
+      const auto [t5_solutions, ls5] =
+          sp4(axes[3], axes[4], axes[5], axes[3].dot(r_36 * axes[5]), tol);
+      (void)ls5;
+
+      for (double q5 : t5_solutions) {
+        const auto [q4, ls4] =
+            sp1(axes[3], rotation_matrix(axes[4], q5) * axes[5], r_36 * axes[5], tol);
+        const auto [q6, ls6] =
+            sp1(-axes[5], rotation_matrix(-axes[4], q5) * axes[3], r_36.transpose() * axes[3], tol);
+        (void)ls4;
+        (void)ls6;
+        candidates.push_back({q1, q2, q3, q4, q5, q6});
+      }
+    }
+  }
+
+  // verify_candidates tail: FK-closure gate (+ optional Newton polish), then
+  // dedup_by_wrap_close (lowest fk_residual per cluster, first-seen order).
+  std::vector<Solution<6>> verified;
+  for (const auto& q : candidates) {
+    const Pose fk_q = fk<6>(c, q);
+    const double resid = (fk_q - T).norm();
+    if (resid <= kSphericalTwoParallelFkAtol) {
+      verified.push_back(Solution<6>{q, resid, Refinement::None});
+    } else if (allow_refinement) {
+      const auto refined = lm_refine<6>(c, q, T, kSphericalTwoParallelFkAtol, refinement_max_iters);
+      if (refined) verified.push_back(Solution<6>{refined->first, refined->second, Refinement::Lm});
+    }
+  }
+
+  std::vector<Solution<6>> deduped;
+  for (const auto& cand : verified) {
+    int match = -1;
+    for (int j = 0; j < static_cast<int>(deduped.size()); ++j) {
+      bool close = true;
+      for (int i = 0; i < 6; ++i) {
+        if (std::abs(detail::wrap_pi(cand.q[i] - deduped[j].q[i])) > tol.dedup) {
+          close = false;
+          break;
+        }
+      }
+      if (close) {
+        match = j;
+        break;
+      }
+    }
+    if (match == -1) {
+      deduped.push_back(cand);
+    } else if (cand.fk_residual < deduped[match].fk_residual) {
+      deduped[match] = cand;
+    }
+  }
+  return deduped;
+}
+
+}  // namespace ssik

--- a/scripts/native_smoke.py
+++ b/scripts/native_smoke.py
@@ -40,7 +40,8 @@ def main() -> int:
     q = np.array([0.3, -0.7, 0.9, 1.1, -0.5, 0.2])
     t_target = np.asarray(ur5_ik.fk(q), dtype=np.float64)
 
-    qs, resids, _refine = _ssik_native.three_parallel_artifact_solve(
+    qs, resids, _refine = _ssik_native.native_artifact_solve(
+        "ikgeo.three_parallel",
         axes,
         t_left,
         t_right,

--- a/src/ssik/_native.py
+++ b/src/ssik/_native.py
@@ -21,7 +21,7 @@ from numpy.typing import NDArray
 from ssik.core.solution import Solution
 
 # Solver families with a native implementation in _ssik_native.
-_NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel"})
+_NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel", "ikgeo.spherical_two_parallel"})
 
 _ext: Any = None
 _ext_tried = False
@@ -52,19 +52,31 @@ def native_available() -> bool:
 _consts_cache: dict[int, tuple[Any, ...]] = {}
 
 
-def _consts(kb: Any) -> tuple[Any, ...]:
+def _consts(solver_name: str, kb: Any) -> tuple[Any, ...]:
     cached = _consts_cache.get(id(kb))
     if cached is not None:
         return cached
-    joints = kb.joints
+    # Per-family geometry preprocessing: spherical_two_parallel needs the wrist
+    # gauge canonicalized (the artifact bakes it at build time; the raw _KB lacks
+    # it -- 15/18 arms). Canonicalization is FK-identical, so the returned q are
+    # physical joint values and the joint limits are unchanged. Done here in
+    # Python (cached per-arm), so no preprocessing is ported to C++.
+    geom = kb
+    if solver_name == "ikgeo.spherical_two_parallel":
+        from ssik._kinbody import canonicalize_spherical_wrist
+        from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY
+
+        geom = canonicalize_spherical_wrist(kb, DEFAULT_TOLERANCE_POLICY)
+    gj = geom.joints
+    lj = kb.joints  # limits from the original (physical) joints
     marshalled = (
-        np.array([j.axis for j in joints], dtype=np.float64),
-        np.array([j.T_left for j in joints], dtype=np.float64),
-        np.array([j.T_right for j in joints], dtype=np.float64),
-        np.array([0 if j.joint_type == "revolute" else 1 for j in joints], dtype=np.int32),
-        np.array([j.limits[0] if j.limits else 0.0 for j in joints], dtype=np.float64),
-        np.array([j.limits[1] if j.limits else 0.0 for j in joints], dtype=np.float64),
-        np.array([1 if j.limits else 0 for j in joints], dtype=np.int32),
+        np.array([j.axis for j in gj], dtype=np.float64),
+        np.array([j.T_left for j in gj], dtype=np.float64),
+        np.array([j.T_right for j in gj], dtype=np.float64),
+        np.array([0 if j.joint_type == "revolute" else 1 for j in gj], dtype=np.int32),
+        np.array([j.limits[0] if j.limits else 0.0 for j in lj], dtype=np.float64),
+        np.array([j.limits[1] if j.limits else 0.0 for j in lj], dtype=np.float64),
+        np.array([1 if j.limits else 0 for j in lj], dtype=np.int32),
     )
     _consts_cache[id(kb)] = marshalled
     return marshalled
@@ -97,12 +109,13 @@ def try_native_solve(
     if len(kb.joints) != 6:
         return None
 
-    axes, t_left, t_right, types, lo, hi, has_limits = _consts(kb)
+    axes, t_left, t_right, types, lo, hi, has_limits = _consts(solver_name, kb)
     has_seed = q_seed is not None
     seed_arr = (
         np.asarray(q_seed, dtype=np.float64) if has_seed else np.zeros(len(kb.joints), np.float64)
     )
-    qs, resids, refine = ext.three_parallel_artifact_solve(
+    qs, resids, refine = ext.native_artifact_solve(
+        solver_name,
         axes,
         t_left,
         t_right,

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ssik._native import _NATIVE_SOLVERS as _NATIVE_SOLVER_FAMILIES
 from ssik.core.solver_registry import SOLVERS
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
@@ -241,10 +242,10 @@ def _render_specialised(
         "rescue_via_T_perturbation as _rescue_via_T_perturbation\n"
     )
     buf.write("from ssik.postprocess import finalize_solutions as _ps_finalize\n")
-    # Opt-in native (C++) dispatch (#507), emitted only for families with a
+    # Opt-in native (C++) dispatch (#507/#510), emitted only for families with a
     # native implementation: solve(..., native=True) tries ssik._ssik_native and
     # silently falls back to the Python path below when it is unavailable.
-    if plan.solver_name == "ikgeo.three_parallel":
+    if plan.solver_name in _NATIVE_SOLVER_FAMILIES:
         buf.write("from ssik._native import try_native_solve as _try_native_solve\n")
     buf.write("from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix\n\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
@@ -274,7 +275,7 @@ def _render_specialised(
             _render_specialised_solve_orchestrator(
                 _spec.fk_atol_expr,
                 force_refine=_spec.force_refine,
-                emit_native=plan.solver_name == "ikgeo.three_parallel",
+                emit_native=plan.solver_name in _NATIVE_SOLVER_FAMILIES,
             )
         )
     buf.write(_render_fk_alias())

--- a/src/ssik/prebuilt/abb/irb120_ik.py
+++ b/src/ssik/prebuilt/abb/irb120_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -504,6 +505,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -553,12 +555,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/abb/irb1600_ik.py
+++ b/src/ssik/prebuilt/abb/irb1600_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -502,6 +503,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -551,12 +553,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/abb/irb6700_ik.py
+++ b/src/ssik/prebuilt/abb/irb6700_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -504,6 +505,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -553,12 +555,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/denso/vs060_ik.py
+++ b/src/ssik/prebuilt/denso/vs060_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -504,6 +505,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -553,12 +555,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/fanuc/lrmate200id_ik.py
+++ b/src/ssik/prebuilt/fanuc/lrmate200id_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -512,6 +513,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -561,12 +563,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/fanuc/m710ic_ik.py
+++ b/src/ssik/prebuilt/fanuc/m710ic_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -512,6 +513,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -561,12 +563,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/fanuc/r2000ic210l_ik.py
+++ b/src/ssik/prebuilt/fanuc/r2000ic210l_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -512,6 +513,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -561,12 +563,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/hyundai/hh020_ik.py
+++ b/src/ssik/prebuilt/hyundai/hh020_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -559,6 +560,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -608,12 +610,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/kawasaki/rs007n_ik.py
+++ b/src/ssik/prebuilt/kawasaki/rs007n_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -549,6 +550,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -598,12 +600,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/kinova/j2s6s300_ik.py
+++ b/src/ssik/prebuilt/kinova/j2s6s300_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -737,6 +738,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -786,12 +788,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/kuka/kr210_r2700_ik.py
+++ b/src/ssik/prebuilt/kuka/kr210_r2700_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -704,6 +705,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -753,12 +755,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/kuka/kr6_r900_ik.py
+++ b/src/ssik/prebuilt/kuka/kr6_r900_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -509,6 +510,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -558,12 +560,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/mitsubishi/rv4fr_ik.py
+++ b/src/ssik/prebuilt/mitsubishi/rv4fr_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -504,6 +505,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -553,12 +555,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/staubli/rx160_ik.py
+++ b/src/ssik/prebuilt/staubli/rx160_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -502,6 +503,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -551,12 +553,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/trossen/viperx300s_ik.py
+++ b/src/ssik/prebuilt/trossen/viperx300s_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -502,6 +503,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -551,12 +553,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/trossen/widowx250s_ik.py
+++ b/src/ssik/prebuilt/trossen/widowx250s_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -502,6 +503,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -551,12 +553,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/unimation/puma560_ik.py
+++ b/src/ssik/prebuilt/unimation/puma560_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -542,6 +543,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -591,12 +593,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/src/ssik/prebuilt/yaskawa/gp8_ik.py
+++ b/src/ssik/prebuilt/yaskawa/gp8_ik.py
@@ -53,6 +53,7 @@ from ssik.refinement import lm_refine as _lm_refine
 import functools as _functools
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.postprocess import finalize_solutions as _ps_finalize
+from ssik._native import try_native_solve as _try_native_solve
 from ssik.subproblems._rotation import rotation_matrix as _rotation_matrix
 
 SOLVER_NAME = "ikgeo.spherical_two_parallel"
@@ -508,6 +509,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -557,12 +559,33 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     T = np.asarray(T_target, dtype=np.float64)
     candidates = _solve_algebraic(T)
 

--- a/tests/_cpp_backend.py
+++ b/tests/_cpp_backend.py
@@ -152,7 +152,8 @@ def cpp_artifact_solve(
         np.asarray(q_seed, dtype=np.float64) if has_seed else np.zeros(len(kb.joints), np.float64)
     )
 
-    qs, resids, refine = ext.three_parallel_artifact_solve(
+    qs, resids, refine = ext.native_artifact_solve(
+        "ikgeo.three_parallel",
         axes,
         t_left,
         t_right,

--- a/tests/test_native_dispatch.py
+++ b/tests/test_native_dispatch.py
@@ -24,7 +24,7 @@ from ssik import _native
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.prebuilt._manifest import load_manifest
 
-_ARMS = [arm.name for arm in load_manifest().values() if arm.solver == "ikgeo.three_parallel"]
+_ARMS = [arm.name for arm in load_manifest().values() if arm.solver in _native._NATIVE_SOLVERS]
 
 
 def _wrap(a: float) -> float:

--- a/tests/test_three_parallel_boundary.py
+++ b/tests/test_three_parallel_boundary.py
@@ -35,6 +35,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from ssik._native import _NATIVE_SOLVERS
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.prebuilt._manifest import load_manifest
 
@@ -119,15 +120,16 @@ def test_unreachable_returns_empty_is_ls(target_name: str, three_parallel_backen
     assert is_ls, f"{target_name}: expected is_ls=True for unreachable target"
 
 
-_FAMILY_ARMS = [a.name for a in load_manifest().values() if a.solver == "ikgeo.three_parallel"]
+_FAMILY_ARMS = [a.name for a in load_manifest().values() if a.solver in _NATIVE_SOLVERS]
 
 
 @pytest.mark.parametrize("arm_name", _FAMILY_ARMS)
 def test_rescue_is_dormant_across_family(arm_name: str) -> None:
-    """The T-perturbation rescue never fires for the three_parallel family.
+    """The T-perturbation rescue never fires for the native geometric families.
 
-    This is the assumption that lets the native artifact layer (#503) omit the
-    full ``rescue_via_T_perturbation`` port: the analytical path is complete, so
+    This is the assumption that lets the native artifact layer (#503/#510) omit
+    the full ``rescue_via_T_perturbation`` port: the analytical path is complete
+    for these geometric families (three_parallel, spherical_two_parallel), so
     ``allow_rescue`` changes nothing on reachable poses. If a future geometry or
     tolerance change makes rescue start firing here, this goes red -- the signal
     that the C++ artifact layer now needs the rescue port (deferred to the RR/HP


### PR DESCRIPTION
Closes #510. Second native family (#496), reusing all the 1a infrastructure -- the per-family cost prediction held (~1/3 of 1a).

## What

- **`spherical_two_parallel.hpp`** -- the SP4→SP3→SP1 core solver (spherical wrist + two parallel shoulder axes), reusing the existing SP1/SP3/SP4 + fk + newton primitives.
- **Generalized binding**: `three_parallel_artifact_solve` → `native_artifact_solve(family, …)`, dispatching the core solver by family with a shared force-refine + finalize tail. Future geometric families are one more dispatch case.
- **`ssik._native`**: `_NATIVE_SOLVERS` grows to include spherical; per-family geometry preprocessing -- spherical needs `canonicalize_spherical_wrist` (the wrist gauge the artifact bakes; **15/18 raw `_KB` lack it**), done in Python (cached per-arm, FK-identical) so C++ gets canonical constants. No preprocessing ported to C++.
- **Codegen**: the `emit_native` gate is now keyed on `_NATIVE_SOLVERS` (single source). Regenerated the 18 spherical artifacts; byte-identical elsewhere.
- Docs/dispatch/CI: all reused unchanged.

## Validation

- **Beachhead**: C++ spherical core == Python solver on **18/18 arms, 0 mismatches, FK ≤6e-9** (offset-wrist arms included).
- **`test_native_dispatch` + rescue-dormancy** now sweep **all 35 native-capable arms** (three_parallel + spherical). `native=True` parity across the family, incl. offset-wrist irb6700 (0.2m canon): **40/40 set-match**.
- snapshot + live-parity green; mypy 257 clean; 168 native/three_parallel tests green.

## Contract

```python
irb6700_ik.solve(T, native=True)   # ~50-100x, same set, silent fallback
```

Same opt-in contract as three_parallel: `native=False` default, silent fallback, robust-at-singularities assertions.

## Reused (no new work)
finalize / newton / subproblems / quartic / two_ellipse / rotation, the binding+adapter+dispatch, the drift + cpp + native_wheel CI jobs, the codegen gate pattern. Part of #496.