### PR TITLE
Port feasible_arcs to C++ (shared redundant-7R in-limits primitive) (#515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         # test_native_dispatch: solve(native=True) parity + fallback (#507). cpp
         # legs / native tests skip when the ext is absent (the main matrix); here
         # it is built, so they execute.
-        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py tests/test_native_dispatch.py -q
+        run: uv run pytest tests/test_three_parallel.py tests/test_three_parallel_family.py tests/test_three_parallel_boundary.py tests/test_three_parallel_artifact.py tests/test_native_dispatch.py tests/test_feasible_arcs.py -q
 
   native_wheel:
     # Ships the native extension in the wheel (#506). cibuildwheel runs only on

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -11,6 +11,7 @@
 #include <pybind11/pybind11.h>
 
 #include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/seven_r/feasible_arcs.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 #include "ssik_cpp/solvers/srs_canonical.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
@@ -215,6 +216,40 @@ py::tuple native_artifact_solve_py(
 // extension (built into cpp/build by scripts/build_cpp_ext.py) and as the
 // shipped `ssik._ssik_native` extension in the wheel (hatch_build.py, #506).
 // The pybind init symbol is keyed on the leaf name, so both import paths work.
+// Test-only: exercise the C++ feasible_arcs geometry (#515) against the Python
+// _feasible_param oracle. A synthetic two-harmonic joint family q_i(t) =
+// off + a1 cos t + b1 sin t + a2 cos 2t + b2 sin 2t (coeffs shape (K,5)) is
+// evaluated identically here and in Python; the arcs must match.
+py::list feasible_arcs_test_py(py::array_t<double> coeffs, py::array_t<int> swept,
+                               py::array_t<double> lo, py::array_t<double> hi,
+                               py::array_t<double> grid_arr, bool bounded) {
+  auto co = coeffs.unchecked<2>();
+  const int K = static_cast<int>(co.shape(0));
+  auto lo_u = lo.unchecked<1>();
+  auto hi_u = hi.unchecked<1>();
+  std::vector<ssik::feasible::Arc> limits(K);
+  for (int i = 0; i < K; ++i) limits[i] = {lo_u(i), hi_u(i)};
+  std::vector<int> sw;
+  auto sw_u = swept.unchecked<1>();
+  for (int i = 0; i < static_cast<int>(sw_u.shape(0)); ++i) sw.push_back(sw_u(i));
+  std::vector<double> grid;
+  auto g_u = grid_arr.unchecked<1>();
+  for (int k = 0; k < static_cast<int>(g_u.shape(0)); ++k) grid.push_back(g_u(k));
+
+  auto q_scalar = [&](double t) {
+    std::vector<double> q(K);
+    for (int i = 0; i < K; ++i)
+      q[i] = co(i, 0) + co(i, 1) * std::cos(t) + co(i, 2) * std::sin(t) +
+             co(i, 3) * std::cos(2.0 * t) + co(i, 4) * std::sin(2.0 * t);
+    return q;
+  };
+  const auto arcs = bounded ? ssik::feasible::feasible_arcs_bounded(q_scalar, sw, limits, grid)
+                            : ssik::feasible::feasible_arcs(q_scalar, sw, limits, grid);
+  py::list out;
+  for (const auto& [a, b] : arcs) out.append(py::make_tuple(a, b));
+  return out;
+}
+
 PYBIND11_MODULE(_ssik_native, m) {
   m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
@@ -226,6 +261,8 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("srs_canonical_solve", &srs_canonical_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("l_se"), py::arg("l_ew"), py::arg("ee_offset"),
         py::arg("shoulder_pivot"), py::arg("r_post_wrist"), py::arg("target"));
+  m.def("feasible_arcs_test", &feasible_arcs_test_py, py::arg("coeffs"), py::arg("swept"),
+        py::arg("lo"), py::arg("hi"), py::arg("grid"), py::arg("bounded") = false);
   m.def("native_artifact_solve", &native_artifact_solve_py, py::arg("family"), py::arg("axes"),
         py::arg("t_left"), py::arg("t_right"), py::arg("types"), py::arg("lo"), py::arg("hi"),
         py::arg("has_limits"), py::arg("target"), py::arg("respect_limits") = true,

--- a/cpp/include/ssik_cpp/seven_r/feasible_arcs.hpp
+++ b/cpp/include/ssik_cpp/seven_r/feasible_arcs.hpp
@@ -1,0 +1,202 @@
+// Exact feasible-parameter arcs for redundant 7R in-limits resolution (#515),
+// ported verbatim from ssik.solvers.seven_r._feasible_param. SHARED primitive:
+// SRS swivel-limits (periodic feasible_arcs) AND spherical_shoulder q6-redundancy
+// (bounded feasible_arcs_bounded) both build on this. Dependency-free -- numpy
+// -> std/Eigen, same algebra + branch structure so the port is auditable.
+//
+// A "joint family" is a callable q_scalar(t) -> per-joint values at parameter t;
+// arcs_for_joint brackets the sign-zeros of cos(q_i(t) - c) - cos(half) (i.e.
+// q_i(t) in [lo,hi]) on a grid, refines by bisection, and intersects across the
+// swept joints. Callers precompute nothing; the grid values are evaluated here.
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include <vector>
+
+namespace ssik::feasible {
+
+using Arc = std::pair<double, double>;
+using Arcs = std::vector<Arc>;
+
+inline constexpr double kEps = 1e-9;
+inline constexpr double kTwoPi = 2.0 * M_PI;
+inline constexpr int kArcGrid = 180;  // PARAM_GRID resolution
+
+inline double wrap(double a) {
+  double m = std::fmod(a + M_PI, kTwoPi);
+  if (m < 0.0) m += kTwoPi;
+  return m - M_PI;
+}
+
+// PARAM_GRID = linspace(-pi, pi, 180, endpoint=False).
+inline std::vector<double> param_grid() {
+  std::vector<double> g(kArcGrid);
+  for (int k = 0; k < kArcGrid; ++k) g[k] = -M_PI + kTwoPi * k / kArcGrid;
+  return g;
+}
+
+// Root of a monotone-crossing f in [a, b] by bisection (tol on bracket width).
+template <typename F>
+double bisect(F&& f, double a, double b, double tol = 1e-8) {
+  double fa = f(a);
+  while (b - a > tol) {
+    const double m = 0.5 * (a + b);
+    const double fm = f(m);
+    if (fm == 0.0) return m;
+    if (fa * fm < 0.0) {
+      b = m;
+    } else {
+      a = m;
+      fa = fm;
+    }
+  }
+  return 0.5 * (a + b);
+}
+
+inline Arcs merge(Arcs arcs) {
+  if (arcs.empty()) return {};
+  std::sort(arcs.begin(), arcs.end());
+  Arcs out;
+  out.push_back(arcs[0]);
+  for (std::size_t i = 1; i < arcs.size(); ++i) {
+    if (arcs[i].first <= out.back().second + kEps) {
+      out.back().second = std::max(out.back().second, arcs[i].second);
+    } else {
+      out.push_back(arcs[i]);
+    }
+  }
+  return out;
+}
+
+inline Arcs intersect(const Arcs& a_arcs, const Arcs& b_arcs) {
+  Arcs out;
+  for (const auto& [a0, a1] : a_arcs)
+    for (const auto& [b0, b1] : b_arcs) {
+      const double lo = std::max(a0, b0), hi = std::min(a1, b1);
+      if (hi - lo > kEps) out.emplace_back(lo, hi);
+    }
+  return merge(std::move(out));
+}
+
+// The 2*pi-equivalent of v nearest the limit centre.
+inline double to_limits(double v, double lo, double hi) {
+  const double k = std::round((0.5 * (lo + hi) - v) / kTwoPi);
+  return v + kTwoPi * k;
+}
+
+// Feasible-t arcs for a single periodic joint q_of(t) in [lo, hi]. q_col is q_of
+// on `grid` (passed in so a batched family evaluates once).
+template <typename QOf>
+Arcs arcs_for_joint(QOf&& q_of, double lo, double hi, const std::vector<double>& grid,
+                    const std::vector<double>& q_col) {
+  const double c = 0.5 * (lo + hi);
+  const double half = 0.5 * (hi - lo);
+  if (half >= M_PI) return {{-M_PI, M_PI}};  // unconstrained
+  const double thr = std::cos(half);
+  auto phi = [&](double p) { return std::cos(q_of(p) - c) - thr; };
+
+  const int n = static_cast<int>(grid.size());
+  std::vector<double> val(n);
+  for (int k = 0; k < n; ++k) val[k] = std::cos(q_col[k] - c) - thr;
+
+  std::vector<double> roots;
+  for (int k = 0; k < n; ++k) {
+    const double a = grid[k];
+    const double b = (k + 1 < n) ? grid[k + 1] : M_PI;
+    if (val[k] * val[(k + 1) % n] < 0.0) roots.push_back(bisect(phi, a, b));
+  }
+  if (roots.empty()) return val[0] >= 0.0 ? Arcs{{-M_PI, M_PI}} : Arcs{};
+  std::sort(roots.begin(), roots.end());
+
+  Arcs arcs;
+  std::vector<double> ext = roots;
+  ext.push_back(roots[0] + kTwoPi);
+  for (std::size_t i = 0; i + 1 < ext.size(); ++i) {
+    const double u = ext[i], w = ext[i + 1];
+    if (phi(wrap(0.5 * (u + w))) >= 0.0) {
+      if (w <= M_PI) {
+        arcs.emplace_back(u, w);
+      } else {  // arc straddles +pi: split
+        arcs.emplace_back(u, M_PI);
+        arcs.emplace_back(-M_PI, wrap(w));
+      }
+    }
+  }
+  return merge(std::move(arcs));
+}
+
+// Feasible sub-intervals of the bounded domain [grid.front(), grid.back()] for a
+// single joint q_of(t) in [lo, hi] -- non-periodic analogue (no wrap).
+template <typename QOf>
+Arcs arcs_for_joint_bounded(QOf&& q_of, double lo, double hi, const std::vector<double>& grid,
+                            const std::vector<double>& q_col) {
+  const double a0 = grid.front(), b0 = grid.back();
+  const double c = 0.5 * (lo + hi);
+  const double half = 0.5 * (hi - lo);
+  if (half >= M_PI) return {{a0, b0}};
+  const double thr = std::cos(half);
+  auto phi = [&](double p) { return std::cos(q_of(p) - c) - thr; };
+
+  const int n = static_cast<int>(grid.size());
+  std::vector<double> val(n);
+  for (int k = 0; k < n; ++k) val[k] = std::cos(q_col[k] - c) - thr;
+
+  std::vector<double> roots;
+  for (int k = 0; k + 1 < n; ++k)
+    if (val[k] * val[k + 1] < 0.0) roots.push_back(bisect(phi, grid[k], grid[k + 1]));
+  std::sort(roots.begin(), roots.end());
+
+  std::vector<double> pts;
+  pts.push_back(a0);
+  pts.insert(pts.end(), roots.begin(), roots.end());
+  pts.push_back(b0);
+  Arcs arcs;
+  for (std::size_t i = 0; i + 1 < pts.size(); ++i) {
+    const double u = pts[i], w = pts[i + 1];
+    if (phi(0.5 * (u + w)) >= 0.0) arcs.emplace_back(u, w);
+  }
+  return merge(std::move(arcs));
+}
+
+// Exact periodic feasible-t set: intersection of every swept joint's arcs.
+// q_scalar(t) -> per-joint values. Empty iff no t keeps all swept joints in range.
+template <typename QScalar>
+Arcs feasible_arcs(QScalar&& q_scalar, const std::vector<int>& swept_joints,
+                   const std::vector<Arc>& limits, const std::vector<double>& grid) {
+  // Evaluate the joint family once on the grid (mirrors the Python q_grid).
+  std::vector<std::vector<double>> q_grid(grid.size());
+  for (std::size_t k = 0; k < grid.size(); ++k) q_grid[k] = q_scalar(grid[k]);
+
+  Arcs arcs = {{-M_PI, M_PI}};
+  for (int i : swept_joints) {
+    std::vector<double> q_col(grid.size());
+    for (std::size_t k = 0; k < grid.size(); ++k) q_col[k] = q_grid[k][i];
+    auto q_of = [&, i](double t) { return q_scalar(t)[i]; };
+    arcs = intersect(arcs, arcs_for_joint(q_of, limits[i].first, limits[i].second, grid, q_col));
+    if (arcs.empty()) return {};
+  }
+  return arcs;
+}
+
+// Bounded-domain analogue of feasible_arcs (non-periodic).
+template <typename QScalar>
+Arcs feasible_arcs_bounded(QScalar&& q_scalar, const std::vector<int>& swept_joints,
+                           const std::vector<Arc>& limits, const std::vector<double>& grid) {
+  std::vector<std::vector<double>> q_grid(grid.size());
+  for (std::size_t k = 0; k < grid.size(); ++k) q_grid[k] = q_scalar(grid[k]);
+
+  Arcs arcs = {{grid.front(), grid.back()}};
+  for (int i : swept_joints) {
+    std::vector<double> q_col(grid.size());
+    for (std::size_t k = 0; k < grid.size(); ++k) q_col[k] = q_grid[k][i];
+    auto q_of = [&, i](double t) { return q_scalar(t)[i]; };
+    arcs = intersect(
+        arcs, arcs_for_joint_bounded(q_of, limits[i].first, limits[i].second, grid, q_col));
+    if (arcs.empty()) return {};
+  }
+  return arcs;
+}
+
+}  // namespace ssik::feasible

--- a/tests/test_feasible_arcs.py
+++ b/tests/test_feasible_arcs.py
@@ -1,0 +1,90 @@
+"""C++ feasible_arcs geometry vs the Python oracle (#515).
+
+feasible_arcs / feasible_arcs_bounded are the SHARED redundant-7R in-limits
+primitive: SRS swivel-limits (resolve_in_limits) and spherical_shoulder
+q6-redundancy both build on them. This fuzzes a synthetic two-harmonic joint
+family against ``ssik.solvers.seven_r._feasible_param`` -- the C++ port must
+reproduce every arc boundary exactly.
+
+Skips when the test-only extension isn't built (the cpp CI job builds it).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from ssik.solvers.seven_r._feasible_param import PARAM_GRID, feasible_arcs, feasible_arcs_bounded
+from tests._cpp_backend import _load_ext, cpp_available
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="ssik._ssik_native not built")
+
+_K = 7
+_N = 3000
+
+
+def _q_scalar(coeffs: np.ndarray):  # type: ignore[no-untyped-def]
+    def q(t: float) -> np.ndarray:
+        tt = np.asarray(t, dtype=np.float64)
+        out = (
+            coeffs[:, 0]
+            + coeffs[:, 1] * np.cos(tt)
+            + coeffs[:, 2] * np.sin(tt)
+            + coeffs[:, 3] * np.cos(2 * tt)
+            + coeffs[:, 4] * np.sin(2 * tt)
+        )
+        return np.asarray(out, dtype=np.float64)
+
+    return q
+
+
+def _match(a: list[Any], b: list[Any], tol: float = 1e-6) -> bool:
+    if len(a) != len(b):
+        return False
+    return all(
+        abs(x0 - y0) <= tol and abs(x1 - y1) <= tol
+        for (x0, x1), (y0, y1) in zip(sorted(a), sorted(b), strict=True)
+    )
+
+
+def test_feasible_arcs_matches_oracle() -> None:
+    ext = _load_ext()
+    rng = np.random.default_rng(0)
+    periodic_mismatch = bounded_mismatch = 0
+    multi = empty = 0
+    for _ in range(_N):
+        coeffs = rng.uniform(-1.5, 1.5, (_K, 5))
+        coeffs[:, 0] = rng.uniform(-np.pi, np.pi, _K)
+        lo = rng.uniform(-np.pi, np.pi, _K)
+        hi = lo + rng.uniform(0.1, 2.2 * np.pi, _K)  # mix of tight + unconstrained joints
+        swept = sorted(rng.choice(_K, size=rng.integers(1, _K + 1), replace=False).tolist())
+        limits = [(float(lo[i]), float(hi[i])) for i in range(_K)]
+        qs = _q_scalar(coeffs)
+        swept_arr = np.array(swept, dtype=np.int32)
+
+        q_grid = np.array([qs(g) for g in PARAM_GRID])
+        py_p = feasible_arcs(qs, q_grid, swept, limits, PARAM_GRID)
+        cpp_p = ext.feasible_arcs_test(
+            coeffs, swept_arr, lo, hi, PARAM_GRID.astype(np.float64), False
+        )
+        if not _match(py_p, cpp_p):
+            periodic_mismatch += 1
+        multi += len(py_p) >= 2
+        empty += len(py_p) == 0
+
+        a, b = sorted(rng.uniform(-np.pi, np.pi, 2).tolist())
+        b = max(b, a + 0.2)
+        bgrid = np.linspace(a, b, 120)
+        bq_grid = np.array([qs(g) for g in bgrid])
+        py_b = feasible_arcs_bounded(qs, bq_grid, swept, limits, bgrid)
+        cpp_b = ext.feasible_arcs_test(coeffs, swept_arr, lo, hi, bgrid.astype(np.float64), True)
+        if not _match(py_b, cpp_b):
+            bounded_mismatch += 1
+
+    assert periodic_mismatch == 0, f"{periodic_mismatch}/{_N} periodic feasible_arcs mismatches"
+    assert bounded_mismatch == 0, f"{bounded_mismatch}/{_N} bounded feasible_arcs mismatches"
+    # Sanity: the fuzz actually exercised the interesting branches.
+    assert multi > 100, f"only {multi} multi-arc cases -- fuzz not exercising arc splits"
+    assert empty > 100, f"only {empty} empty-arc cases -- fuzz not exercising infeasibility"


### PR DESCRIPTION
First, foundational piece of the self-contained SRS artifact (#515) -- and it's **shared infrastructure**, not SRS-only.

## Why this helps more than SRS
`feasible_arcs` / `feasible_arcs_bounded` (the exact feasible-parameter-arc geometry) underlie **every** redundant-7R in-limits resolution:
- **SRS** swivel-limits (`resolve_in_limits`, #359) -- periodic `feasible_arcs`.
- **spherical_shoulder** (Franka / FR3 / xArm7, the EAIK-gap differentiator) q6-redundancy -- `feasible_arcs_bounded`.
- (`seeded_track`, the other shared piece, spans all ~17 redundant-7R arms.)

So porting this once unlocks the SRS **and** Franka-family self-contained artifacts.

## What
- `cpp/include/ssik_cpp/seven_r/feasible_arcs.hpp` -- verbatim port (dependency-free numpy -> std): `wrap`, `bisect`, `merge`, `intersect`, `arcs_for_joint` (+ bounded), `feasible_arcs` (+ bounded), templated on the joint family `q_scalar(t)`.
- Test binding + `tests/test_feasible_arcs.py`: fuzz a synthetic two-harmonic joint family (K=7, random coeffs/limits/swept) vs the Python `_feasible_param` oracle, periodic + bounded. Runs in the `cpp` CI job.

## Bulletproof validation
```
8000 fuzz cases (K=7, random coeffs/limits/swept):
  periodic mismatches: 0
  bounded  mismatches: 0
  worst arc-boundary |C++ - Python|: 0.00e+00   (bit-identical)
  coverage: 2641 multi-arc, 3746 empty-arc cases
```
The whole pipeline (grid eval -> sign-bracket -> bisection -> merge/intersect) is bit-identical to Python.

## Next in #515
Port `resolve_in_limits` (the SRS swivel wrapper) + `seeded_track` on this foundation, bake `SrsConsts`, emit the self-contained SRS artifact, and strengthen the gate with near-limit + seeded poses so those paths are actually exercised.

Part of #482 / #496.