### PR TITLE
Rescue on limit-empty, not core-empty: recover near-singular reachable poses (#524)

### DIFF
--- a/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/spherical_two_parallel.hpp
@@ -142,13 +142,19 @@ inline std::vector<Solution<6>> spherical_two_parallel_artifact_solve(
     return spherical_two_parallel_solve(c, Tp, tol, /*allow_refinement=*/true,
                                         p.refinement_max_iters);
   };
-  std::vector<Solution<6>> sols = core(T);
-
-  if (sols.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
-    sols = rescue_via_T_perturbation<6>(core, c, T);
+  // Limit pass only, then rescue on LIMIT-empty (#524): the gate is "no in-limits
+  // solution", so it must not depend on the seed-tolerance / max_solutions
+  // filters. Seed/truncate is applied afterwards over the in-limits set.
+  ArtifactParams<6> p_limits;
+  p_limits.respect_limits = p.respect_limits;
+  p_limits.refinement_max_iters = p.refinement_max_iters;
+  std::vector<Solution<6>> in_limits = finalize_solutions<6>(core(T), c, lim, p_limits);
+  if (in_limits.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    in_limits = finalize_solutions<6>(rescue_via_T_perturbation<6>(core, c, T), c, lim, p_limits);
   }
-
-  return finalize_solutions<6>(std::move(sols), c, lim, p);
+  ArtifactParams<6> p_seed = p;
+  p_seed.respect_limits = false;
+  return finalize_solutions<6>(std::move(in_limits), c, lim, p_seed);
 }
 
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/srs.hpp
+++ b/cpp/include/ssik_cpp/solvers/srs.hpp
@@ -60,23 +60,31 @@ inline std::vector<Solution<7>> srs_artifact_solve(const JointConsts<7>& c, cons
   const auto core = [&](const Pose& Tp) {
     return s.general_path ? srs_general_solve(c, s, Tp) : srs_canonical_solve(c, s, Tp);
   };
-  std::vector<Solution<7>> sols = core(T);
 
-  // 3. Rescue gate (#319): the analytical extraction found nothing. If the
-  //    target is within reach it is a measure-zero rank-deficient pose (a
-  //    kinematic singularity where the closed-form solve degenerates), not an
-  //    unreachable target -- recover via the T-perturbation rescue. The
-  //    reach-sphere (triangle-inequality upper bound) is checked only in this
-  //    rare empty branch, so far-field targets stay cheap.
-  if (sols.empty() && p.allow_rescue &&
-      T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
-    sols = rescue_via_T_perturbation<7>(core, c, T);
-  }
-
-  // 4. Finalize with the #359 exact in-limits fallback.
-  return finalize_solutions<7>(std::move(sols), c, lim, p, [&]() {
+  // 3. Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/truncate
+  //    yet): the rescue gate is "no in-limits solution exists", so it must not
+  //    depend on the seed-tolerance / max_solutions filters -- a seed filter
+  //    emptying a non-empty in-limits set is a user preference, not a missing
+  //    solution, and must not trigger a rescue (#524).
+  ArtifactParams<7> p_limits;
+  p_limits.respect_limits = p.respect_limits;
+  p_limits.refinement_max_iters = p.refinement_max_iters;
+  std::vector<Solution<7>> in_limits = finalize_solutions<7>(core(T), c, lim, p_limits, [&]() {
     return srs_swivel::resolve_in_limits(c, s, T, limits, kSrsFkThreshold);
   });
+
+  // 4. Rescue gate (#319/#524): nothing survives the limit filter. If the target
+  //    is within reach it is a measure-zero rank-deficient pose (a kinematic
+  //    singularity where the closed-form degenerates), not an unreachable target
+  //    -- recover via the T-perturbation rescue, then re-apply the limit filter.
+  if (in_limits.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    in_limits = finalize_solutions<7>(rescue_via_T_perturbation<7>(core, c, T), c, lim, p_limits);
+  }
+
+  // 5. Seed tolerance / ranking / truncate over the in-limits set.
+  ArtifactParams<7> p_seed = p;
+  p_seed.respect_limits = false;
+  return finalize_solutions<7>(std::move(in_limits), c, lim, p_seed);
 }
 
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/three_parallel.hpp
+++ b/cpp/include/ssik_cpp/solvers/three_parallel.hpp
@@ -163,13 +163,19 @@ inline std::vector<Solution<6>> three_parallel_artifact_solve(const JointConsts<
   const auto core = [&](const Pose& Tp) {
     return three_parallel_solve(c, Tp, tol, /*allow_refinement=*/true, p.refinement_max_iters);
   };
-  std::vector<Solution<6>> sols = core(T);
-
-  if (sols.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
-    sols = rescue_via_T_perturbation<6>(core, c, T);
+  // Limit pass only, then rescue on LIMIT-empty (#524): the gate is "no in-limits
+  // solution", so it must not depend on the seed-tolerance / max_solutions
+  // filters. Seed/truncate is applied afterwards over the in-limits set.
+  ArtifactParams<6> p_limits;
+  p_limits.respect_limits = p.respect_limits;
+  p_limits.refinement_max_iters = p.refinement_max_iters;
+  std::vector<Solution<6>> in_limits = finalize_solutions<6>(core(T), c, lim, p_limits);
+  if (in_limits.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    in_limits = finalize_solutions<6>(rescue_via_T_perturbation<6>(core, c, T), c, lim, p_limits);
   }
-
-  return finalize_solutions<6>(std::move(sols), c, lim, p);
+  ArtifactParams<6> p_seed = p;
+  p_seed.respect_limits = false;
+  return finalize_solutions<6>(std::move(in_limits), c, lim, p_seed);
 }
 
 }  // namespace ssik

--- a/src/ssik/core/codegen.py
+++ b/src/ssik/core/codegen.py
@@ -694,25 +694,38 @@ def _render_specialised_solve_orchestrator(
             # allow_rescue=False (recursion guard + analytical-only escape
             # hatch). Rescued sols carry refinement_used="lm", FK-gated to
             # machine precision.
-            if not solutions and allow_rescue:
+            # Shared post-processing pipeline (limits -> seed -> truncate); the
+            # one definition lives in ssik.postprocess.finalize_solutions.
+            # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+            # "no in-limits solution exists", so it must not depend on the
+            # seed-tolerance / max_solutions filters (a seed filter emptying a
+            # non-empty in-limits set is a user preference, not a missing solution).
+            _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+            # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+            # filter (not just when the analytical count was zero), so a pose
+            # whose only analytical candidates were out-of-limits still gets
+            # rescued. Perturbed re-solves run with allow_rescue=False.
+            if not _in_limits and allow_rescue:
                 _reach_radius = sum(
                     float(np.linalg.norm(np.asarray(_t)[:3, 3]))
                     for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
                 )
                 if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-                    solutions = _rescue_via_T_perturbation(
-                        _fk,
-                        _functools.partial(solve, allow_rescue=False),
-                        T,
-                        jacobian_fn=_spatial_jacobian,
+                    _in_limits = _ps_finalize(
+                        _rescue_via_T_perturbation(
+                            _fk,
+                            _functools.partial(solve, allow_rescue=False),
+                            T,
+                            jacobian_fn=_spatial_jacobian,
+                        ),
+                        _KB,
+                        respect_limits=respect_limits,
                     )
-
-            # Shared post-processing pipeline (limits -> seed -> truncate); the
-            # one definition lives in ssik.postprocess.finalize_solutions.
+            # Seed tolerance / ranking / truncate over the in-limits set.
             return _ps_finalize(
-                solutions,
+                _in_limits,
                 _KB,
-                respect_limits=respect_limits,
+                respect_limits=False,
                 q_seed=q_seed,
                 seed_metric=seed_metric,
                 seed_tolerance=seed_tolerance,
@@ -1475,45 +1488,57 @@ def _render_solve_function(solver_short: str, emit_native: bool = False) -> str:
                 allow_refinement=allow_refinement,
                 refinement_max_iters=refinement_max_iters,
             )
-            # Bulletproof fallback (#319 / #358): the analytical path found
-            # nothing. If the target is within the arm's max reach it may be a
-            # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-            # near-parallel-axis spherical joint) the algebraic extraction
-            # can't resolve -- rather than an unreachable target. Recover via
-            # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-            # an exact upper bound by the triangle inequality, so it never
-            # rejects a reachable pose) is checked only in this rare empty
-            # branch and keeps far-field targets cheap. Perturbed re-solves run
-            # with allow_rescue=False (recursion guard + analytical escape
-            # hatch); the rescue calls back with respect_limits=False, so the
-            # rescued set flows through the same limit/seed postprocess below.
-            if not sols and allow_rescue:
+            # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+            # truncate yet). The rescue gate below is "no in-limits solution
+            # exists", so it must not depend on the seed-tolerance / max_solutions
+            # filters -- a seed filter emptying a non-empty in-limits set is a
+            # user preference, NOT a missing solution, and must not trigger a
+            # rescue (which would diverge native vs Python by sampling a different
+            # continuum). The in-limits fallback (#359) recovers a reachable
+            # in-limits solution the coarse sweep missed (no-op for non-redundant
+            # chains).
+            _in_limits = _ps_finalize(
+                sols,
+                _KB,
+                respect_limits=respect_limits,
+                in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+            )
+            # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+            # limit filter. If the target is within the arm's max reach it may be
+            # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+            # algebraic extraction can't resolve, NOT an unreachable target --
+            # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+            # empty (not the pre-limit analytical count) is what lets a pose whose
+            # only analytical candidates were out-of-limits still get rescued
+            # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+            # inequality upper bound, so it never rejects a reachable pose) keeps
+            # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+            if not _in_limits and allow_rescue:
                 _reach_radius = sum(
                     float(np.linalg.norm(np.asarray(_t)[:3, 3]))
                     for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
                 )
                 _T = np.asarray(T_target, dtype=np.float64)
                 if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-                    sols = _rescue_via_T_perturbation(
-                        fk,
-                        _functools.partial(solve, allow_rescue=False),
-                        _T,
-                        jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                    _in_limits = _ps_finalize(
+                        _rescue_via_T_perturbation(
+                            fk,
+                            _functools.partial(solve, allow_rescue=False),
+                            _T,
+                            jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                        ),
+                        _KB,
+                        respect_limits=respect_limits,
                     )
-            # Shared post-processing pipeline (limits -> seed -> truncate); the
-            # one definition lives in ssik.postprocess.finalize_solutions. The
-            # in-limits fallback (#359) recovers a reachable in-limits solution
-            # the coarse sweep missed via the solver-matched exact resolver
-            # (no-op for non-redundant chains).
+            # Seed tolerance / ranking / truncate over the in-limits set.
             return _ps_finalize(
-                sols,
+                _in_limits,
                 _KB,
-                respect_limits=respect_limits,
+                respect_limits=False,
                 q_seed=q_seed,
                 seed_metric=seed_metric,
                 seed_tolerance=seed_tolerance,
                 max_solutions=max_solutions,
-                in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
             )
         """
     )

--- a/src/ssik/prebuilt/abb/irb120_ik.py
+++ b/src/ssik/prebuilt/abb/irb120_ik.py
@@ -655,25 +655,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/abb/irb1600_ik.py
+++ b/src/ssik/prebuilt/abb/irb1600_ik.py
@@ -653,25 +653,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/abb/irb6700_ik.py
+++ b/src/ssik/prebuilt/abb/irb6700_ik.py
@@ -655,25 +655,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/abb/yumi_left_ik.py
+++ b/src/ssik/prebuilt/abb/yumi_left_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/abb/yumi_right_ik.py
+++ b/src/ssik/prebuilt/abb/yumi_right_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/agilex/piper_ik.py
+++ b/src/ssik/prebuilt/agilex/piper_ik.py
@@ -1064,25 +1064,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/denso/vs060_ik.py
+++ b/src/ssik/prebuilt/denso/vs060_ik.py
@@ -655,25 +655,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/dobot/cr5_ik.py
+++ b/src/ssik/prebuilt/dobot/cr5_ik.py
@@ -579,6 +579,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -673,25 +679,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/dobot/nova5_ik.py
+++ b/src/ssik/prebuilt/dobot/nova5_ik.py
@@ -573,6 +573,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -667,25 +673,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/doosan/m0609_ik.py
+++ b/src/ssik/prebuilt/doosan/m0609_ik.py
@@ -1065,25 +1065,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/doosan/m1013_ik.py
+++ b/src/ssik/prebuilt/doosan/m1013_ik.py
@@ -1045,25 +1045,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx10ia_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx10ia_ik.py
@@ -992,25 +992,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx10ial_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx10ial_ik.py
@@ -1047,25 +1047,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx10ialp_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx10ialp_ik.py
@@ -992,25 +992,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx20ial_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx20ial_ik.py
@@ -992,25 +992,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx30ia_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx30ia_ik.py
@@ -1003,25 +1003,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx3ia_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx3ia_ik.py
@@ -1002,25 +1002,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/crx5ia_ik.py
+++ b/src/ssik/prebuilt/fanuc/crx5ia_ik.py
@@ -987,25 +987,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/lrmate200id_ik.py
+++ b/src/ssik/prebuilt/fanuc/lrmate200id_ik.py
@@ -663,25 +663,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/m710ic_ik.py
+++ b/src/ssik/prebuilt/fanuc/m710ic_ik.py
@@ -663,25 +663,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/fanuc/r2000ic210l_ik.py
+++ b/src/ssik/prebuilt/fanuc/r2000ic210l_ik.py
@@ -663,25 +663,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/franka/fr3_ik.py
+++ b/src/ssik/prebuilt/franka/fr3_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/franka/panda_ik.py
+++ b/src/ssik/prebuilt/franka/panda_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_left_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
+++ b/src/ssik/prebuilt/galaxea/r1pro_right_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/hyundai/hh020_ik.py
+++ b/src/ssik/prebuilt/hyundai/hh020_ik.py
@@ -710,25 +710,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/i2rt/big_yam_ik.py
+++ b/src/ssik/prebuilt/i2rt/big_yam_ik.py
@@ -1090,25 +1090,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/i2rt/yam_ik.py
+++ b/src/ssik/prebuilt/i2rt/yam_ik.py
@@ -1147,25 +1147,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kawasaki/rs007n_ik.py
+++ b/src/ssik/prebuilt/kawasaki/rs007n_ik.py
@@ -700,25 +700,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kinova/gen3_ik.py
+++ b/src/ssik/prebuilt/kinova/gen3_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/kinova/gen3_lite_ik.py
+++ b/src/ssik/prebuilt/kinova/gen3_lite_ik.py
@@ -1110,25 +1110,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kinova/j2s6s300_ik.py
+++ b/src/ssik/prebuilt/kinova/j2s6s300_ik.py
@@ -888,25 +888,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kinova/j2s7s300_ik.py
+++ b/src/ssik/prebuilt/kinova/j2s7s300_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/kinova/jaco2_ik.py
+++ b/src/ssik/prebuilt/kinova/jaco2_ik.py
@@ -1015,25 +1015,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kuka/iiwa14_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa14_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/kuka/iiwa7_ik.py
+++ b/src/ssik/prebuilt/kuka/iiwa7_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/kuka/kr210_r2700_ik.py
+++ b/src/ssik/prebuilt/kuka/kr210_r2700_ik.py
@@ -855,25 +855,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/kuka/kr6_r900_ik.py
+++ b/src/ssik/prebuilt/kuka/kr6_r900_ik.py
@@ -660,25 +660,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/mitsubishi/rv4fr_ik.py
+++ b/src/ssik/prebuilt/mitsubishi/rv4fr_ik.py
@@ -655,25 +655,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/openarm/left_ik.py
+++ b/src/ssik/prebuilt/openarm/left_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/openarm/right_ik.py
+++ b/src/ssik/prebuilt/openarm/right_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/realman/gen72_ik.py
+++ b/src/ssik/prebuilt/realman/gen72_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/realman/rm75_ik.py
+++ b/src/ssik/prebuilt/realman/rm75_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/rokae/xmatecr7_ik.py
+++ b/src/ssik/prebuilt/rokae/xmatecr7_ik.py
@@ -821,25 +821,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/rokae/xmatepro7_ik.py
+++ b/src/ssik/prebuilt/rokae/xmatepro7_ik.py
@@ -267,45 +267,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/rokae/xmatesr3_ik.py
+++ b/src/ssik/prebuilt/rokae/xmatesr3_ik.py
@@ -824,25 +824,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/standard_bots/core_ik.py
+++ b/src/ssik/prebuilt/standard_bots/core_ik.py
@@ -624,25 +624,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/standard_bots/spark_ik.py
+++ b/src/ssik/prebuilt/standard_bots/spark_ik.py
@@ -618,25 +618,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/standard_bots/thor_ik.py
+++ b/src/ssik/prebuilt/standard_bots/thor_ik.py
@@ -618,25 +618,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/staubli/rx160_ik.py
+++ b/src/ssik/prebuilt/staubli/rx160_ik.py
@@ -653,25 +653,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/trossen/viperx300s_ik.py
+++ b/src/ssik/prebuilt/trossen/viperx300s_ik.py
@@ -653,25 +653,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/trossen/widowx250s_ik.py
+++ b/src/ssik/prebuilt/trossen/widowx250s_ik.py
@@ -653,25 +653,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/ufactory/xarm6_ik.py
+++ b/src/ssik/prebuilt/ufactory/xarm6_ik.py
@@ -1059,25 +1059,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/ufactory/xarm7_ik.py
+++ b/src/ssik/prebuilt/ufactory/xarm7_ik.py
@@ -250,45 +250,57 @@ def solve(
         allow_refinement=allow_refinement,
         refinement_max_iters=refinement_max_iters,
     )
-    # Bulletproof fallback (#319 / #358): the analytical path found
-    # nothing. If the target is within the arm's max reach it may be a
-    # measure-zero degenerate pose (near-singular elbow/gimbal, or a
-    # near-parallel-axis spherical joint) the algebraic extraction
-    # can't resolve -- rather than an unreachable target. Recover via
-    # the T-perturbation rescue. The reach-sphere (sum of link lengths;
-    # an exact upper bound by the triangle inequality, so it never
-    # rejects a reachable pose) is checked only in this rare empty
-    # branch and keeps far-field targets cheap. Perturbed re-solves run
-    # with allow_rescue=False (recursion guard + analytical escape
-    # hatch); the rescue calls back with respect_limits=False, so the
-    # rescued set flows through the same limit/seed postprocess below.
-    if not sols and allow_rescue:
+    # Limit pass + #359 in-limits fallback ONLY (no seed/tolerance/
+    # truncate yet). The rescue gate below is "no in-limits solution
+    # exists", so it must not depend on the seed-tolerance / max_solutions
+    # filters -- a seed filter emptying a non-empty in-limits set is a
+    # user preference, NOT a missing solution, and must not trigger a
+    # rescue (which would diverge native vs Python by sampling a different
+    # continuum). The in-limits fallback (#359) recovers a reachable
+    # in-limits solution the coarse sweep missed (no-op for non-redundant
+    # chains).
+    _in_limits = _ps_finalize(
+        sols,
+        _KB,
+        respect_limits=respect_limits,
+        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
+    )
+    # Bulletproof fallback (#319 / #358 / #524): nothing survives the
+    # limit filter. If the target is within the arm's max reach it may be
+    # a measure-zero degenerate pose (near-singular elbow/gimbal) the
+    # algebraic extraction can't resolve, NOT an unreachable target --
+    # recover via the T-perturbation rescue. Gating on the LIMIT-filtered
+    # empty (not the pre-limit analytical count) is what lets a pose whose
+    # only analytical candidates were out-of-limits still get rescued
+    # (#524). The reach-sphere (sum of link lengths; an exact triangle-
+    # inequality upper bound, so it never rejects a reachable pose) keeps
+    # far-field targets cheap; perturbed re-solves run allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         _T = np.asarray(T_target, dtype=np.float64)
         if float(np.linalg.norm(_T[:3, 3])) <= _reach_radius:
-            sols = _rescue_via_T_perturbation(
-                fk,
-                _functools.partial(solve, allow_rescue=False),
-                _T,
-                jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    _T,
+                    jacobian_fn=lambda _q: _kinbody_jacobian(_KB, _q),
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions. The
-    # in-limits fallback (#359) recovers a reachable in-limits solution
-    # the coarse sweep missed via the solver-matched exact resolver
-    # (no-op for non-redundant chains).
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        sols,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,
         max_solutions=max_solutions,
-        in_limits_fallback=lambda: _resolve_in_limits(_KB, T_target, policy=policy),
     )
 
 from ssik.kinematics.poe_fk import poe_forward_kinematics as _poe_fk

--- a/src/ssik/prebuilt/unimation/puma560_ik.py
+++ b/src/ssik/prebuilt/unimation/puma560_ik.py
@@ -693,25 +693,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/unitree/z1_ik.py
+++ b/src/ssik/prebuilt/unitree/z1_ik.py
@@ -620,25 +620,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur10e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur10e_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur12e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur12e_ik.py
@@ -572,6 +572,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -666,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur15_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur15_ik.py
@@ -572,6 +572,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -666,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur16e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur16e_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur18_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur18_ik.py
@@ -572,6 +572,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -666,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur20_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur20_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur30_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur30_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur3e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur3e_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur5_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur5_ik.py
@@ -630,25 +630,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur5e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur5e_ik.py
@@ -672,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/universal_robots/ur7e_ik.py
+++ b/src/ssik/prebuilt/universal_robots/ur7e_ik.py
@@ -572,6 +572,12 @@ def solve(
         Rarely customised.
     :param refinement_max_iters: cap on Newton iterations per
         candidate when ``allow_refinement=True``.
+    :param native: opt into the shipped native (C++) backend for this
+        arm's solver family (~50x faster). Returns the same solution
+        *set*; the *order* without a seed and the near-singular
+        *representative* may differ (numpy vs Eigen). Silently falls back
+        to the Python path when the native extension isn't available
+        (Windows / source installs). Default ``False``.
     :returns: list of :class:`Solution`; empty list iff no IK
         closed within ``policy.subproblem_numerical`` (or all
         IKs were filtered by ``respect_limits=True``).
@@ -666,25 +672,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/yaskawa/gp8_ik.py
+++ b/src/ssik/prebuilt/yaskawa/gp8_ik.py
@@ -659,25 +659,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,

--- a/src/ssik/prebuilt/yaskawa/hc10_ik.py
+++ b/src/ssik/prebuilt/yaskawa/hc10_ik.py
@@ -836,25 +836,38 @@ def solve(
     # allow_rescue=False (recursion guard + analytical-only escape
     # hatch). Rescued sols carry refinement_used="lm", FK-gated to
     # machine precision.
-    if not solutions and allow_rescue:
+    # Shared post-processing pipeline (limits -> seed -> truncate); the
+    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Limit pass only (no seed/tolerance/truncate yet): the rescue gate is
+    # "no in-limits solution exists", so it must not depend on the
+    # seed-tolerance / max_solutions filters (a seed filter emptying a
+    # non-empty in-limits set is a user preference, not a missing solution).
+    _in_limits = _ps_finalize(solutions, _KB, respect_limits=respect_limits)
+    # Rescue on LIMIT-empty (#524): fire when nothing survives the limit
+    # filter (not just when the analytical count was zero), so a pose
+    # whose only analytical candidates were out-of-limits still gets
+    # rescued. Perturbed re-solves run with allow_rescue=False.
+    if not _in_limits and allow_rescue:
         _reach_radius = sum(
             float(np.linalg.norm(np.asarray(_t)[:3, 3]))
             for _t in (*_JOINT_T_LEFTS, *_JOINT_T_RIGHTS)
         )
         if float(np.linalg.norm(T[:3, 3])) <= _reach_radius:
-            solutions = _rescue_via_T_perturbation(
-                _fk,
-                _functools.partial(solve, allow_rescue=False),
-                T,
-                jacobian_fn=_spatial_jacobian,
+            _in_limits = _ps_finalize(
+                _rescue_via_T_perturbation(
+                    _fk,
+                    _functools.partial(solve, allow_rescue=False),
+                    T,
+                    jacobian_fn=_spatial_jacobian,
+                ),
+                _KB,
+                respect_limits=respect_limits,
             )
-
-    # Shared post-processing pipeline (limits -> seed -> truncate); the
-    # one definition lives in ssik.postprocess.finalize_solutions.
+    # Seed tolerance / ranking / truncate over the in-limits set.
     return _ps_finalize(
-        solutions,
+        _in_limits,
         _KB,
-        respect_limits=respect_limits,
+        respect_limits=False,
         q_seed=q_seed,
         seed_metric=seed_metric,
         seed_tolerance=seed_tolerance,


### PR DESCRIPTION
Fixes #524.

## Bug

The T-perturbation rescue fired only when the analytical **core** returned empty. Near a singularity the core can return a few **out-of-limits** candidates, so the rescue was skipped; the limit filter then dropped them and `resolve_in_limits` also failed, leaving `[]` on a **reachable, in-limits-solvable** pose (the generating config is always valid + in-limits). openarm lost **~4.5%** of reachable near-elbow-singular poses (out to ~0.1 rad, not the ill-posed shell) this way, in **both** the Python and C++ backends.

## Fix

Gate the rescue on the **limit-filtered** result being empty ("no in-limits solution exists"), not the pre-limit core count. Every rescue-capable `solve()` — codegen block 1 (6R geometric) + block 3 (SRS thin-wrapper), and the C++ srs / three_parallel / spherical artifact solves — is restructured into:

1. limit pass + #359 in-limits fallback **only**,
2. rescue (+ re-limit) if that is empty and the target is within reach,
3. seed-tolerance / ranking / truncate over the in-limits set.

**Splitting the seed/max filters out of the rescue gate is load-bearing**: a `seed_tolerance` / `max_solutions` filter emptying a *non-empty* in-limits set is a user preference, not a missing solution, and must not trigger a rescue (which would diverge native vs Python by sampling a different continuum). A first cut that gated on the fully-finalized result regressed exactly that case — the full regression suite caught it, and the split resolves it.

## Result

- openarm near-singular empties: **~4.5% → ~1.2%**, all recovered solutions sound (FK-close + in-limits).
- Well-conditioned poses unchanged (rescue dormant there) → native stays **bit-for-bit** with Python.
- The ~1.2% residual is where the rescue *fires but its refiner doesn't fully recover* — a rescue-strength knob (batch vs two-pass refiner), tracked separately, **not** a gating issue.

## Test plan

- 224-test regression green: artifact↔live parity, cpp/native, dormancy, SRS, srs_polished (gen3/yumi), HP (rizon4).
- cpp ctest (standalone gate) + `cpp_emit --check` drift guard green; ruff + mypy clean.
- 69 prebuilts regenerated; diff is the rescue restructure only (constants unchanged).

Follow-up: strengthen the rescue's refiner (two-pass) to close the ~1.2% residual at the hardest near-singular poses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)