### PR TITLE
native=True covers every SRS arm automatically (canonical + general)

### DIFF
--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -91,6 +91,51 @@ py::tuple srs_canonical_solve_py(py::array_t<double> axes, py::array_t<double> t
   return py::make_tuple(qs, resids);
 }
 
+// Core general-path SRS analytical solve (#354): the Davenport sweep for
+// concurrent-axis arms the canonical path can't (offset/tilted wrist, non-ZYZ).
+// Same pre-finalize candidate contract as srs_canonical_solve; needs the
+// branch-enumeration extras (elbow_index, upper_home, forearm_home).
+py::tuple srs_general_solve_py(py::array_t<double> axes, py::array_t<double> t_left,
+                               py::array_t<double> t_right, py::array_t<int> types, double l_se,
+                               double l_ew, py::array_t<double> ee_offset,
+                               py::array_t<double> shoulder_pivot, py::array_t<double> r_post,
+                               int elbow_index, py::array_t<double> upper_home,
+                               py::array_t<double> forearm_home, py::array_t<double> target) {
+  const ssik::JointConsts<7> c = make_consts_n<7>(axes, t_left, t_right, types);
+  ssik::SrsConsts s;
+  s.l_se = l_se;
+  s.l_ew = l_ew;
+  s.elbow_index = elbow_index;
+  auto eo = ee_offset.unchecked<1>();
+  auto sp = shoulder_pivot.unchecked<1>();
+  auto uh = upper_home.unchecked<1>();
+  auto fh = forearm_home.unchecked<1>();
+  auto rp = r_post.unchecked<2>();
+  for (int i = 0; i < 3; ++i) {
+    s.ee_offset_local[i] = eo(i);
+    s.shoulder_pivot[i] = sp(i);
+    s.upper_home[i] = uh(i);
+    s.forearm_home[i] = fh(i);
+    for (int j = 0; j < 3; ++j) s.r_post_wrist(i, j) = rp(i, j);
+  }
+  auto tm = target.unchecked<2>();
+  ssik::Pose T;
+  for (int r = 0; r < 4; ++r)
+    for (int col = 0; col < 4; ++col) T(r, col) = tm(r, col);
+
+  const std::vector<ssik::Solution<7>> sols = ssik::srs_general_solve(c, s, T);
+  const int n = static_cast<int>(sols.size());
+  py::array_t<double> qs({n, 7});
+  py::array_t<double> resids(n);
+  auto qm = qs.mutable_unchecked<2>();
+  auto rm = resids.mutable_unchecked<1>();
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < 7; ++j) qm(i, j) = sols[i].q[j];
+    rm(i) = sols[i].fk_residual;
+  }
+  return py::make_tuple(qs, resids);
+}
+
 py::tuple three_parallel_solve_py(py::array_t<double> axes, py::array_t<double> t_left,
                                   py::array_t<double> t_right, py::array_t<int> types,
                                   py::array_t<double> target, bool allow_refinement,
@@ -419,6 +464,10 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("srs_canonical_solve", &srs_canonical_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("l_se"), py::arg("l_ew"), py::arg("ee_offset"),
         py::arg("shoulder_pivot"), py::arg("r_post_wrist"), py::arg("target"));
+  m.def("srs_general_solve", &srs_general_solve_py, py::arg("axes"), py::arg("t_left"),
+        py::arg("t_right"), py::arg("types"), py::arg("l_se"), py::arg("l_ew"), py::arg("ee_offset"),
+        py::arg("shoulder_pivot"), py::arg("r_post_wrist"), py::arg("elbow_index"),
+        py::arg("upper_home"), py::arg("forearm_home"), py::arg("target"));
   m.def("feasible_arcs_test", &feasible_arcs_test_py, py::arg("coeffs"), py::arg("swept"),
         py::arg("lo"), py::arg("hi"), py::arg("grid"), py::arg("bounded") = false);
   m.def("srs_resolve_in_limits", &srs_resolve_in_limits_py, py::arg("axes"), py::arg("t_left"),

--- a/scripts/cpp_emit.py
+++ b/scripts/cpp_emit.py
@@ -90,44 +90,13 @@ def _render_solve(solver: str, kb: KinBody) -> tuple[str, list[str]] | None:
 
 def _srs_bake(kb: KinBody) -> dict[str, Any] | None:
     """Bake the SrsConsts for a concurrent-axis SRS 7R arm, or None when the arm
-    is not SRS-class. ``general_path`` mirrors the Python ``use_canonical``
-    dispatch (reach_slack == 0): canonical-ZYZ + offset-free wrist -> canonical
-    fast-path, everything else (non-ZYZ shoulder/wrist, offset wrist) -> the
-    general Davenport path (#354). Both are self-contained in C++."""
-    from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY as pol
-    from ssik.solvers.seven_r.srs import (  # type: ignore[attr-defined]
-        _arm_constants,
-        _classify_srs_7r_geometric,
-    )
+    is not SRS-class. Delegates to :func:`ssik._native.srs_native_geometry` -- the
+    single source shared with the runtime ``native=True`` path -- so the emitted
+    self-contained artifact and the pip native backend always cover exactly the
+    same arms and route them the same way (``general_path``)."""
+    from ssik._native import srs_native_geometry
 
-    cls = _classify_srs_7r_geometric(kb, pol)
-    if cls is None or len(kb.joints) != 7:
-        return None
-    l_se, l_ew, ee_offset, origins = _arm_constants(kb, cls)
-    j = kb.joints
-    upper = origins[cls.elbow_index] - cls.shoulder_pivot
-    u_home = upper / np.linalg.norm(upper)
-    ez, ey = np.array([0.0, 0.0, 1.0]), np.array([0.0, 1.0, 0.0])
-    canonical = (
-        np.allclose(j[0].axis, ez)
-        and np.allclose(j[1].axis, ey)
-        and np.allclose(u_home, ez)
-        and np.allclose(j[4].axis, ez)
-        and np.allclose(j[5].axis, ey)
-        and np.allclose(j[6].axis, ez)
-    )
-    offset_free = np.allclose(origins[5], cls.wrist_pivot, atol=pol.axis_intersect)
-    return {
-        "l_se": float(l_se),
-        "l_ew": float(l_ew),
-        "ee_offset_local": np.asarray(ee_offset, dtype=np.float64),
-        "shoulder_pivot": np.asarray(cls.shoulder_pivot, dtype=np.float64),
-        "r_post_wrist": np.asarray(j[6].T_right[:3, :3], dtype=np.float64),
-        "elbow_index": int(cls.elbow_index),
-        "upper_home": np.asarray(upper, dtype=np.float64),
-        "forearm_home": np.asarray(cls.wrist_pivot - origins[cls.elbow_index], dtype=np.float64),
-        "general_path": not (canonical and offset_free),
-    }
+    return srs_native_geometry(kb)
 
 
 def _render_srs_solve(kb: KinBody) -> tuple[str, list[str]] | None:

--- a/src/ssik/_native.py
+++ b/src/ssik/_native.py
@@ -147,52 +147,79 @@ def try_native_solve(
     ]
 
 
-# Per-KinBody native-SRS metadata: (is_canonical, marshalled args) or None. The
-# canonical-ZYZ + offset-free check + the SRS geometric constants are geometry-
-# only, so cache per-arm (keyed on id(kb)).
-_srs_cache: dict[int, Any] = {}
+# Per-KinBody native-SRS args (baked geometry + marshalled JointConsts) or None.
+# Geometry-only, so cache per-arm (keyed on the long-lived artifact _KB's id).
+_srs_cache: dict[int, dict[str, Any] | None] = {}
 
 
-def _srs_native_args(kb: Any) -> Any:
-    """Marshalled srs_canonical_solve args for a canonical SRS arm, or None when
-    the arm isn't the canonical-ZYZ offset-free path the native core supports."""
-    if id(kb) in _srs_cache:
-        return _srs_cache[id(kb)]
+def srs_native_geometry(kb: Any) -> dict[str, Any] | None:
+    """Baked SRS geometry (the SrsConsts fields + the canonical/general dispatch
+    flag) for ANY concurrent-axis SRS 7R arm, or None when the arm is not
+    SRS-class. Single source of truth shared by the runtime native path
+    (:func:`_srs_native_args` / :func:`try_native_srs_algebraic`) AND the C++
+    emit (``scripts/cpp_emit._srs_bake``), so the pip ``native=True`` backend and
+    the self-contained artifact always cover exactly the same arms -- adding an
+    SRS arm enrols it in both automatically.
+
+    ``general_path`` mirrors the Python ``use_canonical`` dispatch (reach_slack
+    == 0): canonical-ZYZ + offset-free wrist -> the canonical fast-path core,
+    everything else (non-ZYZ shoulder/wrist, laterally-offset wrist) -> the
+    general Davenport core (#354). Both are native.
+    """
     from ssik.core.tolerances import DEFAULT_TOLERANCE_POLICY as _POL
     from ssik.solvers.seven_r.srs import (  # type: ignore[attr-defined]
         _arm_constants,
         _classify_srs_7r_geometric,
     )
 
-    result = None
     cls = _classify_srs_7r_geometric(kb, _POL)
-    if cls is not None and len(kb.joints) == 7:
-        l_se, l_ew, ee_offset, origins = _arm_constants(kb, cls)
-        upper = origins[cls.elbow_index] - cls.shoulder_pivot
-        u_home = upper / np.linalg.norm(upper)
+    if cls is None or len(kb.joints) != 7:
+        return None
+    l_se, l_ew, ee_offset, origins = _arm_constants(kb, cls)
+    j = kb.joints
+    upper = origins[cls.elbow_index] - cls.shoulder_pivot
+    u_home = upper / np.linalg.norm(upper)
+    ez, ey = np.array([0.0, 0.0, 1.0]), np.array([0.0, 1.0, 0.0])
+    canonical = (
+        np.allclose(j[0].axis, ez)
+        and np.allclose(j[1].axis, ey)
+        and np.allclose(u_home, ez)
+        and np.allclose(j[4].axis, ez)
+        and np.allclose(j[5].axis, ey)
+        and np.allclose(j[6].axis, ez)
+    )
+    offset_free = np.allclose(origins[5], cls.wrist_pivot, atol=_POL.axis_intersect)
+    return {
+        "l_se": float(l_se),
+        "l_ew": float(l_ew),
+        "ee_offset_local": np.asarray(ee_offset, dtype=np.float64),
+        "shoulder_pivot": np.asarray(cls.shoulder_pivot, dtype=np.float64),
+        "r_post_wrist": np.asarray(j[6].T_right[:3, :3], dtype=np.float64),
+        "elbow_index": int(cls.elbow_index),
+        "upper_home": np.asarray(upper, dtype=np.float64),
+        "forearm_home": np.asarray(cls.wrist_pivot - origins[cls.elbow_index], dtype=np.float64),
+        "general_path": not (canonical and offset_free),
+    }
+
+
+def _srs_native_args(kb: Any) -> dict[str, Any] | None:
+    """Cached :func:`srs_native_geometry` + the marshalled JointConsts arrays for
+    the binding, or None when the arm isn't SRS-class."""
+    if id(kb) in _srs_cache:
+        return _srs_cache[id(kb)]
+    geom = srs_native_geometry(kb)
+    result: dict[str, Any] | None = None
+    if geom is not None:
         j = kb.joints
-        ez, ey = np.array([0.0, 0.0, 1.0]), np.array([0.0, 1.0, 0.0])
-        canonical = (
-            np.allclose(j[0].axis, ez)
-            and np.allclose(j[1].axis, ey)
-            and np.allclose(u_home, ez)
-            and np.allclose(j[4].axis, ez)
-            and np.allclose(j[5].axis, ey)
-            and np.allclose(j[6].axis, ez)
-        )
-        offset_free = np.allclose(origins[5], cls.wrist_pivot, atol=_POL.axis_intersect)
-        if canonical and offset_free:
-            result = (
-                np.array([jt.axis for jt in j], dtype=np.float64),
-                np.array([jt.T_left for jt in j], dtype=np.float64),
-                np.array([jt.T_right for jt in j], dtype=np.float64),
-                np.array([0 if jt.joint_type == "revolute" else 1 for jt in j], dtype=np.int32),
-                float(l_se),
-                float(l_ew),
-                np.asarray(ee_offset, dtype=np.float64),
-                np.asarray(cls.shoulder_pivot, dtype=np.float64),
-                np.asarray(j[6].T_right[:3, :3], dtype=np.float64),
-            )
+        result = {
+            "axes": np.array([jt.axis for jt in j], dtype=np.float64),
+            "t_left": np.array([jt.T_left for jt in j], dtype=np.float64),
+            "t_right": np.array([jt.T_right for jt in j], dtype=np.float64),
+            "types": np.array(
+                [0 if jt.joint_type == "revolute" else 1 for jt in j], dtype=np.int32
+            ),
+            **geom,
+        }
     _srs_cache[id(kb)] = result
     return result
 
@@ -204,30 +231,49 @@ def try_native_srs_algebraic(
 
     Returns the deduped, FK-verified analytical candidate set (pre-finalize) --
     the Python artifact keeps the seeded-track / limits / resolve_in_limits /
-    finalize postprocess around it. Supports the canonical-ZYZ offset-free path
-    (iiwa14 / xmatepro7); other SRS arms (offset/tilted wrist) return None.
+    finalize postprocess around it. Covers EVERY concurrent-axis SRS arm: the
+    canonical-ZYZ offset-free core (iiwa14 / xmatepro7) and the general Davenport
+    core (#354; iiwa7 / r1pro / openarm), dispatched on the baked ``general_path``
+    flag so no arm silently falls back to Python.
     """
     if solver_name != "seven_r.srs":
         return None
     ext = _load_ext()
     if ext is None:
         return None
-    args = _srs_native_args(kb)
-    if args is None:
+    a = _srs_native_args(kb)
+    if a is None:
         return None
-    axes, t_left, t_right, types, l_se, l_ew, ee_offset, shoulder_pivot, r_post = args
-    qs, resids = ext.srs_canonical_solve(
-        axes,
-        t_left,
-        t_right,
-        types,
-        l_se,
-        l_ew,
-        ee_offset,
-        shoulder_pivot,
-        r_post,
-        np.asarray(t_target, dtype=np.float64),
-    )
+    tt = np.asarray(t_target, dtype=np.float64)
+    if a["general_path"]:
+        qs, resids = ext.srs_general_solve(
+            a["axes"],
+            a["t_left"],
+            a["t_right"],
+            a["types"],
+            a["l_se"],
+            a["l_ew"],
+            a["ee_offset_local"],
+            a["shoulder_pivot"],
+            a["r_post_wrist"],
+            a["elbow_index"],
+            a["upper_home"],
+            a["forearm_home"],
+            tt,
+        )
+    else:
+        qs, resids = ext.srs_canonical_solve(
+            a["axes"],
+            a["t_left"],
+            a["t_right"],
+            a["types"],
+            a["l_se"],
+            a["l_ew"],
+            a["ee_offset_local"],
+            a["shoulder_pivot"],
+            a["r_post_wrist"],
+            tt,
+        )
     return [
         Solution(q=np.asarray(qs[i], dtype=np.float64), fk_residual=float(resids[i]))
         for i in range(len(qs))

--- a/tests/test_native_srs_coverage.py
+++ b/tests/test_native_srs_coverage.py
@@ -1,0 +1,73 @@
+"""Every SRS-class arm is native=True accelerated, and native matches non-native.
+
+Guards the invariant that the pip ``native=True`` backend covers EVERY concurrent-
+axis SRS arm -- the canonical-ZYZ core (iiwa14/xmatepro7) AND the general
+Davenport core (#354; iiwa7/r1pro/openarm) -- with no silent Python fallback, and
+that the native path is bit-for-bit set-equivalent to the pure-Python solve. If a
+future change re-narrows the native gate (as it once did, only covering canonical
+arms), this turns red.
+
+Skips when the test-only extension isn't built (the cpp CI job builds it).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from ssik._native import srs_native_geometry, try_native_srs_algebraic
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.prebuilt._manifest import load_manifest
+from tests._cpp_backend import cpp_available
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="ssik._ssik_native not built")
+
+# Every shipped seven_r.srs prebuilt (the family whose native core this covers).
+_SRS_ARMS = sorted(a.name for a in load_manifest().values() if a.solver == "seven_r.srs")
+
+
+def _wrap_linf(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.max(np.abs((a - b + np.pi) % (2 * np.pi) - np.pi)))
+
+
+def _agree(x: list[np.ndarray], y: list[np.ndarray], tol: float = 1e-6) -> bool:
+    if len(x) != len(y):
+        return False
+    used = [False] * len(y)
+    for a in x:
+        for k, b in enumerate(y):
+            if not used[k] and _wrap_linf(a, b) <= tol:
+                used[k] = True
+                break
+        else:
+            return False
+    return True
+
+
+@pytest.mark.parametrize("arm", _SRS_ARMS)
+def test_native_covers_and_matches(arm: str) -> None:
+    mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+    kb = mod._KB
+    assert srs_native_geometry(kb) is not None, f"{arm}: SRS arm not enrolled in the native gate"
+
+    lims = [
+        (float(j.limits[0]), float(j.limits[1])) if j.limits else (-np.pi, np.pi) for j in kb.joints
+    ]
+    rng = np.random.default_rng(0)
+    routed_native = mismatch = nonempty = 0
+    for _ in range(60):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in lims])
+        T = poe_forward_kinematics(kb, q)
+        if try_native_srs_algebraic("seven_r.srs", kb, np.asarray(T)) is not None:
+            routed_native += 1
+        na = [np.asarray(s.q) for s in mod.solve(T, native=True)]
+        py = [np.asarray(s.q) for s in mod.solve(T, native=False)]
+        if not _agree(na, py):
+            mismatch += 1
+        nonempty += len(py) > 0
+
+    assert routed_native == 60, f"{arm}: native core did not fire on {60 - routed_native}/60 poses"
+    assert mismatch == 0, f"{arm}: native != non-native on {mismatch}/60 poses"
+    assert nonempty > 45, f"{arm}: only {nonempty}/60 nonempty -- fuzz not exercising the arm"


### PR DESCRIPTION
## Why

The pip `native=True` runtime path accelerated only the canonical-ZYZ offset-free SRS core (iiwa14/xmatepro7). The general Davenport arms (iiwa7 offset wrist, r1pro/openarm non-ZYZ) **silently fell back to Python** even though their self-contained C++ artifact already shipped — the emit gate and the runtime gate had drifted apart.

## What

**One eligibility source.** `ssik._native.srs_native_geometry` is now the single source of the baked SRS fields + the `general_path` dispatch flag, used by **both** the runtime path (`_srs_native_args` / `try_native_srs_algebraic`) and the C++ emit (`cpp_emit._srs_bake`). Any SRS-class arm routes `native=True` to the C++ core — canonical or general, dispatched on the baked flag — and any SRS arm added later enrols in both automatically. They can never drift again.

- New `srs_general_solve` binding (analytical, pre-finalize candidates), mirroring `srs_canonical_solve`; `try_native_srs_algebraic` dispatches on `general_path`.
- The general SRS prebuilts already carry the native hook, so this needs **zero prebuilt re-emit** and no artifact change — `cpp_emit --check` confirms the emitted headers are byte-identical (pure delegation).

## Result

| arm | before | after |
|---|---|---|
| iiwa14, xmatepro7 (canonical) | C++ | C++ |
| **iiwa7, r1pro, openarm (general)** | **Python fallback** | **C++** |

## Test plan

- `test_native_srs_coverage` (new guard): every `seven_r.srs` prebuilt fires the native core on every pose **and** `native == non-native` (wrap-close set agreement). Turns red if the gate ever re-narrows.
- Verified 7 SRS arms native-accelerated + matching; native + dispatch + srs + cpp-parity suites green (80 tests); `--check` drift guard green; ruff + mypy clean.

Closes the runtime half of the SRS native coverage. `native=True` is now automatic for all geometric 6R families and all SRS arms. Remaining non-native families: `srs_polished`, `spherical_shoulder`, and the emit-only RR/HP (#490/#491).

🤖 Generated with [Claude Code](https://claude.com/claude-code)