### PR TITLE
SRS native=True runs the full C++ artifact (20-53x, was 5-9x)

### DIFF
--- a/src/ssik/_native.py
+++ b/src/ssik/_native.py
@@ -21,9 +21,9 @@ from numpy.typing import NDArray
 from ssik.core.solution import Solution
 
 # Solver families with a native implementation in _ssik_native. The 6R geometric
-# families expose the full artifact contract via try_native_solve; seven_r.srs
-# exposes only its analytical sweep via try_native_srs_algebraic (the Python
-# wrapper keeps seeded-track / resolve_in_limits / finalize).
+# families run the full artifact via try_native_solve; seven_r.srs runs the full
+# artifact via try_native_srs_solve (seeded-track + canonical/general core +
+# finalize + in-limits fallback, all native).
 _NATIVE_SOLVERS = frozenset({"ikgeo.three_parallel", "ikgeo.spherical_two_parallel", "seven_r.srs"})
 
 _ext: Any = None
@@ -156,7 +156,7 @@ def srs_native_geometry(kb: Any) -> dict[str, Any] | None:
     """Baked SRS geometry (the SrsConsts fields + the canonical/general dispatch
     flag) for ANY concurrent-axis SRS 7R arm, or None when the arm is not
     SRS-class. Single source of truth shared by the runtime native path
-    (:func:`_srs_native_args` / :func:`try_native_srs_algebraic`) AND the C++
+    (:func:`_srs_native_args` / :func:`try_native_srs_solve`) AND the C++
     emit (``scripts/cpp_emit._srs_bake``), so the pip ``native=True`` backend and
     the self-contained artifact always cover exactly the same arms -- adding an
     SRS arm enrols it in both automatically.
@@ -218,23 +218,38 @@ def _srs_native_args(kb: Any) -> dict[str, Any] | None:
             "types": np.array(
                 [0 if jt.joint_type == "revolute" else 1 for jt in j], dtype=np.int32
             ),
+            # Joint limits for the full-artifact native path (finalize's box).
+            "lo": np.array([jt.limits[0] if jt.limits else 0.0 for jt in j], dtype=np.float64),
+            "hi": np.array([jt.limits[1] if jt.limits else 0.0 for jt in j], dtype=np.float64),
+            "has_limits": np.array([1 if jt.limits else 0 for jt in j], dtype=np.int32),
             **geom,
         }
     _srs_cache[id(kb)] = result
     return result
 
 
-def try_native_srs_algebraic(
-    solver_name: str, kb: Any, t_target: NDArray[np.float64]
+def try_native_srs_solve(
+    solver_name: str,
+    kb: Any,
+    t_target: NDArray[np.float64],
+    *,
+    respect_limits: bool = True,
+    q_seed: NDArray[np.float64] | None = None,
+    seed_metric: str = "wrap_linf",
+    seed_tolerance: float | None = None,
+    max_solutions: int | None = None,
+    allow_rescue: bool = True,
+    refinement_max_iters: int = 15,
 ) -> list[Solution] | None:
-    """Native SRS analytical sweep (the expensive part), or None to fall back.
+    """FULL native SRS artifact solve (the whole ``<arm>.solve()`` contract in
+    C++), or ``None`` to fall back. Runs the entire pipeline natively via
+    ``srs_artifact_solve`` -- seeded-track fast path, canonical/general core,
+    finalize (limits -> seed -> truncate), and the #359 in-limits fallback -- so
+    the Python postprocess (which dominated the per-call time) is skipped.
 
-    Returns the deduped, FK-verified analytical candidate set (pre-finalize) --
-    the Python artifact keeps the seeded-track / limits / resolve_in_limits /
-    finalize postprocess around it. Covers EVERY concurrent-axis SRS arm: the
-    canonical-ZYZ offset-free core (iiwa14 / xmatepro7) and the general Davenport
-    core (#354; iiwa7 / r1pro / openarm), dispatched on the baked ``general_path``
-    flag so no arm silently falls back to Python.
+    The T-perturbation rescue is omitted (proven dormant for SRS + guarded), same
+    as the 6R native path. Parity with the Python solve is validated across the
+    full contract in tests/test_srs_artifact_cpp.py + test_srs_general_cpp.py.
     """
     if solver_name != "seven_r.srs":
         return None
@@ -244,37 +259,41 @@ def try_native_srs_algebraic(
     a = _srs_native_args(kb)
     if a is None:
         return None
-    tt = np.asarray(t_target, dtype=np.float64)
-    if a["general_path"]:
-        qs, resids = ext.srs_general_solve(
-            a["axes"],
-            a["t_left"],
-            a["t_right"],
-            a["types"],
-            a["l_se"],
-            a["l_ew"],
-            a["ee_offset_local"],
-            a["shoulder_pivot"],
-            a["r_post_wrist"],
-            a["elbow_index"],
-            a["upper_home"],
-            a["forearm_home"],
-            tt,
-        )
-    else:
-        qs, resids = ext.srs_canonical_solve(
-            a["axes"],
-            a["t_left"],
-            a["t_right"],
-            a["types"],
-            a["l_se"],
-            a["l_ew"],
-            a["ee_offset_local"],
-            a["shoulder_pivot"],
-            a["r_post_wrist"],
-            tt,
-        )
+    has_seed = q_seed is not None
+    seed_arr = np.asarray(q_seed, dtype=np.float64) if has_seed else np.zeros(7, np.float64)
+    qs, resids, refine = ext.srs_artifact_solve(
+        a["axes"],
+        a["t_left"],
+        a["t_right"],
+        a["types"],
+        a["l_se"],
+        a["l_ew"],
+        a["ee_offset_local"],
+        a["shoulder_pivot"],
+        a["r_post_wrist"],
+        a["elbow_index"],
+        a["upper_home"],
+        a["forearm_home"],
+        a["lo"],
+        a["hi"],
+        a["has_limits"],
+        np.asarray(t_target, dtype=np.float64),
+        a["general_path"],
+        respect_limits,
+        has_seed,
+        seed_arr,
+        seed_metric,
+        seed_tolerance is not None,
+        seed_tolerance if seed_tolerance is not None else 0.0,
+        max_solutions if max_solutions is not None else -1,
+        allow_rescue,
+        refinement_max_iters,
+    )
     return [
-        Solution(q=np.asarray(qs[i], dtype=np.float64), fk_residual=float(resids[i]))
+        Solution(
+            q=np.asarray(qs[i], dtype=np.float64),
+            fk_residual=float(resids[i]),
+            refinement_used="lm" if int(refine[i]) == 1 else "none",
+        )
         for i in range(len(qs))
     ]

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -179,15 +179,15 @@ def _render_thin_wrapper(
     )
     buf.write(f"from {_resolver_module} import resolve_in_limits as _resolve_in_limits\n")
     buf.write(f"from {solver_module} import solve as _solver_solve\n")
-    # Opt-in native (C++) dispatch (#512) for thin-wrapper families with a native
-    # core (seven_r.srs canonical path). solve(..., native=True) replaces the
-    # analytical sweep with ssik._ssik_native and reuses the Python postprocess
-    # (seeded-track / limits / seed / resolve_in_limits). Falls back silently.
+    # Opt-in native (C++) dispatch for thin-wrapper families with a native core
+    # (seven_r.srs, canonical + general #354). solve(..., native=True) runs the
+    # WHOLE artifact in C++ via ssik._ssik_native -- seeded-track, the analytical
+    # core, finalize (limits/seed/truncate), and the #359 in-limits fallback -- so
+    # the Python postprocess (which dominated per-call time) is skipped. Returns
+    # early on success, else falls back silently to the Python path below.
     emit_native = plan.solver_name in _NATIVE_SOLVER_FAMILIES
     if emit_native:
-        buf.write(
-            "from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic\n"
-        )
+        buf.write("from ssik._native import try_native_srs_solve as _try_native_srs_solve\n")
     buf.write("\n")
     buf.write(f'SOLVER_NAME = "{plan.solver_name}"\n')
     buf.write(f"SOLVER_TIER = {plan.tier}\n")
@@ -1518,34 +1518,34 @@ def _render_solve_function(solver_short: str, emit_native: bool = False) -> str:
         """
     )
     if emit_native:
-        # Add the `native` kwarg + replace the analytical sweep with the native
-        # core (when available), reusing the Python postprocess. Only families
-        # with a native thin-wrapper core opt in; others stay byte-identical.
+        # Add the `native` kwarg + inject a top-of-body early dispatch to the FULL
+        # C++ artifact (whole pipeline, not just the analytical sweep). Only
+        # families with a native thin-wrapper core opt in; others stay
+        # byte-identical.
         template = template.replace(
             "    seed_tolerance: float | None = None,\n):",
             "    seed_tolerance: float | None = None,\n    native: bool = False,\n):",
         )
         template = template.replace(
-            "    sols, _is_ls = _solver_solve(\n"
-            "        _KB,\n"
-            "        T_target,\n"
-            "        policy=policy,\n"
-            "        allow_refinement=allow_refinement,\n"
-            "        refinement_max_iters=refinement_max_iters,\n"
-            "    )",
-            "    _native_sols = (\n"
-            "        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None\n"
-            "    )\n"
-            "    if _native_sols is not None:\n"
-            "        sols = _native_sols\n"
-            "    else:\n"
-            "        sols, _is_ls = _solver_solve(\n"
+            "    if seed_tolerance is not None and q_seed is None:\n"
+            '        raise ValueError("seed_tolerance requires q_seed")\n',
+            "    if seed_tolerance is not None and q_seed is None:\n"
+            '        raise ValueError("seed_tolerance requires q_seed")\n'
+            "    if native:\n"
+            "        _native_sols = _try_native_srs_solve(\n"
+            "            SOLVER_NAME,\n"
             "            _KB,\n"
             "            T_target,\n"
-            "            policy=policy,\n"
-            "            allow_refinement=allow_refinement,\n"
+            "            respect_limits=respect_limits,\n"
+            "            q_seed=q_seed,\n"
+            "            seed_metric=seed_metric,\n"
+            "            seed_tolerance=seed_tolerance,\n"
+            "            max_solutions=max_solutions,\n"
+            "            allow_rescue=allow_rescue,\n"
             "            refinement_max_iters=refinement_max_iters,\n"
-            "        )",
+            "        )\n"
+            "        if _native_sols is not None:\n"
+            "            return _native_sols\n",
         )
     return template
 

--- a/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/kuka/iiwa14_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa14_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/kuka/iiwa7_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa7_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/openarm/left_ik.py
+++ b/src/ssik/prebuilt/openarm/left_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/openarm/right_ik.py
+++ b/src/ssik/prebuilt/openarm/right_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/src/ssik/prebuilt/rokae/xmatepro7_ik.py
+++ b/src/ssik/prebuilt/rokae/xmatepro7_ik.py
@@ -50,7 +50,7 @@ from ssik.refinement import seeded_track as _seeded_track
 from ssik.refinement.rescue import rescue_via_T_perturbation as _rescue_via_T_perturbation
 from ssik.solvers.seven_r._swivel_limits import resolve_in_limits as _resolve_in_limits
 from ssik.solvers.seven_r.srs import solve as _solver_solve
-from ssik._native import try_native_srs_algebraic as _try_native_srs_algebraic
+from ssik._native import try_native_srs_solve as _try_native_srs_solve
 
 SOLVER_NAME = "seven_r.srs"
 SOLVER_TIER = 0
@@ -212,6 +212,21 @@ def solve(
     """
     if seed_tolerance is not None and q_seed is None:
         raise ValueError("seed_tolerance requires q_seed")
+    if native:
+        _native_sols = _try_native_srs_solve(
+            SOLVER_NAME,
+            _KB,
+            T_target,
+            respect_limits=respect_limits,
+            q_seed=q_seed,
+            seed_metric=seed_metric,
+            seed_tolerance=seed_tolerance,
+            max_solutions=max_solutions,
+            allow_rescue=allow_rescue,
+            refinement_max_iters=refinement_max_iters,
+        )
+        if _native_sols is not None:
+            return _native_sols
     # Seeded numerical-tracking fast path (#380): the caller gave a seed
     # and wants a single IK -- the trajectory-tracking idiom. Newton-
     # continue from the seed (~0.2 ms) instead of resolving the whole
@@ -245,19 +260,13 @@ def solve(
             )
             if _fast:
                 return _fast
-    _native_sols = (
-        _try_native_srs_algebraic(SOLVER_NAME, _KB, T_target) if native else None
+    sols, _is_ls = _solver_solve(
+        _KB,
+        T_target,
+        policy=policy,
+        allow_refinement=allow_refinement,
+        refinement_max_iters=refinement_max_iters,
     )
-    if _native_sols is not None:
-        sols = _native_sols
-    else:
-        sols, _is_ls = _solver_solve(
-            _KB,
-            T_target,
-            policy=policy,
-            allow_refinement=allow_refinement,
-            refinement_max_iters=refinement_max_iters,
-        )
     # Bulletproof fallback (#319 / #358): the analytical path found
     # nothing. If the target is within the arm's max reach it may be a
     # measure-zero degenerate pose (near-singular elbow/gimbal, or a

--- a/tests/test_native_srs_coverage.py
+++ b/tests/test_native_srs_coverage.py
@@ -17,7 +17,7 @@ import importlib
 import numpy as np
 import pytest
 
-from ssik._native import srs_native_geometry, try_native_srs_algebraic
+from ssik._native import srs_native_geometry, try_native_srs_solve
 from ssik.kinematics.poe_fk import poe_forward_kinematics
 from ssik.prebuilt._manifest import load_manifest
 from tests._cpp_backend import cpp_available
@@ -60,7 +60,7 @@ def test_native_covers_and_matches(arm: str) -> None:
     for _ in range(60):
         q = np.array([rng.uniform(lo, hi) for lo, hi in lims])
         T = poe_forward_kinematics(kb, q)
-        if try_native_srs_algebraic("seven_r.srs", kb, np.asarray(T)) is not None:
+        if try_native_srs_solve("seven_r.srs", kb, np.asarray(T)) is not None:
             routed_native += 1
         na = [np.asarray(s.q) for s in mod.solve(T, native=True)]
         py = [np.asarray(s.q) for s in mod.solve(T, native=False)]


### PR DESCRIPTION
## Why

`native=True` for SRS arms previously swapped only the analytical sweep for C++ and kept the Python postprocess (`seeded_track` / `finalize` / `resolve_in_limits`) — which then dominated per-call time (73–83%), capping the speedup at ~5–9×. The whole pipeline is already ported and gated (`srs_artifact_solve`), so there was no reason not to run all of it natively, like the 6R geometric families do.

## What

- **`try_native_srs_solve`**: the full-artifact native path — seeded-track fast path, canonical/general core, finalize (limits/seed/truncate), and the #359 in-limits fallback — dispatched on the baked `general_path` flag. Rescue omitted (proven dormant + guarded), same as the 6R native path.
- **Codegen hook** switched from the mid-body analytical-swap to a top-of-`solve()` early return (mirrors the 6R `_NATIVE_HOOK`). All 7 `seven_r.srs` prebuilts regenerated; the `native=False` fallback path is unchanged.
- Removed the now-dead `try_native_srs_algebraic` (superseded).

## Result (300 poses/arm)

| arm | old Python | full native | speedup | (was, split path) |
|---|---|---|---|---|
| iiwa14 | 11.0 ms | **0.31 ms** | **35×** | 9× |
| xmatepro7 | 9.9 ms | **0.50 ms** | **20×** | 9.5× |
| iiwa7 | 13.1 ms | **0.55 ms** | **24×** | 7.5× |
| r1pro | 11.7 ms | **0.22 ms** | **53×** | 6.4× |
| openarm | 10.6 ms | **0.31 ms** | **34×** | 5.3× |

Per-call is now ~0.2–0.5 ms (was ~1–1.8 ms) — the Python postprocess is gone, landing SRS in the 6R families' speedup range.

## Test plan

- `test_native_srs_coverage` (updated to probe the full path): every `seven_r.srs` prebuilt fires the native core on every pose **and** `native == non-native`.
- Prebuilt↔live parity + native dispatch + SRS + swivel-limits suites green (152 passed, 3 expected skips); ruff + mypy clean; prebuilts are ruff-excluded and regenerated deterministically.

With this, `native=True` runs the **whole** solve in C++ for every arm that has a native core — all 6R geometric families and all SRS arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)