### PR TITLE
C++ Phase 1c: native=True for canonical SRS 7R (iiwa14 + xmatepro7) (#512)

### DIFF
--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -12,24 +12,26 @@
 
 #include "ssik_cpp/fk.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
+#include "ssik_cpp/solvers/srs_canonical.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace py = pybind11;
 
 namespace {
 
-// Build the native JointConsts<6> from the KinBody arrays marshalled by the
-// Python adapter. Shapes: axes (6,3), t_left/t_right (6,4,4), types (6,).
-ssik::JointConsts<6> make_consts(const py::array_t<double>& axes,
-                                 const py::array_t<double>& t_left,
-                                 const py::array_t<double>& t_right,
-                                 const py::array_t<int>& types) {
+// Build a native JointConsts<N> from the KinBody arrays marshalled by the Python
+// adapter. Shapes: axes (N,3), t_left/t_right (N,4,4), types (N,).
+template <int N>
+ssik::JointConsts<N> make_consts_n(const py::array_t<double>& axes,
+                                   const py::array_t<double>& t_left,
+                                   const py::array_t<double>& t_right,
+                                   const py::array_t<int>& types) {
   auto a = axes.unchecked<2>();
   auto tl = t_left.unchecked<3>();
   auto tr = t_right.unchecked<3>();
   auto ty = types.unchecked<1>();
-  ssik::JointConsts<6> c;
-  for (int i = 0; i < 6; ++i) {
+  ssik::JointConsts<N> c;
+  for (int i = 0; i < N; ++i) {
     c.axis[i] = Eigen::Vector3d(a(i, 0), a(i, 1), a(i, 2));
     for (int r = 0; r < 4; ++r)
       for (int col = 0; col < 4; ++col) {
@@ -39,6 +41,50 @@ ssik::JointConsts<6> make_consts(const py::array_t<double>& axes,
     c.type[i] = ty(i) == 0 ? ssik::JointType::Revolute : ssik::JointType::Prismatic;
   }
   return c;
+}
+
+ssik::JointConsts<6> make_consts(const py::array_t<double>& axes,
+                                 const py::array_t<double>& t_left,
+                                 const py::array_t<double>& t_right,
+                                 const py::array_t<int>& types) {
+  return make_consts_n<6>(axes, t_left, t_right, types);
+}
+
+// Core canonical-SRS solve (#512) for the beachhead validation. SRS geometric
+// constants are precomputed in Python and passed in.
+py::tuple srs_canonical_solve_py(py::array_t<double> axes, py::array_t<double> t_left,
+                                 py::array_t<double> t_right, py::array_t<int> types, double l_se,
+                                 double l_ew, py::array_t<double> ee_offset,
+                                 py::array_t<double> shoulder_pivot,
+                                 py::array_t<double> r_post_wrist, py::array_t<double> target) {
+  const ssik::JointConsts<7> c = make_consts_n<7>(axes, t_left, t_right, types);
+  ssik::SrsConsts s;
+  s.l_se = l_se;
+  s.l_ew = l_ew;
+  auto eo = ee_offset.unchecked<1>();
+  auto sp = shoulder_pivot.unchecked<1>();
+  auto rp = r_post_wrist.unchecked<2>();
+  for (int i = 0; i < 3; ++i) {
+    s.ee_offset_local[i] = eo(i);
+    s.shoulder_pivot[i] = sp(i);
+    for (int j = 0; j < 3; ++j) s.r_post_wrist(i, j) = rp(i, j);
+  }
+  auto tm = target.unchecked<2>();
+  ssik::Pose T;
+  for (int r = 0; r < 4; ++r)
+    for (int col = 0; col < 4; ++col) T(r, col) = tm(r, col);
+
+  const std::vector<ssik::Solution<7>> sols = ssik::srs_canonical_solve(c, s, T);
+  const int n = static_cast<int>(sols.size());
+  py::array_t<double> qs({n, 7});
+  py::array_t<double> resids(n);
+  auto qm = qs.mutable_unchecked<2>();
+  auto rm = resids.mutable_unchecked<1>();
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < 7; ++j) qm(i, j) = sols[i].q[j];
+    rm(i) = sols[i].fk_residual;
+  }
+  return py::make_tuple(qs, resids);
 }
 
 py::tuple three_parallel_solve_py(py::array_t<double> axes, py::array_t<double> t_left,
@@ -177,6 +223,9 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("spherical_two_parallel_solve", &spherical_two_parallel_solve_py, py::arg("axes"),
         py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("target"),
         py::arg("allow_refinement") = false, py::arg("refinement_max_iters") = 15);
+  m.def("srs_canonical_solve", &srs_canonical_solve_py, py::arg("axes"), py::arg("t_left"),
+        py::arg("t_right"), py::arg("types"), py::arg("l_se"), py::arg("l_ew"), py::arg("ee_offset"),
+        py::arg("shoulder_pivot"), py::arg("r_post_wrist"), py::arg("target"));
   m.def("native_artifact_solve", &native_artifact_solve_py, py::arg("family"), py::arg("axes"),
         py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("lo"), py::arg("hi"),
         py::arg("has_limits"), py::arg("target"), py::arg("respect_limits") = true,

--- a/cpp/include/ssik_cpp/fk.hpp
+++ b/cpp/include/ssik_cpp/fk.hpp
@@ -45,4 +45,23 @@ Pose fk(const JointConsts<N>& c, const std::array<double, N>& q) {
   return t;
 }
 
+// Partial FK: the world frame (rotation R, origin p) at joint k BEFORE its own
+// rotation, given config q. Mirrors ssik.solvers.seven_r.srs._frame_at_joint
+// exactly (T_left contributes translation only -- rotation block is I in a
+// POE-normalized chain -- and T_right's rotation is applied after the joint).
+template <int N>
+std::pair<Eigen::Matrix3d, Eigen::Vector3d> frame_at_joint(const JointConsts<N>& c,
+                                                           const std::array<double, N>& q, int k) {
+  Eigen::Matrix3d R = Eigen::Matrix3d::Identity();
+  Eigen::Vector3d p = Eigen::Vector3d::Zero();
+  for (int i = 0; i < N; ++i) {
+    p = p + R * c.t_left[i].template block<3, 1>(0, 3);
+    if (i == k) return {R, p};
+    R = R * Eigen::AngleAxisd(q[i], c.axis[i].normalized()).toRotationMatrix();
+    R = R * c.t_right[i].template block<3, 3>(0, 0);
+    p = p + R * c.t_right[i].template block<3, 1>(0, 3);
+  }
+  return {R, p};
+}
+
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/srs_canonical.hpp
+++ b/cpp/include/ssik_cpp/solvers/srs_canonical.hpp
@@ -1,0 +1,184 @@
+// Canonical-ZYZ SRS-class 7R analytical IK (#512), ported from the canonical
+// path of ssik.solvers.seven_r.srs.solve (iiwa-class: z-y-z shoulder + z-y-z
+// wrist, offset-free wrist). Singh-Kreutz swivel parameterization: sweep the
+// elbow swivel, place the elbow on the reach circle (cosine rule), SP1 for the
+// upper-arm roll q2, ZYZ-Euler the residual for the wrist triple.
+//
+// The general Davenport path (tilted/offset elbow, non-ZYZ axes) is deferred;
+// those arms fall back to Python. SRS geometric constants are precomputed in the
+// Python dispatch (classify + _arm_constants) and passed in via SrsConsts.
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/sp6.hpp"  // detail::wrap_pi
+#include "ssik_cpp/subproblems.hpp"
+
+namespace ssik {
+
+// Precomputed SRS geometry (from the Python classifier + _arm_constants).
+struct SrsConsts {
+  double l_se = 0.0;
+  double l_ew = 0.0;
+  Eigen::Vector3d ee_offset_local{0, 0, 0};  // ee_home - wrist_pivot (local)
+  Eigen::Vector3d shoulder_pivot{0, 0, 0};
+  Eigen::Matrix3d r_post_wrist = Eigen::Matrix3d::Identity();  // joints[6].T_right rotation
+};
+
+inline constexpr int kSrsSwivelSamples = 16;
+inline constexpr double kSrsFkThreshold = 1e-5;   // policy.subproblem_numerical
+inline constexpr double kSrsDedupTol = 1e-3;      // policy.subproblem_dedup
+
+namespace srs_detail {
+
+// Two orthonormal vectors spanning the plane perpendicular to u_sw
+// (ssik.solvers.seven_r.srs._swivel_basis).
+inline void swivel_basis(const Eigen::Vector3d& u_sw, Eigen::Vector3d& u_perp1,
+                         Eigen::Vector3d& u_perp2) {
+  const Eigen::Vector3d ref =
+      std::abs(u_sw[2]) < 0.99 ? Eigen::Vector3d(0, 0, 1) : Eigen::Vector3d(1, 0, 0);
+  u_perp1 = ref - ref.dot(u_sw) * u_sw;
+  u_perp1.normalize();
+  u_perp2 = u_sw.cross(u_perp1);
+}
+
+// Canonical-ZYZ shoulder: (q0, q1) aiming home upper arm (+z) onto elbow dir d
+// (ssik.solvers.seven_r.srs._shoulder_angles_zyz).
+inline void shoulder_angles_zyz(const Eigen::Vector3d& d, int q1_sign, double& q0, double& q1) {
+  const double cos_q1 = std::max(-1.0, std::min(1.0, d[2]));
+  q1 = q1_sign * std::acos(cos_q1);
+  const double sin_q1 = std::sin(q1);
+  q0 = 0.0;
+  if (std::abs(sin_q1) > 1e-9) q0 = std::atan2(d[1] / sin_q1, d[0] / sin_q1);
+}
+
+}  // namespace srs_detail
+
+// Canonical-path SRS solve. Returns FK-verified, deduped 7-DOF solutions.
+// Assumes a canonical-ZYZ, offset-free-wrist SRS arm (the dispatch gates this).
+inline std::vector<Solution<7>> srs_canonical_solve(const JointConsts<7>& c, const SrsConsts& s,
+                                                    const Pose& T) {
+  const Eigen::Matrix3d R_target = T.block<3, 3>(0, 0);
+  const Eigen::Vector3d p_target = T.block<3, 1>(0, 3);
+  const Eigen::Vector3d W_t = p_target - R_target * s.ee_offset_local;
+
+  const Eigen::Vector3d SW = W_t - s.shoulder_pivot;
+  const double d_sw = SW.norm();
+  if (d_sw > s.l_se + s.l_ew || d_sw < std::abs(s.l_se - s.l_ew) || d_sw < 1e-12) return {};
+  const Eigen::Vector3d u_sw = SW / d_sw;
+
+  const double cos_int = std::max(
+      -1.0, std::min(1.0, (s.l_se * s.l_se + s.l_ew * s.l_ew - d_sw * d_sw) / (2.0 * s.l_se * s.l_ew)));
+  const double base_q3 = M_PI - std::acos(cos_int);
+  const std::array<double, 2> q3_branches = {base_q3, -base_q3};
+
+  const double x_c = (s.l_se * s.l_se - s.l_ew * s.l_ew + d_sw * d_sw) / (2.0 * d_sw);
+  const double r_circle = std::sqrt(std::max(s.l_se * s.l_se - x_c * x_c, 0.0));
+  Eigen::Vector3d u_perp1, u_perp2;
+  srs_detail::swivel_basis(u_sw, u_perp1, u_perp2);
+
+  const Eigen::Matrix3d R_post = s.r_post_wrist;
+  const Eigen::Vector3d S = s.shoulder_pivot;
+
+  // Per-swivel elbow placement.
+  std::array<Eigen::Vector3d, kSrsSwivelSamples> E_t, d_dir;
+  for (int n = 0; n < kSrsSwivelSamples; ++n) {
+    const double sw = -M_PI + (2.0 * M_PI) * n / kSrsSwivelSamples;  // linspace endpoint=False
+    E_t[n] = S + x_c * u_sw + r_circle * (std::cos(sw) * u_perp1 + std::sin(sw) * u_perp2);
+    d_dir[n] = (E_t[n] - S) / s.l_se;
+  }
+
+  // Candidate order matches Python: q3 -> q1_sign -> q5_sign -> swivel.
+  std::vector<Solution<7>> candidates;
+  for (double q3 : q3_branches) {
+    for (int q1_sign : {+1, -1}) {
+      // Per-swivel (q0, q1, q2, R_res), independent of q5_sign.
+      std::array<double, kSrsSwivelSamples> q0s, q1s, q2s;
+      std::array<Eigen::Matrix3d, kSrsSwivelSamples> R_res;
+      for (int n = 0; n < kSrsSwivelSamples; ++n) {
+        const Eigen::Vector3d& d = d_dir[n];
+        double q0, q1;
+        srs_detail::shoulder_angles_zyz(d, q1_sign, q0, q1);
+
+        std::array<double, 7> q_partial = {q0, q1, 0.0, q3, 0.0, 0.0, 0.0};
+        const auto [R5, W_at_q2_zero] = frame_at_joint<7>(c, q_partial, 5);
+
+        // SP1 for q2 (upper-arm roll mapping the q2=0 wrist pivot onto W_t).
+        const Eigen::Vector3d p_from = W_at_q2_zero - E_t[n];
+        const Eigen::Vector3d p_to = W_t - E_t[n];
+        const double up_pf = d.dot(p_from);
+        const double up_pt = d.dot(p_to);
+        const double num = d.dot(p_from.cross(p_to));
+        const double den = p_from.dot(p_to) - up_pf * up_pt;
+        const double q2 = std::atan2(num, den);
+
+        std::array<double, 7> q_post = {q0, q1, q2, q3, 0.0, 0.0, 0.0};
+        const auto [R_pre_wrist, p4] = frame_at_joint<7>(c, q_post, 4);
+        (void)p4;
+        q0s[n] = q0;
+        q1s[n] = q1;
+        q2s[n] = q2;
+        R_res[n] = R_pre_wrist.transpose() * R_target * R_post.transpose();
+      }
+
+      for (int q5_sign : {+1, -1}) {
+        for (int n = 0; n < kSrsSwivelSamples; ++n) {
+          const Eigen::Matrix3d& r = R_res[n];
+          const double cos_q5 = std::max(-1.0, std::min(1.0, r(2, 2)));
+          const double q5 = q5_sign * std::acos(cos_q5);
+          const double sin_q5 = std::sin(q5);
+          double q4, q6;
+          if (std::abs(sin_q5) > 1e-9) {
+            q4 = std::atan2(q5_sign * r(1, 2), q5_sign * r(0, 2));
+            q6 = std::atan2(q5_sign * r(2, 1), q5_sign * -r(2, 0));
+          } else {
+            q4 = 0.0;  // gimbal lock
+            q6 = cos_q5 > 0.0 ? std::atan2(-r(0, 1), r(0, 0)) : std::atan2(r(0, 1), -r(0, 0));
+          }
+          const std::array<double, 7> q = {q0s[n], q1s[n], q2s[n], q3, q4, q5, q6};
+          bool finite = true;
+          for (double v : q)
+            if (!std::isfinite(v)) finite = false;
+          if (finite) candidates.push_back(Solution<7>{q, 0.0, Refinement::None});
+        }
+      }
+    }
+  }
+
+  if (candidates.empty()) return {};
+
+  // dedup_by_wrap_close (all fk_residual == 0 pre-verify -> first-seen wins).
+  std::vector<Solution<7>> deduped;
+  for (const auto& cand : candidates) {
+    bool dup = false;
+    for (const auto& u : deduped) {
+      bool close = true;
+      for (int i = 0; i < 7; ++i) {
+        if (std::abs(detail::wrap_pi(cand.q[i] - u.q[i])) > kSrsDedupTol) {
+          close = false;
+          break;
+        }
+      }
+      if (close) {
+        dup = true;
+        break;
+      }
+    }
+    if (!dup) deduped.push_back(cand);
+  }
+
+  // FK verify: fill residual, drop past threshold.
+  std::vector<Solution<7>> verified;
+  for (const auto& cand : deduped) {
+    const double resid = (fk<7>(c, cand.q) - T).norm();
+    if (resid <= kSrsFkThreshold) verified.push_back(Solution<7>{cand.q, resid, Refinement::None});
+  }
+  return verified;
+}
+
+}  // namespace ssik

--- a/src/ssik/_native.py
+++ b/src/ssik/_native.py
@@ -20,8 +20,11 @@ from numpy.typing import NDArray
 
 from ssik.core.solution import Solution
 
-# Solver families with a native implementation in _ssik_native.
-_NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel", "ikgeo.spherical_two_parallel"})
+# Solver families with a native implementation in _ssik_native. The 6R geometric
+# families expose the full artifact contract via try_native_solve; seven_r.srs
+# exposes only its analytical sweep via try_native_srs_algebraic (the Python
+# wrapper keeps seeded-track / resolve_in_limits / finalize).
+_NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel", "ikgeo.spherical_two_parallel", "seven_r.srs"})
 
 _ext: Any = None
 _ext_tried = False
@@ -140,5 +143,92 @@ def try_native_solve(
             fk_residual=float(resids[i]),
             refinement_used="lm" if int(refine[i]) == 1 else "none",
         )
+        for i in range(len(qs))
+    ]
+
+
+# Per-KinBody native-SRS metadata: (is_canonical, marshalled args) or None. The
+# canonical-ZYZ + offset-free check + the SRS geometric constants are geometry-
+# only, so cache per-arm (keyed on id(kb)).
+_srs_cache: dict[int, Any] = {}
+
+
+def _srs_native_args(kb: Any) -> Any:
+    """Marshalled srs_canonical_solve args for a canonical SRS arm, or None when
+    the arm isn't the canonical-ZYZ offset-free path the native core supports."""
+    if id(kb) in _srs_cache:
+        return _srs_cache[id(kb)]
+    from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY as _POL
+    from ssik.solvers.seven_r.srs import (  # type: ignore[attr-defined]
+        _arm_constants,
+        _classify_srs_7r_geometric,
+    )
+
+    result = None
+    cls = _classify_srs_7r_geometric(kb, _POL)
+    if cls is not None and len(kb.joints) == 7:
+        l_se, l_ew, ee_offset, origins = _arm_constants(kb, cls)
+        upper = origins[cls.elbow_index] - cls.shoulder_pivot
+        u_home = upper / np.linalg.norm(upper)
+        j = kb.joints
+        ez, ey = np.array([0.0, 0.0, 1.0]), np.array([0.0, 1.0, 0.0])
+        canonical = (
+            np.allclose(j[0].axis, ez)
+            and np.allclose(j[1].axis, ey)
+            and np.allclose(u_home, ez)
+            and np.allclose(j[4].axis, ez)
+            and np.allclose(j[5].axis, ey)
+            and np.allclose(j[6].axis, ez)
+        )
+        offset_free = np.allclose(origins[5], cls.wrist_pivot, atol=_POL.axis_intersect)
+        if canonical and offset_free:
+            result = (
+                np.array([jt.axis for jt in j], dtype=np.float64),
+                np.array([jt.T_left for jt in j], dtype=np.float64),
+                np.array([jt.T_right for jt in j], dtype=np.float64),
+                np.array([0 if jt.joint_type == "revolute" else 1 for jt in j], dtype=np.int32),
+                float(l_se),
+                float(l_ew),
+                np.asarray(ee_offset, dtype=np.float64),
+                np.asarray(cls.shoulder_pivot, dtype=np.float64),
+                np.asarray(j[6].T_right[:3, :3], dtype=np.float64),
+            )
+    _srs_cache[id(kb)] = result
+    return result
+
+
+def try_native_srs_algebraic(
+    solver_name: str, kb: Any, t_target: NDArray[np.float64]
+) -> list[Solution] | None:
+    """Native SRS analytical sweep (the expensive part), or None to fall back.
+
+    Returns the deduped, FK-verified analytical candidate set (pre-finalize) --
+    the Python artifact keeps the seeded-track / limits / resolve_in_limits /
+    finalize postprocess around it. Supports the canonical-ZYZ offset-free path
+    (iiwa14 / xmatepro7); other SRS arms (offset/tilted wrist) return None.
+    """
+    if solver_name != "seven_r.srs":
+        return None
+    ext = _load_ext()
+    if ext is None:
+        return None
+    args = _srs_native_args(kb)
+    if args is None:
+        return None
+    axes, t_left, t_right, types, l_se, l_ew, ee_offset, shoulder_pivot, r_post = args
+    qs, resids = ext.srs_canonical_solve(
+        axes,
+        t_left,
+        t_right,
+        types,
+        l_se,
+        l_ew,
+        ee_offset,
+        shoulder_pivot,
+        r_post,
+        np.asarray(t_target, dtype=np.float64),
+    )
+    return [
+        Solution(q=np.asarray(qs[i], dtype=np.float64), fk_residual=float(resids[i]))
         for i in range(len(qs))
     ]

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -178,7 +178,17 @@ def _render_thin_wrapper(
         else "ssik.solvers.seven_r._swivel_limits"
     )
     buf.write(f"from {_resolver_module} import resolve_in_limits as _resolve_in_limits\n")
-    buf.write(f"from {solver_module} import solve as _solver_solve\n\n")
+    buf.write(f"from {solver_module} import solve as _solver_solve\n")
+    # Opt-in native (C++) dispatch (#512) for thin-wrapper families with a native
+    # core (seven_r.srs canonical path). solve(..., native=True) replaces the
+    # analytical sweep with ssik._ssik_native and reuses the Python postprocess
+    # (seeded-track / limits / seed / resolve_in_limits). Falls back silently.
+    emit_native = plan.solver_name in _NATIVE_SOLVER_FAMILIES
+    if emit_native:
+        buf.write(
+            "from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic\n"
+        )
+    buf.write("\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
     buf.write(f"EXPECTED_MS_MEDIAN = {plan.expected_ms_median!r}\n")
@@ -190,7 +200,7 @@ def _render_thin_wrapper(
     buf.write("\n")
     buf.write(_render_kinbody_builder())
     buf.write("\n")
-    buf.write(_render_solve_function(solver_short))
+    buf.write(_render_solve_function(solver_short, emit_native=emit_native))
     buf.write(_render_fk_function_from_kb())
     buf.write(_render_all_export())
     return buf.getvalue()
@@ -1361,9 +1371,9 @@ def _render_kinbody_builder() -> str:
     )
 
 
-def _render_solve_function(solver_short: str) -> str:
+def _render_solve_function(solver_short: str, emit_native: bool = False) -> str:
     """Emit the public ``solve`` callable wrapping the chosen ssik solver."""
-    return textwrap.dedent(
+    template = textwrap.dedent(
         f"""\
 
         def solve(
@@ -1507,6 +1517,37 @@ def _render_solve_function(solver_short: str) -> str:
             )
         """
     )
+    if emit_native:
+        # Add the `native` kwarg + replace the analytical sweep with the native
+        # core (when available), reusing the Python postprocess. Only families
+        # with a native thin-wrapper core opt in; others stay byte-identical.
+        template = template.replace(
+            "    seed_tolerance: float | None = None,\n):",
+            "    seed_tolerance: float | None = None,\n    native: bool = False,\n):",
+        )
+        template = template.replace(
+            "    sols, _is_ls = _solver_solve(\n"
+            "        _KB,\n"
+            "        T_target,\n"
+            "        policy=policy,\n"
+            "        allow_refinement=allow_refinement,\n"
+            "        refinement_max_iters=refinement_max_iters,\n"
+            "    )",
+            "    _native_sols = (\n"
+            "        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None\n"
+            "    )\n"
+            "    if _native_sols is not None:\n"
+            "        sols = _native_sols\n"
+            "    else:\n"
+            "        sols, _is_ls = _solver_solve(\n"
+            "            _KB,\n"
+            "            T_target,\n"
+            "            policy=policy,\n"
+            "            allow_refinement=allow_refinement,\n"
+            "            refinement_max_iters=refinement_max_iters,\n"
+            "        )",
+        )
+    return template
 
 
 def _render_all_export() -> str:

--- a/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/kuka/iiwa14_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa14_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/kuka/iiwa7_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa7_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/openarm/left_ik.py
+++ b/src/ssik/prebuilt/openarm/left_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/openarm/right_ik.py
+++ b/src/ssik/prebuilt/openarm/right_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/rokae/xmatepro7_ik.py
+++ b/src/ssik/prebuilt/rokae/xmatepro7_ik.py
@@ -50,6 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
+from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -163,6 +164,7 @@ def solve(
     refinement_max_iters: int = 15,
     seed_metric: str = "wrap_linf",
     seed_tolerance: float | None = None,
+    native: bool = False,
 ):
     """Inverse kinematics. Returns ``list[Solution]``.
 
@@ -243,13 +245,19 @@ def solve(
             )
             if _fast:
                 return _fast
-    sols, _is_ls = _solver_solve(
-        _KB,
-        T_target,
-        policy=policy,
-        allow_refinement=allow_refinement,
-        refinement_max_iters=refinement_max_iters,
+    _native_sols = (
+        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
     )
+    if _native_sols is not None:
+        sols = _native_sols
+    else:
+        sols, _is_ls = _solver_solve(
+            _KB,
+            T_target,
+            policy=policy,
+            allow_refinement=allow_refinement,
+            refinement_max_iters=refinement_max_iters,
+        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a


### PR DESCRIPTION
Closes #512. First 7R native family, canonical-path slice (#496). The general Davenport path is deferred; those SRS arms fall back to Python.

## Why it's the biggest win yet
The SRS artifact is **~12ms/solve** (the *slowest* family -- redundant 7R, ~88 solutions from the swivel sweep). Native takes iiwa14 to sub-millisecond.

## What (new territory: 7R + N=7)
- **`srs_canonical.hpp`** -- the Singh-Kreutz swivel sweep (16 samples): cosine-rule elbow + swivel circle + SP1 for q2 + ZYZ-Euler wrist (gimbal-handled) + dedup + FK verify. `frame_at_joint<N>` partial-FK primitive added to `fk.hpp`.
- **N=7 binding**: `make_consts` templated; `srs_canonical_solve` exposed. SRS geometric constants precomputed in the Python dispatch (classify + `_arm_constants`, cached) and passed in -- same "preprocess in Python" pattern as the spherical canonicalization.
- **Codegen (thin-wrapper hook)**: SRS arms use the thin wrapper, not the 6R orchestrator. The native hook here **replaces only the analytical sweep** and reuses the Python postprocess (seeded-track / limits / seed / `resolve_in_limits` / finalize) -- distinct from the 6R hook. Gated on `seven_r.srs`, so every other thin-wrapper family stays byte-identical.
- **`_native.try_native_srs_algebraic`** -- native analytical set, or None (fall back) when the ext is absent or the arm isn't the canonical-ZYZ offset-free path.

## Coverage
Native fires for **iiwa14 (flagship) + xmatepro7**. `iiwa7 / r1pro_left/right / openarm_left/right` accept `native=True` and **silently fall back to Python** (general Davenport path deferred).

## Validation
- **Beachhead**: C++ canonical SRS = Python `srs.solve` on iiwa14 + xmatepro7, **0/60 mismatch, worst FK 1.3e-14**, 128==128.
- **`native=True`**: iiwa14 vs Python **50/50 set-match** incl. seed+max / respect_limits.
- `test_native_dispatch` + rescue-dormancy sweep **all 42 native-capable arms** (3 families).
- snapshot + live-parity green (only 7 SRS arms regenerated); mypy 257 clean.

## Scope
General Davenport path (`decompose_3axis`) is the follow-up for the remaining 5 SRS arms. Part of #496.