### PR TITLE
Port the T-perturbation rescue to C++ so the standalone artifact is complete (#319)

### DIFF
--- a/cpp/include/ssik_cpp/rescue.hpp
+++ b/cpp/include/ssik_cpp/rescue.hpp
@@ -1,0 +1,128 @@
+// Family-agnostic T-perturbation rescue (#319), ported from
+// ssik.refinement.rescue.rescue_via_T_perturbation. Recovers IK at reachable
+// but rank-deficient poses (kinematic singularities) where the closed-form
+// analytical extraction returns nothing: perturb T_target by small random SE(3)
+// increments (off the rank-deficient ridge), re-solve the analytical core at
+// each perturbed pose, then Newton-polish every candidate back to the original
+// T_target. Returns the unique FK-closing solutions.
+//
+// Like the Python original this is SOLVER-AGNOSTIC: the analytical core is a
+// callable, so one implementation serves every family (three_parallel /
+// spherical / SRS now; RR / HP when they gain native cores). Each
+// <family>_artifact_solve wires it in by passing its own core.
+//
+// RNG note: this uses a portable std PRNG, NOT numpy's PCG64, so at a singular
+// pose (where the solution set is an ill-posed continuum sampled via the
+// perturbations) the recovered SET differs from Python's -- both are sound
+// (every solution FK-closes), which is the only meaningful contract there
+// (#56). On the non-singular poses that dominate, rescue never fires, so the
+// artifact stays bit-for-bit with Python.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "ssik_cpp/fk.hpp"
+#include "ssik_cpp/newton.hpp"  // lm_refine
+#include "ssik_cpp/rotation.hpp"
+
+namespace ssik {
+
+// Reach-sphere upper bound (sum of all link translation norms) -- the rescue
+// gate. A triangle-inequality bound, so it never rejects a reachable pose; it
+// only keeps far-field unreachable targets from paying for a rescue attempt.
+template <int N>
+double reach_radius(const JointConsts<N>& c) {
+  double r = 0.0;
+  for (int i = 0; i < N; ++i) {
+    r += c.t_left[i].template block<3, 1>(0, 3).norm();
+    r += c.t_right[i].template block<3, 1>(0, 3).norm();
+  }
+  return r;
+}
+
+struct RescueParams {
+  int n_perturbations = 16;
+  double perturbation_scale_m = 5e-3;
+  double perturbation_scale_rad = 5e-3;
+  std::array<double, 4> scale_multipliers = {1.0, 2.0, 4.0, 10.0};
+  double fk_atol = 1e-8;
+  int refinement_max_iters = 20;
+  double dedup_atol = 1e-4;
+  std::uint64_t seed = 20260608;
+};
+
+namespace rescue_detail {
+
+// ||wrap_to_pi(a - b)||_2, the dedup metric.
+template <int N>
+double wrap_dist(const std::array<double, N>& a, const std::array<double, N>& b) {
+  double s = 0.0;
+  for (int i = 0; i < N; ++i) {
+    double d = std::fmod(a[i] - b[i] + M_PI, 2.0 * M_PI);
+    if (d < 0.0) d += 2.0 * M_PI;
+    d -= M_PI;
+    s += d * d;
+  }
+  return std::sqrt(s);
+}
+
+}  // namespace rescue_detail
+
+// solve_fn: (const Pose&) -> vector<Solution<N>>, the arm's analytical core
+// evaluated at a perturbed pose (identical role to Python's solve_fn). Returns
+// the FK-closing, deduped solutions rescued back to T_target; empty if none.
+template <int N, typename SolveFn>
+std::vector<Solution<N>> rescue_via_T_perturbation(SolveFn&& solve_fn, const JointConsts<N>& c,
+                                                   const Pose& T_target,
+                                                   const RescueParams& p = {}) {
+  std::mt19937_64 rng(p.seed);
+  std::normal_distribution<double> normal(0.0, 1.0);
+  const double tight = std::min(1e-12, p.fk_atol);
+
+  std::vector<Solution<N>> refined;
+  std::vector<std::array<double, N>> refined_qs;
+
+  for (int i = 0; i < p.n_perturbations; ++i) {
+    const double mult = p.scale_multipliers[i % p.scale_multipliers.size()];
+    // Draw dx (translation) then w (so3), matching the Python draw order.
+    Eigen::Vector3d dx, w;
+    for (int k = 0; k < 3; ++k) dx[k] = normal(rng) * p.perturbation_scale_m * mult;
+    for (int k = 0; k < 3; ++k) w[k] = normal(rng) * p.perturbation_scale_rad * mult;
+    const double angle = w.norm();
+    Eigen::Matrix3d R_delta = Eigen::Matrix3d::Identity();
+    if (angle > 0.0) R_delta = rotation_matrix(w / angle, angle);
+    Pose dT = Pose::Identity();
+    dT.block<3, 3>(0, 0) = R_delta;
+    dT.block<3, 1>(0, 3) = dx;
+    const Pose T_pert = T_target * dT;
+
+    const std::vector<Solution<N>> pert = solve_fn(T_pert);
+    for (const auto& sol : pert) {
+      // Polish back to the ORIGINAL T_target: tight (machine precision) then a
+      // loose retry for candidates that only reach fk_atol on a genuine ridge.
+      auto r = lm_refine<N>(c, sol.q, T_target, tight, p.refinement_max_iters);
+      if (!r) r = lm_refine<N>(c, sol.q, T_target, p.fk_atol, p.refinement_max_iters);
+      if (!r || r->second > p.fk_atol) continue;
+
+      bool dup = false;
+      for (const auto& e : refined_qs)
+        if (rescue_detail::wrap_dist<N>(r->first, e) < p.dedup_atol) {
+          dup = true;
+          break;
+        }
+      if (dup) continue;
+      refined.push_back(Solution<N>{r->first, r->second, Refinement::Rescue});
+      refined_qs.push_back(r->first);
+    }
+  }
+  return refined;
+}
+
+}  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
@@ -19,6 +19,7 @@
 #include "ssik_cpp/finalize.hpp"
 #include "ssik_cpp/fk.hpp"
 #include "ssik_cpp/newton.hpp"
+#include "ssik_cpp/rescue.hpp"
 #include "ssik_cpp/rotation.hpp"
 #include "ssik_cpp/sp6.hpp"  // detail::wrap_pi
 #include "ssik_cpp/subproblems.hpp"
@@ -129,15 +130,25 @@ inline std::vector<Solution<6>> spherical_two_parallel_solve(const JointConsts<6
 }
 
 // Full artifact-contract solve (#513): core solve (force-refined, as the artifact
-// always polishes) -> finalize (limits -> seed -> truncate). `c` must be the
-// CANONICAL constants (canonicalize_spherical_wrist applied at emit time and
-// baked). Rescue is dormant for this family (guarded on the Python side).
+// always polishes) -> rescue gate (#319) -> finalize (limits -> seed ->
+// truncate). `c` must be the CANONICAL constants (canonicalize_spherical_wrist
+// applied at emit time and baked). The rescue recovers solutions at reachable
+// rank-deficient (singular) poses where the analytical returns empty, so the
+// standalone artifact matches Python's solve() there; dormant otherwise.
 inline std::vector<Solution<6>> spherical_two_parallel_artifact_solve(
     const JointConsts<6>& c, const JointLimits<6>& lim, const Pose& T, const ArtifactParams<6>& p,
     const Tolerances& tol = {}) {
-  std::vector<Solution<6>> core =
-      spherical_two_parallel_solve(c, T, tol, /*allow_refinement=*/true, p.refinement_max_iters);
-  return finalize_solutions<6>(std::move(core), c, lim, p);
+  const auto core = [&](const Pose& Tp) {
+    return spherical_two_parallel_solve(c, Tp, tol, /*allow_refinement=*/true,
+                                        p.refinement_max_iters);
+  };
+  std::vector<Solution<6>> sols = core(T);
+
+  if (sols.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    sols = rescue_via_T_perturbation<6>(core, c, T);
+  }
+
+  return finalize_solutions<6>(std::move(sols), c, lim, p);
 }
 
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/srs.hpp
+++ b/cpp/include/ssik_cpp/solvers/srs.hpp
@@ -6,13 +6,14 @@
 //
 //   1. seeded_track fast path (q_seed + max_solutions == 1): Newton-continue
 //      from the seed, finalize, return if non-empty.
-//   2. analytical solve (srs_canonical_solve, the Singh-Kreutz swivel sweep).
-//   3. T-perturbation rescue gate: PROVEN DORMANT for the canonical SRS arms
-//      (well-conditioned; the analytical path is never empty on a reachable
-//      pose) and guarded red-on-fire by a Python dormancy fuzz, so the body is
-//      omitted -- matching three_parallel_artifact_solve. The rescue uses a
-//      numpy RNG that cannot be reproduced bit-for-bit in C++ anyway; it lands
-//      with the RR/HP families where it is load-bearing.
+//   2. analytical solve (canonical Singh-Kreutz or general Davenport sweep).
+//   3. T-perturbation rescue (#319): when the analytical path is empty at a
+//      reachable target -- a measure-zero kinematic singularity where the
+//      closed-form solve degenerates (within ~1e-9 rad of an exact singularity;
+//      the exact-SRS analytical is complete everywhere else) -- recover via the
+//      shared, family-agnostic rescue. This is what makes the standalone artifact
+//      genuinely complete: no Python fallback, so it must handle the singular
+//      poses Python's solve() does.
 //   4. finalize (limits -> seed -> truncate) with the #359 in-limits fallback
 //      wired to resolve_in_limits (the exact feasible-swivel resolver).
 #pragma once
@@ -24,22 +25,12 @@
 
 #include "ssik_cpp/finalize.hpp"
 #include "ssik_cpp/newton.hpp"  // seeded_track
+#include "ssik_cpp/rescue.hpp"
 #include "ssik_cpp/seven_r/srs_swivel_limits.hpp"
 #include "ssik_cpp/solvers/srs_canonical.hpp"
 #include "ssik_cpp/solvers/srs_general.hpp"
 
 namespace ssik {
-
-// Reach-sphere upper bound (sum of all link translation norms), the rescue
-// gate. Triangle-inequality bound, so it never rejects a reachable pose.
-inline double reach_radius(const JointConsts<7>& c) {
-  double r = 0.0;
-  for (int i = 0; i < 7; ++i) {
-    r += c.t_left[i].block<3, 1>(0, 3).norm();
-    r += c.t_right[i].block<3, 1>(0, 3).norm();
-  }
-  return r;
-}
 
 // Full artifact-contract solve for a canonical-ZYZ offset-free SRS arm. All
 // geometry is baked (JointConsts + SrsConsts + JointLimits); no Python.
@@ -66,14 +57,21 @@ inline std::vector<Solution<7>> srs_artifact_solve(const JointConsts<7>& c, cons
 
   // 2. Analytical swivel sweep -- canonical ZYZ fast-path or the general
   //    Davenport path, per the baked dispatch flag (mirrors use_canonical).
-  std::vector<Solution<7>> sols =
-      s.general_path ? srs_general_solve(c, s, T) : srs_canonical_solve(c, s, T);
+  const auto core = [&](const Pose& Tp) {
+    return s.general_path ? srs_general_solve(c, s, Tp) : srs_canonical_solve(c, s, Tp);
+  };
+  std::vector<Solution<7>> sols = core(T);
 
-  // 3. Rescue gate (dormant for this family; see the file comment). If ported,
-  //    the rescue would run here when sols.empty() && p.allow_rescue &&
-  //    T.p.norm() <= reach.
-  const double reach = reach_radius(c);
-  (void)reach;
+  // 3. Rescue gate (#319): the analytical extraction found nothing. If the
+  //    target is within reach it is a measure-zero rank-deficient pose (a
+  //    kinematic singularity where the closed-form solve degenerates), not an
+  //    unreachable target -- recover via the T-perturbation rescue. The
+  //    reach-sphere (triangle-inequality upper bound) is checked only in this
+  //    rare empty branch, so far-field targets stay cheap.
+  if (sols.empty() && p.allow_rescue &&
+      T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    sols = rescue_via_T_perturbation<7>(core, c, T);
+  }
 
   // 4. Finalize with the #359 exact in-limits fallback.
   return finalize_solutions<7>(std::move(sols), c, lim, p, [&]() {

--- a/cpp/include/ssik_cpp/solvers/three_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/three_parallel.hpp
@@ -20,6 +20,7 @@
 #include "ssik_cpp/finalize.hpp"
 #include "ssik_cpp/fk.hpp"
 #include "ssik_cpp/newton.hpp"
+#include "ssik_cpp/rescue.hpp"
 #include "ssik_cpp/rotation.hpp"
 #include "ssik_cpp/sp6.hpp"
 #include "ssik_cpp/subproblems.hpp"
@@ -146,39 +147,27 @@ inline std::vector<Solution<6>> three_parallel_solve(const JointConsts<6>& c, co
   return deduped;
 }
 
-// Reach-sphere upper bound (sum of all link translation norms) -- the rescue
-// gate from the artifact wrapper. Triangle-inequality bound, so it never
-// rejects a reachable pose.
-inline double reach_radius(const JointConsts<6>& c) {
-  double r = 0.0;
-  for (int i = 0; i < 6; ++i) {
-    r += c.t_left[i].block<3, 1>(0, 3).norm();
-    r += c.t_right[i].block<3, 1>(0, 3).norm();
-  }
-  return r;
-}
-
 // Full artifact-contract solve -- the C++ replica of <arm>_ik.solve() (#503):
 // core solve (force-refined, the artifact always polishes near-misses) ->
-// rescue gate -> finalize (limits -> seed -> truncate). The gate mirrors the
-// artifact but the rescue body is intentionally omitted: rescue_via_T_perturbation
-// is PROVEN DORMANT for the three_parallel family (0 firings in 3400 reachable
-// poses; analytical is complete), so this is behaviorally identical to the
-// artifact on every pose. A Python-side dormancy fuzz guards the assumption; the
-// full rescue port lands with the RR/HP families, where it is load-bearing.
+// rescue gate -> finalize (limits -> seed -> truncate). The rescue (#319) makes
+// the standalone artifact complete: at a reachable but rank-deficient pose (a
+// kinematic singularity where the geometric extraction degenerates) it recovers
+// solutions instead of returning empty, matching Python's solve(). Dormant on
+// non-singular poses (the vast majority), so the artifact stays bit-for-bit with
+// Python there.
 inline std::vector<Solution<6>> three_parallel_artifact_solve(const JointConsts<6>& c,
                                                               const JointLimits<6>& lim,
                                                               const Pose& T,
                                                               const ArtifactParams<6>& p,
                                                               const Tolerances& tol = {}) {
-  std::vector<Solution<6>> sols =
-      three_parallel_solve(c, T, tol, /*allow_refinement=*/true, p.refinement_max_iters);
+  const auto core = [&](const Pose& Tp) {
+    return three_parallel_solve(c, Tp, tol, /*allow_refinement=*/true, p.refinement_max_iters);
+  };
+  std::vector<Solution<6>> sols = core(T);
 
-  // Rescue gate (dormant for this family; see the function comment). If it were
-  // ported, it would run here when: sols.empty() && p.allow_rescue &&
-  // T.block<3,1>(0,3).norm() <= reach.
-  const double reach = reach_radius(c);
-  (void)reach;
+  if (sols.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    sols = rescue_via_T_perturbation<6>(core, c, T);
+  }
 
   return finalize_solutions<6>(std::move(sols), c, lim, p);
 }

--- a/tests/test_srs_singularity.py
+++ b/tests/test_srs_singularity.py
@@ -1,0 +1,107 @@
+"""C++ SRS artifact soundness across the singular regime + rescue liveness (#319).
+
+The completeness bar for the no-Python-fallback standalone artifact, stated as
+PROVABLE invariants:
+
+1. **Soundness (everywhere).** Every solution the artifact returns FK-closes and
+   respects limits -- including at singularities, where the T-perturbation rescue
+   may fire. A no-fallback artifact must never emit an invalid solution.
+
+2. **Bit-parity on well-conditioned poses** is covered by the random-pose tests
+   (test_native_srs_coverage / test_srs_general_cpp): native == Python there.
+
+Bit-parity is deliberately NOT asserted in the near-singular regime: there the
+IK branch set is ill-conditioned and BOTH backends have divergent edge behavior
+(each recovers sound branches the other drops -- e.g. openarm's elbow-singular
+shell up to ~0.1 rad, where native sometimes finds solutions Python returns empty
+for, and vice versa). Neither is a gold standard there, so soundness -- not
+matching a non-canonical reference -- is the meaningful guarantee.
+
+Skips when the test-only extension isn't built (native falls back to Python).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.prebuilt._manifest import load_manifest
+from tests._cpp_backend import cpp_available
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="ssik._ssik_native not built")
+
+_EXACT_SRS = sorted(a.name for a in load_manifest().values() if a.solver == "seven_r.srs")
+
+
+def _lims(kb) -> list[tuple[float, float]]:
+    return [
+        (float(j.limits[0]), float(j.limits[1])) if j.limits else (-np.pi, np.pi) for j in kb.joints
+    ]
+
+
+def _singular_q(kb, rng: np.random.Generator, eps: float) -> np.ndarray:
+    """A pose eps rad from an elbow-straight / shoulder-gimbal singularity (eps=0
+    is exactly singular), within limits."""
+    lims = _lims(kb)
+
+    def clamp(v: float, i: int) -> float:
+        return float(np.clip(v, lims[i][0], lims[i][1]))
+
+    q = np.array([rng.uniform(lo, hi) for lo, hi in lims])
+    s = rng.choice([-1.0, 1.0])
+    which = int(rng.integers(0, 3))
+    if which == 0:
+        q[3] = clamp(eps * s, 3)  # elbow straight
+    elif which == 1:
+        q[1] = clamp(np.pi + eps * s, 1)  # shoulder gimbal
+    else:
+        q[1] = clamp(np.pi + eps * s, 1)
+        q[3] = clamp(eps * s, 3)  # combined
+    return q
+
+
+def _assert_sound(arm: str, kb, T: np.ndarray, sols, lims) -> None:
+    for s in sols:
+        q = np.asarray(s.q)
+        resid = float(np.linalg.norm(poe_forward_kinematics(kb, q) - T))
+        assert resid < 1e-6, f"{arm}: unsound solution, FK residual {resid:.2e}"
+        assert all(lims[i][0] - 1e-9 <= q[i] <= lims[i][1] + 1e-9 for i in range(len(q))), (
+            f"{arm}: solution out of limits: {q.tolist()}"
+        )
+
+
+@pytest.mark.parametrize("arm", _EXACT_SRS)
+def test_artifact_sound_in_near_singular_regime(arm: str) -> None:
+    """Everything the native artifact returns in the near-singular regime
+    (1e-3..1e-1 rad off a singularity) is a valid IK. Fast: the analytical core
+    handles this regime, so the rescue stays dormant."""
+    mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+    kb = mod._KB
+    lims = _lims(kb)
+    rng = np.random.default_rng(0)
+    for _ in range(500):
+        eps = 10.0 ** rng.uniform(-3.0, -1.0)
+        T = poe_forward_kinematics(kb, _singular_q(kb, rng, eps))
+        _assert_sound(arm, kb, T, mod.solve(T, native=True), lims)
+
+
+# At exact singularities the rescue fires (slower); check soundness + that the
+# ported rescue is actually live on representative arms (the rescue is shared).
+@pytest.mark.parametrize("arm", ["iiwa14_ik", "r1pro_left_ik"])
+def test_rescue_sound_and_live_at_exact_singularities(arm: str) -> None:
+    mod = importlib.import_module(f"ssik.prebuilt.{arm}")
+    kb = mod._KB
+    lims = _lims(kb)
+    rng = np.random.default_rng(0)
+    recovered = 0
+    for _ in range(80):
+        T = poe_forward_kinematics(kb, _singular_q(kb, rng, 0.0))
+        sols = mod.solve(T, native=True)
+        _assert_sound(arm, kb, T, sols, lims)
+        recovered += len(sols) > 0
+    assert recovered > 0, (
+        f"{arm}: artifact recovered nothing at any exact singularity -- rescue dead"
+    )


### PR DESCRIPTION
## Why

The self-contained C++ artifact has **no Python fallback**, so it must handle every pose Python's `solve()` does — including reachable but rank-deficient (singular) poses where the closed-form analytical extraction returns nothing. It was omitting the rescue on a "provably dormant" argument. That argument is **false**: the exact-SRS analytical is complete everywhere *except within ~1e-9 rad of an exact kinematic singularity*, where it returns `[]` on a reachable pose and Python's rescue recovers solutions. The artifact was incomplete there.

Evidence (iiwa14, shoulder-gimbal + elbow-straight): within ≤1e-9 rad of the exact singularity, the analytical returns empty on **22–24%** of reachable poses; Python's rescue recovers ~500 continuum points; the artifact returned `[]`.

## What

- **`rescue.hpp`** — family-agnostic T-perturbation rescue, ported from `ssik.refinement.rescue`. Takes the analytical core as a **callable** (exactly like Python's `solve_fn`), so **one** implementation serves every family — three_parallel / spherical / SRS now, RR / HP when they gain native cores. `reach_radius` consolidated here as a single template (was duplicated per family).
- **Wired into all three artifact solves**: at a reachable empty result, perturb `T` off the ridge, re-solve the core, LM-polish candidates back to `T`, dedup. Dormant on the well-conditioned poses that dominate, so bit-parity with Python holds there.

## Completeness bar (provable, guarded)

1. **Soundness everywhere** — every returned solution FK-closes + respects limits, including rescued ones. A no-fallback artifact must never emit an invalid solution.
2. **Bit-parity on well-conditioned poses** — native == Python (existing random-pose tests).

Bit-parity is deliberately **not** claimed in the near-singular shell: there the branch set is ill-conditioned and *both* backends have divergent-but-sound edge behavior (openarm's elbow-singular shell reaches ~0.1 rad, where native sometimes recovers solutions Python returns empty for, and vice versa). Neither is a gold standard, so soundness is the meaningful guarantee.

**RNG note**: rescue uses a portable `std` PRNG, not numpy's PCG64, so at a singular pose (an ill-posed continuum sampled via the perturbations) the recovered *set* differs from Python's — both are sound. Non-singular poses never invoke it, so the artifact stays bit-for-bit with Python there.

## Test plan

- `test_srs_singularity`: soundness across the near-singular regime (all 7 SRS arms) + rescue sound & live at exact singularities.
- 106-test native / parity / gate / dormancy regression green; `cpp_emit --check` drift guard + cpp ctest (standalone gate) green; ruff + mypy clean. No prebuilt / emit / binding changes.

Closes the completeness gap for the standalone C++ artifact: it is now sound everywhere, matches Python on every well-conditioned pose, and recovers sound solutions at singularities instead of returning empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)