### PR TITLE
[C++ HP] Slice 3: native HP universal-6R IK kernel ((u,w) refine → back-sub → full solve) (#539)

### DIFF
--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -607,6 +607,73 @@ py::array_t<double> hp_solve_ik_test_py(py::array_t<double> t_u_arr, py::array_t
   return out;
 }
 
+// HP full artifact solve (#539): JointConsts (POE FK) + baked HpConsts + target
+// -> (qs, resids), exactly what ssik::hp_artifact_solve ships.
+py::tuple hp_artifact_solve_test_py(py::array_t<double> axes, py::array_t<double> t_left,
+                                    py::array_t<double> t_right, py::array_t<int> types,
+                                    py::array_t<double> t_u_arr, py::array_t<double> t_w_pre_arr,
+                                    py::array_t<double> dh_a, py::array_t<double> dh_l,
+                                    py::array_t<double> dh_d, py::array_t<double> theta_offset,
+                                    py::array_t<double> t_pre_inv, py::array_t<double> t_post_inv,
+                                    py::array_t<double> t_z_neg_d1,
+                                    py::array_t<double> t_joint6_offset_inv, int right_parametric_var,
+                                    int drop_idx, py::array_t<double> target, bool allow_refinement) {
+  const ssik::JointConsts<6> c = make_consts_n<6>(axes, t_left, t_right, types);
+  ssik::HpConsts hp;
+  auto load = [](py::array_t<double> a, std::array<Eigen::Matrix<double, 4, 8>, 2>& dst) {
+    auto u3 = a.unchecked<3>();
+    for (int i = 0; i < 4; ++i)
+      for (int j = 0; j < 8; ++j)
+        for (int k = 0; k < 2; ++k) dst[k](i, j) = u3(i, j, k);
+  };
+  load(t_u_arr, hp.t_u);
+  load(t_w_pre_arr, hp.t_w_pre);
+  auto mat4 = [](py::array_t<double> a) {
+    auto u = a.unchecked<2>();
+    Eigen::Matrix4d m;
+    for (int i = 0; i < 4; ++i)
+      for (int j = 0; j < 4; ++j) m(i, j) = u(i, j);
+    return m;
+  };
+  hp.t_pre_inv = mat4(t_pre_inv);
+  hp.t_post_inv = mat4(t_post_inv);
+  hp.t_z_neg_d1 = mat4(t_z_neg_d1);
+  hp.t_joint6_offset_inv = mat4(t_joint6_offset_inv);
+  hp.right_parametric_var = right_parametric_var;
+  hp.drop_idx = drop_idx;
+  auto av = dh_a.unchecked<1>(), lv = dh_l.unchecked<1>(), dv = dh_d.unchecked<1>();
+  auto to = theta_offset.unchecked<1>();
+  for (int i = 0; i < 5; ++i) {
+    hp.a[i + 1] = av(i);
+    hp.l[i + 1] = lv(i);
+  }
+  for (int i = 0; i < 4; ++i) hp.d[i + 2] = dv(i);
+  for (int i = 0; i < 6; ++i) hp.theta_offset[i] = to(i);
+
+  ssik::Pose T;
+  auto tm = target.unchecked<2>();
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j) T(i, j) = tm(i, j);
+
+  ssik::JointLimits<6> lim;  // no limits for the parity test
+  lim.present = {false, false, false, false, false, false};
+  (void)allow_refinement;  // HP always lm_refines seeds that miss (like general_6r force_refine)
+  ssik::ArtifactParams<6> p;
+  p.respect_limits = false;
+  p.allow_rescue = false;
+  const std::vector<ssik::Solution<6>> sols = ssik::hp_artifact_solve(c, hp, lim, T, p);
+  const int n = static_cast<int>(sols.size());
+  py::array_t<double> qs({n, 6});
+  py::array_t<double> resids(n);
+  auto qm = qs.mutable_unchecked<2>();
+  auto rm = resids.mutable_unchecked<1>();
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < 6; ++j) qm(i, j) = sols[i].q[j];
+    rm(i) = sols[i].fk_residual;
+  }
+  return py::make_tuple(qs, resids);
+}
+
 PYBIND11_MODULE(_ssik_native, m) {
   m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("decompose_3axis_test", &decompose_3axis_test_py, py::arg("R"), py::arg("n1"),
@@ -623,6 +690,12 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("hp_solve_ik_test", &hp_solve_ik_test_py, py::arg("t_u"), py::arg("t_w_pre"),
         py::arg("sigma_e"), py::arg("dh_a"), py::arg("dh_l"), py::arg("dh_d"),
         py::arg("right_parametric_var"));
+  m.def("hp_artifact_solve_test", &hp_artifact_solve_test_py, py::arg("axes"), py::arg("t_left"),
+        py::arg("t_right"), py::arg("types"), py::arg("t_u"), py::arg("t_w_pre"), py::arg("dh_a"),
+        py::arg("dh_l"), py::arg("dh_d"), py::arg("theta_offset"), py::arg("t_pre_inv"),
+        py::arg("t_post_inv"), py::arg("t_z_neg_d1"), py::arg("t_joint6_offset_inv"),
+        py::arg("right_parametric_var"), py::arg("drop_idx"), py::arg("target"),
+        py::arg("allow_refinement") = true);
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -535,6 +535,44 @@ py::array_t<double> hp_eliminate_uw_pairs_test_py(py::array_t<double> t_u_arr,
   return out;
 }
 
+// HP back-substitution parity (#539): given baked T_u/T_w_pre + sigma_E + a
+// refined (u,w) + the DH + dispatch flags, return the (v_1..v_6) tuple, as
+// _back_substitute.back_substitute_one (Tv1 left).
+py::array_t<double> hp_back_substitute_test_py(py::array_t<double> t_u_arr,
+                                               py::array_t<double> t_w_pre_arr,
+                                               py::array_t<double> sigma_e_arr, double u, double w,
+                                               py::array_t<double> dh_a, py::array_t<double> dh_l,
+                                               py::array_t<double> dh_d, int right_parametric_var,
+                                               int drop_idx) {
+  auto load = [](py::array_t<double> a, std::array<Eigen::Matrix<double, 4, 8>, 2>& dst) {
+    auto u3 = a.unchecked<3>();
+    for (int i = 0; i < 4; ++i)
+      for (int j = 0; j < 8; ++j)
+        for (int k = 0; k < 2; ++k) dst[k](i, j) = u3(i, j, k);
+  };
+  ssik::HpConsts hp;
+  load(t_u_arr, hp.t_u);
+  load(t_w_pre_arr, hp.t_w_pre);
+  hp.drop_idx = drop_idx;
+  hp.right_parametric_var = right_parametric_var;
+  auto av = dh_a.unchecked<1>(), lv = dh_l.unchecked<1>(), dv = dh_d.unchecked<1>();
+  for (int i = 0; i < 5; ++i) {  // dh_a/dh_l = [a_1..a_5] -> hp.a[1..5]
+    hp.a[i + 1] = av(i);
+    hp.l[i + 1] = lv(i);
+  }
+  for (int i = 0; i < 4; ++i) hp.d[i + 2] = dv(i);  // dh_d = [d_2..d_5] -> hp.d[2..5]
+  auto se = sigma_e_arr.unchecked<1>();
+  ssik::Vec8 sigma_E;
+  for (int i = 0; i < 8; ++i) sigma_E[i] = se(i);
+
+  const ssik::hp_detail::JointTuple v =
+      ssik::hp_detail::back_substitute_one(hp, sigma_E, u, w);
+  py::array_t<double> out(6);
+  auto om = out.mutable_unchecked<1>();
+  for (int i = 0; i < 6; ++i) om(i) = v[i];
+  return out;
+}
+
 PYBIND11_MODULE(_ssik_native, m) {
   m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("decompose_3axis_test", &decompose_3axis_test_py, py::arg("R"), py::arg("n1"),
@@ -545,6 +583,9 @@ PYBIND11_MODULE(_ssik_native, m) {
         py::arg("real_tol") = 1e-3, py::arg("max_magnitude") = 1e10);
   m.def("hp_eliminate_uw_pairs_test", &hp_eliminate_uw_pairs_test_py, py::arg("t_u"),
         py::arg("t_w_pre"), py::arg("sigma_e"), py::arg("accept_residue_tol") = 1e-3);
+  m.def("hp_back_substitute_test", &hp_back_substitute_test_py, py::arg("t_u"), py::arg("t_w_pre"),
+        py::arg("sigma_e"), py::arg("u"), py::arg("w"), py::arg("dh_a"), py::arg("dh_l"),
+        py::arg("dh_d"), py::arg("right_parametric_var"), py::arg("drop_idx") = 7);
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -573,6 +573,40 @@ py::array_t<double> hp_back_substitute_test_py(py::array_t<double> t_u_arr,
   return out;
 }
 
+// HP solve_ik parity (#539): baked T_u/T_w_pre + sigma_E + DH + flags -> the
+// (n,6) v-tuple candidates, as _back_substitute.solve_ik.
+py::array_t<double> hp_solve_ik_test_py(py::array_t<double> t_u_arr, py::array_t<double> t_w_pre_arr,
+                                        py::array_t<double> sigma_e_arr, py::array_t<double> dh_a,
+                                        py::array_t<double> dh_l, py::array_t<double> dh_d,
+                                        int right_parametric_var) {
+  auto load = [](py::array_t<double> a, std::array<Eigen::Matrix<double, 4, 8>, 2>& dst) {
+    auto u3 = a.unchecked<3>();
+    for (int i = 0; i < 4; ++i)
+      for (int j = 0; j < 8; ++j)
+        for (int k = 0; k < 2; ++k) dst[k](i, j) = u3(i, j, k);
+  };
+  ssik::HpConsts hp;
+  load(t_u_arr, hp.t_u);
+  load(t_w_pre_arr, hp.t_w_pre);
+  hp.right_parametric_var = right_parametric_var;
+  auto av = dh_a.unchecked<1>(), lv = dh_l.unchecked<1>(), dv = dh_d.unchecked<1>();
+  for (int i = 0; i < 5; ++i) {
+    hp.a[i + 1] = av(i);
+    hp.l[i + 1] = lv(i);
+  }
+  for (int i = 0; i < 4; ++i) hp.d[i + 2] = dv(i);
+  auto se = sigma_e_arr.unchecked<1>();
+  ssik::Vec8 sigma_E;
+  for (int i = 0; i < 8; ++i) sigma_E[i] = se(i);
+
+  const auto sols = ssik::hp_detail::solve_ik(hp, sigma_E);
+  py::array_t<double> out({static_cast<py::ssize_t>(sols.size()), py::ssize_t{6}});
+  auto om = out.mutable_unchecked<2>();
+  for (std::size_t i = 0; i < sols.size(); ++i)
+    for (int j = 0; j < 6; ++j) om(static_cast<py::ssize_t>(i), j) = sols[i][j];
+  return out;
+}
+
 PYBIND11_MODULE(_ssik_native, m) {
   m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("decompose_3axis_test", &decompose_3axis_test_py, py::arg("R"), py::arg("n1"),
@@ -586,6 +620,9 @@ PYBIND11_MODULE(_ssik_native, m) {
   m.def("hp_back_substitute_test", &hp_back_substitute_test_py, py::arg("t_u"), py::arg("t_w_pre"),
         py::arg("sigma_e"), py::arg("u"), py::arg("w"), py::arg("dh_a"), py::arg("dh_l"),
         py::arg("dh_d"), py::arg("right_parametric_var"), py::arg("drop_idx") = 7);
+  m.def("hp_solve_ik_test", &hp_solve_ik_test_py, py::arg("t_u"), py::arg("t_w_pre"),
+        py::arg("sigma_e"), py::arg("dh_a"), py::arg("dh_l"), py::arg("dh_d"),
+        py::arg("right_parametric_var"));
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);

--- a/cpp/bindings/three_parallel_py.cpp
+++ b/cpp/bindings/three_parallel_py.cpp
@@ -507,6 +507,34 @@ py::array_t<double> hp_pencil_roots_test_py(py::array_t<double> f_arr, py::array
   return out;
 }
 
+// HP (u,w) refinement parity (#539): given baked T_u/T_w_pre + sigma_E, return
+// the refined (u,w) pairs, as _eliminate.eliminate_uw_pairs.
+py::array_t<double> hp_eliminate_uw_pairs_test_py(py::array_t<double> t_u_arr,
+                                                  py::array_t<double> t_w_pre_arr,
+                                                  py::array_t<double> sigma_e_arr,
+                                                  double accept_residue_tol) {
+  auto load = [](py::array_t<double> a, std::array<Eigen::Matrix<double, 4, 8>, 2>& dst) {
+    auto u = a.unchecked<3>();
+    for (int i = 0; i < 4; ++i)
+      for (int j = 0; j < 8; ++j)
+        for (int k = 0; k < 2; ++k) dst[k](i, j) = u(i, j, k);
+  };
+  ssik::HpConsts hp;
+  load(t_u_arr, hp.t_u);
+  load(t_w_pre_arr, hp.t_w_pre);
+  auto se = sigma_e_arr.unchecked<1>();
+  ssik::Vec8 sigma_E;
+  for (int i = 0; i < 8; ++i) sigma_E[i] = se(i);
+  const auto pairs = ssik::hp_detail::eliminate_uw_pairs(hp, sigma_E, {7, 4, 0}, accept_residue_tol);
+  py::array_t<double> out({static_cast<py::ssize_t>(pairs.size()), py::ssize_t{2}});
+  auto om = out.mutable_unchecked<2>();
+  for (std::size_t i = 0; i < pairs.size(); ++i) {
+    om(static_cast<py::ssize_t>(i), 0) = pairs[i][0];
+    om(static_cast<py::ssize_t>(i), 1) = pairs[i][1];
+  }
+  return out;
+}
+
 PYBIND11_MODULE(_ssik_native, m) {
   m.doc() = "Native three_parallel solver binding (test conformance + shipped native backend)";
   m.def("decompose_3axis_test", &decompose_3axis_test_py, py::arg("R"), py::arg("n1"),
@@ -515,6 +543,8 @@ PYBIND11_MODULE(_ssik_native, m) {
         py::arg("sigma_e"), py::arg("drop_idx") = 7);
   m.def("hp_pencil_roots_test", &hp_pencil_roots_test_py, py::arg("f"), py::arg("g"),
         py::arg("real_tol") = 1e-3, py::arg("max_magnitude") = 1e10);
+  m.def("hp_eliminate_uw_pairs_test", &hp_eliminate_uw_pairs_test_py, py::arg("t_u"),
+        py::arg("t_w_pre"), py::arg("sigma_e"), py::arg("accept_residue_tol") = 1e-3);
   m.def("three_parallel_solve", &three_parallel_solve_py, py::arg("axes"), py::arg("t_left"),
         py::arg("t_right"), py::arg("types"), py::arg("target"), py::arg("allow_refinement") = false,
         py::arg("refinement_max_iters") = 15);

--- a/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
+++ b/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
@@ -658,5 +658,17 @@ inline JointTuple back_substitute_one(const HpConsts& hp, const Vec8& sigma_E, d
   return {v_1, v_2, v_3, v_4, v_5, v_6};
 }
 
+// Full HP IK kernel: refined (u,w) pairs -> back-substitute each -> the
+// (v_1..v_6) tan-half-angle candidates (_back_substitute.solve_ik). The
+// projective Study-DQ FK-closure filter is intentionally omitted: HP general_6r
+// runs the FK check downstream in POE space (verify_candidates), matching the
+// Python solve_ik(fk_tol=0.5) fast path.
+inline std::vector<JointTuple> solve_ik(const HpConsts& hp, const Vec8& sigma_E) {
+  std::vector<JointTuple> out;
+  for (const auto& uw : eliminate_uw_pairs(hp, sigma_E))
+    out.push_back(back_substitute_one(hp, sigma_E, uw[0], uw[1]));
+  return out;
+}
+
 }  // namespace hp_detail
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
+++ b/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
@@ -10,17 +10,23 @@
 // Slice 1 (#537): the f/g stage -- sigma_E injection + Cramer 5x4
 // evaluation-interpolation + 2-D convolution -> the Study quadric f(u,w) (9x7)
 // and dropped-row g(u,w) (6x5). Parity-gated vs _eliminate.compute_fg_numeric.
+// Slice 2 (#538): Sylvester pencil + 80x80 eigensolve -> candidate u roots.
+// Slice 3 (#539): (u,w) Newton refinement + back-substitution -> joint angles.
 #pragma once
 
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <complex>
+#include <limits>
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 
+#include "ssik_cpp/quartic.hpp"  // np_roots (companion-matrix roots) for _initial_w_for
 #include "ssik_cpp/study_dq.hpp"
 
 namespace ssik {
@@ -178,12 +184,19 @@ inline Mat6x5 dropped_row_g(const std::array<Mat4x8, 2>& t_u, const std::array<M
 // The full f/g stage: sigma_E injection -> Cramer -> quadric + dropped row.
 // Mirrors _eliminate.compute_fg_numeric. `f` is (9,7), `g` is (6,5), indexed
 // [u-power, w-power].
+// f/g from the (already sigma_E-injected) T_w tensor -- Cramer -> quadric +
+// dropped row (_eliminate._compute_fg_with_tw). Split out so eliminate_uw_pairs
+// hoists the drop-independent apply_sigma_e once across the drop-index loop.
+inline void compute_fg_with_tw(const std::array<Mat4x8, 2>& t_u, const std::array<Mat4x8, 2>& t_w,
+                               int drop_idx, Mat9x7& f, Mat6x5& g) {
+  const PCoef p = cramer_8vec_via_interp(t_u, t_w, drop_idx);
+  f = study_quadric_f(p);
+  g = dropped_row_g(t_u, t_w, p, drop_idx);
+}
+
 inline void compute_fg(const HpConsts& hp, const Vec8& sigma_E, int drop_idx, Mat9x7& f,
                        Mat6x5& g) {
-  const std::array<Mat4x8, 2> t_w = apply_sigma_e(hp.t_w_pre, sigma_E);
-  const PCoef p = cramer_8vec_via_interp(hp.t_u, t_w, drop_idx);
-  f = study_quadric_f(p);
-  g = dropped_row_g(hp.t_u, t_w, p, drop_idx);
+  compute_fg_with_tw(hp.t_u, apply_sigma_e(hp.t_w_pre, sigma_E), drop_idx, f, g);
 }
 
 // =============================================================================
@@ -370,6 +383,159 @@ inline std::vector<double> solve_pencil_eigenvalues(const Mat9x7& f, const Mat6x
     }
   }
   std::sort(out.begin(), out.end());
+  return out;
+}
+
+// =============================================================================
+// (u,w) refinement (#539): each pencil u-root is seeded with a w and polished by
+// a 2x2 Newton on [f(u,w); g(u,w)] = 0. Mirrors _eliminate._initial_w_for +
+// _refine_uw_inline + eliminate_uw_pairs.
+// =============================================================================
+
+inline constexpr int kHpNewtonMaxIter = 5;
+inline constexpr double kHpNewtonResidueTol = 1e-12;
+inline constexpr double kHpClusterTol = 1e-7;
+
+// Evaluate a bivariate-polynomial block p (rows = u-power, cols = w-power) and
+// its partials at (u,w); `scale` is the abs-coefficient polyval floored at the
+// block's max |coeff| (the residue normaliser, matching _refine_uw_inline).
+template <int R, int C>
+inline void eval_poly2d(const Eigen::Matrix<double, R, C>& p, double u, double w, double& val,
+                        double& du, double& dw, double& scale) {
+  double up[R], wp[C], uap[R], wap[C];
+  up[0] = wp[0] = uap[0] = wap[0] = 1.0;
+  for (int i = 1; i < R; ++i) {
+    up[i] = up[i - 1] * u;
+    uap[i] = uap[i - 1] * std::abs(u);
+  }
+  for (int j = 1; j < C; ++j) {
+    wp[j] = wp[j - 1] * w;
+    wap[j] = wap[j - 1] * std::abs(w);
+  }
+  val = du = dw = 0.0;
+  double sc = 0.0, maxc = 0.0;
+  for (int i = 0; i < R; ++i)
+    for (int j = 0; j < C; ++j) {
+      const double c = p(i, j);
+      val += c * up[i] * wp[j];
+      if (i >= 1) du += i * c * up[i - 1] * wp[j];
+      if (j >= 1) dw += j * c * up[i] * wp[j - 1];
+      sc += std::abs(c) * uap[i] * wap[j];
+      maxc = std::max(maxc, std::abs(c));
+    }
+  scale = std::max(sc, maxc);
+}
+
+// Seed w at u=u0: cross-validate the real roots of f(u0,.) and g(u0,.), take the
+// closest f/g pair's midpoint (_eliminate._initial_w_for). nullopt if neither has
+// a real root.
+inline std::optional<double> initial_w_for(const Mat9x7& f, const Mat6x5& g, double u0) {
+  Eigen::Matrix<double, 1, 7> fu = Eigen::Matrix<double, 1, 7>::Zero();
+  Eigen::Matrix<double, 1, 5> gu = Eigen::Matrix<double, 1, 5>::Zero();
+  double up = 1.0;
+  for (int i = 0; i < 9; ++i) {
+    fu += up * f.row(i);
+    if (i < 6) gu += up * g.row(i);
+    up *= u0;
+  }
+  if (fu.cwiseAbs().maxCoeff() == 0.0 || gu.cwiseAbs().maxCoeff() == 0.0) return std::nullopt;
+  // np_roots takes highest-degree-first; our row is lowest-first -> reverse.
+  auto real_roots = [](auto row, int n) {
+    std::vector<double> coeffs(n);
+    for (int k = 0; k < n; ++k) coeffs[k] = row(n - 1 - k);
+    std::vector<double> reals;
+    for (const auto& r : np_roots(coeffs))
+      if (std::abs(r.imag()) <= 1e-6 * (1.0 + std::abs(r.real()))) reals.push_back(r.real());
+    return reals;
+  };
+  const std::vector<double> rf = real_roots(fu, 7), rg = real_roots(gu, 5);
+  if (rf.empty() || rg.empty()) return std::nullopt;
+  double best_w = 0.0, best_gap = std::numeric_limits<double>::infinity();
+  for (double wf : rf)
+    for (double wg : rg)
+      if (std::abs(wf - wg) < best_gap) {
+        best_gap = std::abs(wf - wg);
+        best_w = 0.5 * (wf + wg);
+      }
+  return best_w;
+}
+
+// 2x2 Newton on [f;g]=0 with monotone-best tracking (_eliminate._refine_uw_inline).
+// Returns (u, w, best_residue).
+inline std::array<double, 3> refine_uw_inline(const Mat9x7& f, const Mat6x5& g, double u0,
+                                              double w0) {
+  double fv, gv, fdu, fdw, gdu, gdw, sf, sg;
+  double u = u0, w = w0;
+  eval_poly2d(f, u, w, fv, fdu, fdw, sf);
+  eval_poly2d(g, u, w, gv, gdu, gdw, sg);
+  double best_u = u, best_w = w;
+  double best_res = std::max(std::abs(fv) / std::max(sf, 1e-300), std::abs(gv) / std::max(sg, 1e-300));
+  for (int it = 0; it < kHpNewtonMaxIter; ++it) {
+    if (best_res < kHpNewtonResidueTol) break;
+    eval_poly2d(f, u, w, fv, fdu, fdw, sf);
+    eval_poly2d(g, u, w, gv, gdu, gdw, sg);
+    const double det = fdu * gdw - fdw * gdu;
+    if (det == 0.0 || !std::isfinite(det)) break;
+    const double inv = 1.0 / det;
+    const double d_u = -inv * (gdw * fv - fdw * gv);
+    const double d_w = -inv * (-gdu * fv + fdu * gv);
+    if (!std::isfinite(d_u) || !std::isfinite(d_w)) break;
+    u += d_u;
+    w += d_w;
+    double fn, gn, s1, s2, s3, s4, sfn, sgn;
+    eval_poly2d(f, u, w, fn, s1, s2, sfn);
+    eval_poly2d(g, u, w, gn, s3, s4, sgn);
+    const double res =
+        std::max(std::abs(fn) / std::max(sfn, 1e-300), std::abs(gn) / std::max(sgn, 1e-300));
+    if (res < best_res) {
+      best_u = u;
+      best_w = w;
+      best_res = res;
+    }
+  }
+  return {best_u, best_w, best_res};
+}
+
+// Full refinement pipeline: for each drop index, f/g -> pencil roots -> seed w ->
+// Newton, collect accepted (u,w), then 2-D cluster-merge (_eliminate.eliminate_
+// uw_pairs). drop_indices {7,4,0} cover both Tv6 and Tv4 right paths.
+// accept_residue_tol loosens the keep threshold (HP general_6r polishes downstream
+// in 6-D via lm_refine, so multi-root candidates that Newton can't push to 1e-12
+// are still valid IK).
+inline std::vector<std::array<double, 2>> eliminate_uw_pairs(
+    const HpConsts& hp, const Vec8& sigma_E, const std::vector<int>& drop_indices = {7, 4, 0},
+    double accept_residue_tol = 1e-3) {
+  const std::array<Mat4x8, 2> t_w = apply_sigma_e(hp.t_w_pre, sigma_E);
+  std::vector<std::array<double, 2>> refined;
+  for (int di : drop_indices) {
+    Mat9x7 f;
+    Mat6x5 g;
+    compute_fg_with_tw(hp.t_u, t_w, di, f, g);
+    for (double u0 : solve_pencil_eigenvalues(f, g)) {
+      const std::optional<double> w0 = initial_w_for(f, g, u0);
+      if (!w0) continue;
+      const std::array<double, 3> r = refine_uw_inline(f, g, u0, *w0);
+      if (r[2] < accept_residue_tol) refined.push_back({r[0], r[1]});
+    }
+  }
+  // 2-D cluster-merge: sort, then greedily fold points within kHpClusterTol
+  // (scaled) into the running cluster centroid.
+  std::sort(refined.begin(), refined.end());
+  std::vector<std::array<double, 2>> out;
+  for (const auto& uw : refined) {
+    bool merged = false;
+    for (auto& ref : out) {
+      const double scale = std::max({1.0, std::abs(ref[0]), std::abs(ref[1])});
+      const double d2 = (ref[0] - uw[0]) * (ref[0] - uw[0]) + (ref[1] - uw[1]) * (ref[1] - uw[1]);
+      if (d2 <= (kHpClusterTol * scale) * (kHpClusterTol * scale)) {
+        ref[0] = 0.5 * (ref[0] + uw[0]);
+        ref[1] = 0.5 * (ref[1] + uw[1]);
+        merged = true;
+        break;
+      }
+    }
+    if (!merged) out.push_back(uw);
+  }
   return out;
 }
 

--- a/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
+++ b/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
@@ -26,7 +26,10 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 
+#include "ssik_cpp/finalize.hpp"
+#include "ssik_cpp/newton.hpp"   // lm_refine
 #include "ssik_cpp/quartic.hpp"  // np_roots (companion-matrix roots) for _initial_w_for
+#include "ssik_cpp/rescue.hpp"
 #include "ssik_cpp/study_dq.hpp"
 
 namespace ssik {
@@ -48,6 +51,15 @@ struct HpConsts {
   // Dispatch (baked at emit time from the singular-DH predicates):
   int parametric_var = 0;        // u = 0:v_1 (Tv1) | 1:v_2 (Tv2, not yet native)
   int right_parametric_var = 0;  // w = 0:v_6 (Tv6) | 1:v_4 (Tv4)
+  // Target -> sigma_E bridge (all baked): t_hp = t_z_neg_d1 (T_pre^-1 . T .
+  // T_post^-1) t_joint6_offset^-1, then sigma_E = dq_from_se3(t_hp). And the DH
+  // theta_offset to land recovered q back in the POE frame (q = 2 atan(v) -
+  // theta_offset).
+  Eigen::Matrix4d t_pre_inv = Eigen::Matrix4d::Identity();
+  Eigen::Matrix4d t_post_inv = Eigen::Matrix4d::Identity();
+  Eigen::Matrix4d t_z_neg_d1 = Eigen::Matrix4d::Identity();
+  Eigen::Matrix4d t_joint6_offset_inv = Eigen::Matrix4d::Identity();
+  std::array<double, 6> theta_offset{};
 };
 
 namespace hp_detail {
@@ -316,13 +328,17 @@ inline std::vector<double> solve_pencil_eigenvalues(const Mat9x7& f, const Mat6x
   // the reversed polynomial Q(y) = y^d S(1/y) (whose leading coeff is S[0]) and
   // invert the roots u = 1/y. RealQZ remains the fallback when the chosen leading
   // coefficient is singular (a genuine degree drop / infinite eigenvalues).
+  // NB: on well-conditioned HP inputs (the locked-7R sub-chains HP is dispatched
+  // for) this recovers every real root -- verified oracle-complete on clean Tv6
+  // and Tv4 DH. On pathologically ill-conditioned general-6R DH (which HP is
+  // never dispatched for) it can recover fewer roots than LAPACK's generalized
+  // eigensolver; see #544 (monic-vs-dggev completeness gap).
   auto rcond = [](const Mat10& m) {
     Eigen::JacobiSVD<Mat10> svd(m);
     const double smax = svd.singularValues()(0), smin = svd.singularValues()(n - 1);
     return smax > 0.0 ? smin / smax : 0.0;  // reciprocal condition (1 well, 0 singular)
   };
   const bool reversed = rcond(s_eq[0]) > rcond(s_eq[d]);
-  // Coefficient list for the chosen orientation, leading = coeff[d].
   std::array<Mat10, 9> coeff;
   for (int k = 0; k <= d; ++k) coeff[k] = reversed ? s_eq[d - k] : s_eq[k];
 
@@ -338,7 +354,6 @@ inline std::vector<double> solve_pencil_eigenvalues(const Mat9x7& f, const Mat6x
     if (es.info() == Eigen::Success) {
       const auto eig = es.eigenvalues();
       for (int i = 0; i < eig.size(); ++i) {
-        // Reversed solves for y = 1/u; invert (skip y ~ 0, i.e. u -> infinity).
         if (reversed) {
           const std::complex<double> y = eig(i);
           if (std::abs(y) > 1e-300) keep(std::complex<double>(1.0, 0.0) / y);
@@ -349,7 +364,6 @@ inline std::vector<double> solve_pencil_eigenvalues(const Mat9x7& f, const Mat6x
       solved = true;
     }
   }
-
   if (!solved) {
     // Fallback: the generalized pencil via RealQZ. Read the Schur factors S, T
     // directly (never the asserting eigenvalues()/alphas() accessors, which abort
@@ -670,5 +684,78 @@ inline std::vector<JointTuple> solve_ik(const HpConsts& hp, const Vec8& sigma_E)
   return out;
 }
 
+// Wrap-to-pi max-joint dedup for 6-DOF, keeping the lower-FK duplicate.
+inline std::vector<Solution<6>> dedup6(const std::vector<Solution<6>>& cands, double atol) {
+  constexpr double kPi = 3.14159265358979323846;
+  std::vector<Solution<6>> out;
+  for (const auto& cand : cands) {
+    int dup = -1;
+    for (std::size_t j = 0; j < out.size() && dup < 0; ++j) {
+      double worst = 0.0;
+      for (int i = 0; i < 6; ++i) {
+        double dd = std::fmod(cand.q[i] - out[j].q[i] + kPi, 2.0 * kPi);
+        if (dd < 0) dd += 2.0 * kPi;
+        worst = std::max(worst, std::abs(dd - kPi));
+      }
+      if (worst < atol) dup = static_cast<int>(j);
+    }
+    if (dup < 0)
+      out.push_back(cand);
+    else if (cand.fk_residual < out[dup].fk_residual)
+      out[dup] = cand;
+  }
+  return out;
+}
+
 }  // namespace hp_detail
+
+// FK-closure accept gate + dedup tolerance for the HP artifact. Algebraic /
+// back-sub seeds that already close under kHpFkAtol are accepted as-is; the rest
+// (perturbed O(epsilon) seeds, multiplicity-k roots) are lm_refined in POE space.
+inline constexpr double kHpFkAtol = 1e-7;
+inline constexpr double kHpDedupAtol = 1e-3;
+
+// Full self-contained HP universal-6R solve (#539). Bridge the POE target into
+// the HP frame (all transforms baked), run the numeric kernel, convert
+// tan-half-angles to POE q, verify FK + lm_refine, and finalize. Mirrors
+// husty_pfurner.general_6r.solve + verify_candidates, and the limit-gate ->
+// rescue -> seed skeleton of general_6r_artifact_solve.
+inline std::vector<Solution<6>> hp_artifact_solve(const JointConsts<6>& c, const HpConsts& hp,
+                                                  const JointLimits<6>& lim, const Pose& T,
+                                                  const ArtifactParams<6>& p) {
+  const auto core = [&](const Pose& tp) -> std::vector<Solution<6>> {
+    const Pose t_dh = hp.t_pre_inv * tp * hp.t_post_inv;
+    const Pose t_hp = hp.t_z_neg_d1 * t_dh * hp.t_joint6_offset_inv;
+    const Vec8 sigma_E = study::dq_from_se3(t_hp);
+    std::vector<Solution<6>> sols;
+    for (const auto& v : hp_detail::solve_ik(hp, sigma_E)) {
+      std::array<double, 6> q;
+      for (int i = 0; i < 6; ++i) q[i] = 2.0 * std::atan(v[i]) - hp.theta_offset[i];
+      const double fk_err = (fk<6>(c, q) - tp).norm();
+      if (fk_err <= kHpFkAtol) {
+        sols.push_back(Solution<6>{q, fk_err, Refinement::None});
+      } else if (fk_err < 0.1) {  // seed near the basin -> polish (perturbed / multi-root)
+        auto r = lm_refine<6>(c, q, tp, kHpFkAtol, p.refinement_max_iters);
+        if (r && r->second <= kHpFkAtol)
+          sols.push_back(Solution<6>{r->first, r->second, Refinement::Lm});
+      }
+    }
+    return hp_detail::dedup6(sols, kHpDedupAtol);
+  };
+
+  ArtifactParams<6> p_limits;
+  p_limits.respect_limits = p.respect_limits;
+  p_limits.refinement_max_iters = p.refinement_max_iters;
+  std::vector<Solution<6>> in_limits = finalize_solutions<6>(core(T), c, lim, p_limits);
+  if (in_limits.empty() && p.allow_rescue && T.block<3, 1>(0, 3).norm() <= reach_radius(c)) {
+    RescueParams rp;
+    rp.dedup_atol = kHpDedupAtol;
+    in_limits = finalize_solutions<6>(rescue_via_T_perturbation<6>(core, c, T, rp), c, lim,
+                                      p_limits);
+  }
+  ArtifactParams<6> p_seed = p;
+  p_seed.respect_limits = false;
+  return finalize_solutions<6>(std::move(in_limits), c, lim, p_seed);
+}
+
 }  // namespace ssik

--- a/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
+++ b/cpp/include/ssik_cpp/solvers/husty_pfurner.hpp
@@ -39,6 +39,15 @@ struct HpConsts {
   std::array<Eigen::Matrix<double, 4, 8>, 2> t_u{};
   std::array<Eigen::Matrix<double, 4, 8>, 2> t_w_pre{};
   int drop_idx = 7;
+  // Back-substitution DH (the possibly-perturbed chain), 1-indexed to match the
+  // HP naming: a[1..5] link lengths, l[1..5]=tan(alpha/2) twists, d[2..5] offsets
+  // (a[0]/l[0]/d[0]/d[1] unused; d_1 = 0 per HP convention).
+  std::array<double, 6> a{};
+  std::array<double, 6> l{};
+  std::array<double, 6> d{};
+  // Dispatch (baked at emit time from the singular-DH predicates):
+  int parametric_var = 0;        // u = 0:v_1 (Tv1) | 1:v_2 (Tv2, not yet native)
+  int right_parametric_var = 0;  // w = 0:v_6 (Tv6) | 1:v_4 (Tv4)
 };
 
 namespace hp_detail {
@@ -537,6 +546,116 @@ inline std::vector<std::array<double, 2>> eliminate_uw_pairs(
     if (!merged) out.push_back(uw);
   }
   return out;
+}
+
+// =============================================================================
+// Back-substitution (#539): from a refined (u,w) to the joint tan-half-angles
+// (v_1..v_6). Mirrors _back_substitute. Tv1 left + Tv4/Tv6 right; Tv2 left (the
+// case-keyed hyperplanes) is not yet native -- rizon/kassow reach Tv1 via the
+// build-time perturbation, so parametric_var is always 0 here.
+// =============================================================================
+
+// Elementary projective Study DQs (_back_substitute._sigma_*).
+inline Vec8 sigma_z(double v) { return (Vec8() << 1, 0, 0, v, 0, 0, 0, 0).finished(); }
+inline Vec8 sigma_tz(double d) { return (Vec8() << 1, 0, 0, 0, 0, 0, 0, 0.5 * d).finished(); }
+inline Vec8 sigma_tx(double a) { return (Vec8() << 1, 0, 0, 0, 0, 0.5 * a, 0, 0).finished(); }
+inline Vec8 sigma_rx(double ls) { return (Vec8() << 1, ls, 0, 0, 0, 0, 0, 0).finished(); }
+
+// R_z(v) T_z(d) T_x(a) R_x(ls) as a projective DQ (_sigma_joint_full).
+inline Vec8 sigma_joint_full(double v, double a, double ls, double d) {
+  using study::dq_mul;
+  return dq_mul(sigma_z(v), dq_mul(sigma_tz(d), dq_mul(sigma_tx(a), sigma_rx(ls))));
+}
+
+// Cramer cofactor 8-vec P at a single (u,w) (_back_substitute._cramer_P_at):
+// build the 8x8, drop row drop_idx, P = [det(A), x_1 det, ..] with x = A^-1(-col0).
+inline Vec8 cramer_P_at(const std::array<Mat4x8, 2>& t_u, const std::array<Mat4x8, 2>& t_w,
+                        double u, double w, int drop_idx) {
+  Mat8 full;
+  full.block<4, 8>(0, 0) = t_u[0] + u * t_u[1];
+  full.block<4, 8>(4, 0) = t_w[0] + w * t_w[1];
+  Eigen::Matrix<double, 7, 8> m7;
+  int r = 0;
+  for (int k = 0; k < 8; ++k)
+    if (k != drop_idx) m7.row(r++) = full.row(k);
+  const Eigen::Matrix<double, 7, 7> A = m7.block<7, 7>(0, 1);
+  const Eigen::Matrix<double, 7, 1> x = A.lu().solve(-m7.block<7, 1>(0, 0));
+  const double det = A.determinant();
+  Vec8 P;
+  P[0] = det;
+  for (int i = 0; i < 7; ++i) P[i + 1] = x[i] * det;
+  return P;
+}
+
+// Recover (v_a, v_b) from a 2R-chain Study DQ target by a closed-form ZXZ-like
+// rotation decomposition (_back_substitute._solve_2r_chain). d_a/d_b are
+// translation, unused by the rotation extraction. Single (v_a, v_b) solution.
+inline std::pair<double, double> solve_2r_chain(const Vec8& sigma_target, double a_a, double ls_a,
+                                                double a_b, double ls_b) {
+  (void)a_a;
+  (void)a_b;
+  const Eigen::Matrix3d R = study::rot_from_dq(sigma_target);
+
+  const double den_b = 1.0 + ls_b * ls_b;
+  const double sa_b = 2.0 * ls_b / den_b, ca_b = (1.0 - ls_b * ls_b) / den_b;
+  Eigen::Matrix3d rx_neg_b;
+  rx_neg_b << 1, 0, 0, 0, ca_b, sa_b, 0, -sa_b, ca_b;
+  const Eigen::Matrix3d rp = R * rx_neg_b;
+
+  const double den_a = 1.0 + ls_a * ls_a;
+  const double sa_a = 2.0 * ls_a / den_a, ca_a = (1.0 - ls_a * ls_a) / den_a;
+  const double rxz = rp(0, 2), ryz = rp(1, 2);
+
+  double v_a;
+  Eigen::Matrix3d r_double;
+  if (std::abs(sa_a) < 1e-12) {
+    v_a = 0.0;
+    r_double = rp;
+  } else {
+    const double sgn = sa_a > 0.0 ? 1.0 : -1.0;
+    const double th_a = std::atan2(rxz * sgn, -ryz * sgn);
+    v_a = std::tan(0.5 * th_a);
+    const double c = std::cos(th_a), s = std::sin(th_a);
+    Eigen::Matrix3d rz_neg;
+    rz_neg << c, s, 0, -s, c, 0, 0, 0, 1;
+    Eigen::Matrix3d rx_neg_a;
+    rx_neg_a << 1, 0, 0, 0, ca_a, sa_a, 0, -sa_a, ca_a;
+    r_double = rx_neg_a * rz_neg * rp;
+  }
+  const double th_b = std::atan2(r_double(1, 0), r_double(0, 0));
+  return {v_a, std::tan(0.5 * th_b)};
+}
+
+using JointTuple = std::array<double, 6>;  // (v_1..v_6) tan-half-angles
+
+// Full (v_1..v_6) for one (u,w) (_back_substitute.back_substitute_one), Tv1 left.
+inline JointTuple back_substitute_one(const HpConsts& hp, const Vec8& sigma_E, double u, double w) {
+  using study::dq_conj;
+  using study::dq_mul;
+  const std::array<Mat4x8, 2> t_w = apply_sigma_e(hp.t_w_pre, sigma_E);
+  const Vec8 P = cramer_P_at(hp.t_u, t_w, u, w, hp.drop_idx);
+
+  double v_4, v_5, v_6;
+  if (hp.right_parametric_var == 1) {  // Tv4: w = v_4
+    v_4 = w;
+    const Vec8 s4 = sigma_joint_full(v_4, hp.a[4], hp.l[4], hp.d[4]);
+    const Vec8 rhs = dq_mul(dq_conj(s4), dq_mul(dq_conj(P), sigma_E));
+    const auto [a, b] = solve_2r_chain(rhs, hp.a[5], hp.l[5], 0.0, 0.0);
+    v_5 = a;
+    v_6 = b;
+  } else {  // Tv6: w = v_6
+    v_6 = w;
+    const Vec8 rhs = dq_mul(dq_conj(P), dq_mul(sigma_E, dq_conj(sigma_z(v_6))));
+    const auto [a, b] = solve_2r_chain(rhs, hp.a[4], hp.l[4], hp.a[5], hp.l[5]);
+    v_4 = a;
+    v_5 = b;
+  }
+
+  const double v_1 = u;  // Tv1 left
+  const Vec8 s1 = sigma_joint_full(v_1, hp.a[1], hp.l[1], 0.0);
+  const Vec8 left = dq_mul(dq_conj(s1), P);
+  const auto [v_2, v_3] = solve_2r_chain(left, hp.a[2], hp.l[2], hp.a[3], hp.l[3]);
+  return {v_1, v_2, v_3, v_4, v_5, v_6};
 }
 
 }  // namespace hp_detail

--- a/cpp/include/ssik_cpp/study_dq.hpp
+++ b/cpp/include/ssik_cpp/study_dq.hpp
@@ -34,6 +34,23 @@ inline Vec4 quat_mul(const Vec4& p, const Vec4& q) {
 // Quaternion conjugate (_study._quat_conj).
 inline Vec4 quat_conj(const Vec4& p) { return Vec4(p[0], -p[1], -p[2], -p[3]); }
 
+// Dual-quaternion product a*b = (p_a p_b) + eps(p_a q_b + q_a p_b) (_study.dq_mul).
+inline Vec8 dq_mul(const Vec8& a, const Vec8& b) {
+  const Vec4 pa = a.head<4>(), qa = a.tail<4>(), pb = b.head<4>(), qb = b.tail<4>();
+  Vec8 r;
+  r.head<4>() = quat_mul(pa, pb);
+  r.tail<4>() = quat_mul(pa, qb) + quat_mul(qa, pb);
+  return r;
+}
+
+// Dual-quaternion conjugate (p*, q*) (_study.dq_conj / _back_substitute._dq_inv).
+inline Vec8 dq_conj(const Vec8& s) {
+  Vec8 r;
+  r.head<4>() = quat_conj(s.head<4>());
+  r.tail<4>() = quat_conj(s.tail<4>());
+  return r;
+}
+
 // Shepperd (1978) unit quaternion from a 3x3 rotation (_study._quat_from_rot),
 // picking the numerically dominant branch.
 inline Vec4 quat_from_rot(const Eigen::Matrix3d& R) {
@@ -69,6 +86,22 @@ inline Vec4 quat_from_rot(const Eigen::Matrix3d& R) {
   }
   return Vec4(q0, q1, q2, q3);
 }
+
+// 3x3 rotation from a (not necessarily unit) quaternion (_study._rot_from_quat).
+inline Eigen::Matrix3d rot_from_quat(const Vec4& p) {
+  const double p0 = p[0], p1 = p[1], p2 = p[2], p3 = p[3];
+  const double n = p0 * p0 + p1 * p1 + p2 * p2 + p3 * p3;
+  if (n == 0.0) return Eigen::Matrix3d::Identity();
+  const double s = 2.0 / n;
+  Eigen::Matrix3d R;
+  R << 1.0 - s * (p2 * p2 + p3 * p3), s * (p1 * p2 - p3 * p0), s * (p1 * p3 + p2 * p0),  //
+      s * (p1 * p2 + p3 * p0), 1.0 - s * (p1 * p1 + p3 * p3), s * (p2 * p3 - p1 * p0),   //
+      s * (p1 * p3 - p2 * p0), s * (p2 * p3 + p1 * p0), 1.0 - s * (p1 * p1 + p2 * p2);
+  return R;
+}
+
+// Rotation part of se3_from_dq: R from the quaternion (primal) part.
+inline Eigen::Matrix3d rot_from_dq(const Vec8& sigma) { return rot_from_quat(sigma.head<4>()); }
 
 // SE(3) 4x4 -> 8-vec dual quaternion (_study.dq_from_se3).
 // sigma = (p, (1/2) t_quat * p), p = unit quat of R, t_quat = (0, t).

--- a/src/ssik/solvers/husty_pfurner/general_6r.py
+++ b/src/ssik/solvers/husty_pfurner/general_6r.py
@@ -189,6 +189,24 @@ def solve(
     # for the 5 inner joints.
     ls = np.tan(0.5 * dh.alpha)
 
+    # alpha ~ pi twist regularization (#539): the tan-half-angle chart is
+    # singular at alpha = pi, where l = tan(alpha/2) -> +-inf. A joint with a
+    # 180 deg twist (e.g. JACO 2 joint 2, alpha_2 = pi) gives l ~ 1.6e16, which
+    # propagates into the baked T_u/T_w tensors and blows the Cramer f/g
+    # coefficients to ~1e132. At that scale float64's 1e-16 relative precision
+    # leaves ~1e116 absolute error, swamping the smaller f/g coefficients that
+    # encode many IK roots -- the elimination silently loses branches (and two
+    # LU backends lose *different* ones, so results are backend-dependent). This
+    # is the alpha = pi pole of the same chart singularity the perturbation
+    # below handles at alpha = 0; cap |l| at _TWIST_LS_CAP so alpha stays clear
+    # of pi (|l|=1e3 -> alpha within 2e-3 rad of pi, f-scale ~1e21, well inside
+    # float64). The O(1e-3 rad) geometry error is polished out by the
+    # downstream 6-D LM on the *unperturbed* POE FK, exactly as for the alpha=0
+    # perturbation. Only the 5 inner twists feed the elimination; ls[5] (joint 6)
+    # is carried by t_joint6_offset from the exact alpha and is left untouched.
+    _TWIST_LS_CAP = 1.0e3
+    ls[:5] = np.clip(ls[:5], -_TWIST_LS_CAP, _TWIST_LS_CAP)
+
     # Singular-DH perturbation (#176): when a_2 = 0 AND no Tv3 fallback
     # (Tv3 requires a_1 != 0 AND l_1 != 0), the Tv2 case applies and
     # V_L lies entirely in the Study quadric -- the algebraic variety

--- a/tests/test_hp_backsub_cpp.py
+++ b/tests/test_hp_backsub_cpp.py
@@ -1,0 +1,89 @@
+"""Parity gate for the native HP back-substitution (#539, Slice 3b).
+
+`back_substitute_one` recovers the joint tan-half-angles (v_1..v_6) from one
+refined (u,w): Cramer cofactor P at (u,w), then two closed-form 2R sub-chain
+ZXZ-atan2 decompositions (left = Tv1, right = Tv6/Tv4). This is the subtle
+Study-quaternion core, so we hold it to tight parity with Python plus a
+round-trip check (feed the true (u,w) from a known joint vector, recover it).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik.solvers.husty_pfurner._back_substitute import back_substitute_one
+from ssik.solvers.husty_pfurner._eliminate import precompute_rrr_chain
+
+from ._cpp_backend import _load_ext, cpp_available
+from .test_husty_pfurner_eliminate import _full_6r_chain
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="native extension not built")
+
+_DH_SETS = {
+    "baseline": dict(
+        a_1=0.30,
+        l_1=0.40,
+        d_2=0.20,
+        a_2=0.50,
+        l_2=-0.30,
+        d_3=0.10,
+        a_3=0.40,
+        l_3=0.20,
+        d_4=0.15,
+        a_4=0.25,
+        l_4=-0.40,
+        d_5=0.10,
+        a_5=0.20,
+        l_5=0.30,
+    ),
+    "large_alpha": dict(
+        a_1=0.20,
+        l_1=1.50,
+        d_2=0.30,
+        a_2=0.40,
+        l_2=-1.20,
+        d_3=0.20,
+        a_3=0.30,
+        l_3=0.80,
+        d_4=0.10,
+        a_4=0.20,
+        l_4=-0.90,
+        d_5=0.20,
+        a_5=0.30,
+        l_5=1.10,
+    ),
+}
+
+
+def _ang(v: np.ndarray) -> np.ndarray:
+    return np.asarray(2.0 * np.arctan(v), dtype=np.float64)
+
+
+@pytest.mark.parametrize("dh_name", list(_DH_SETS))
+def test_hp_back_substitute(dh_name: str) -> None:
+    ext = _load_ext()
+    dh = _DH_SETS[dh_name]
+    pre = precompute_rrr_chain(**dh)
+    rpv = 1 if pre.right_parametric_var == "v_4" else 0
+    a = tuple(dh[f"a_{i}"] for i in range(1, 6))
+    ls = tuple(dh[f"l_{i}"] for i in range(1, 6))
+    d = tuple(dh[f"d_{i}"] for i in range(2, 6))
+    dh_a, dh_l, dh_d = np.array(a), np.array(ls), np.array(d)
+    rng = np.random.default_rng(3901)
+    for _ in range(400):
+        v = tuple(float(np.tan(x)) for x in rng.uniform(-1.2, 1.2, 6))
+        sigma_E = _full_6r_chain(v=v, a=a, ls=ls, d=d)
+        u_true = v[0]
+        w_true = v[3] if rpv == 1 else v[5]  # Tv4: w=v_4, Tv6: w=v_6
+        v_cpp = np.array(
+            ext.hp_back_substitute_test(
+                pre.T_u, pre.T_w_pre, sigma_E, u_true, w_true, dh_a, dh_l, dh_d, rpv, 7
+            )
+        )
+        v_py = np.array(back_substitute_one(pre, sigma_E, u_true, w_true, **dh)[0])
+        # C++ must match Python's back-substitution at the same (u,w).
+        assert np.max(np.abs(v_cpp - v_py)) <= 1e-9, f"{dh_name}: back_substitute parity"
+        # And it must round-trip to the generating joint angles (mod 2pi).
+        d_ang = (_ang(v_cpp) - _ang(np.array(v)) + np.pi) % (2 * np.pi) - np.pi
+        assert np.max(np.abs(d_ang)) <= 1e-8, f"{dh_name}: round-trip to input joints"

--- a/tests/test_hp_solve_cpp.py
+++ b/tests/test_hp_solve_cpp.py
@@ -1,0 +1,248 @@
+"""Gate for the native HP universal-6R artifact solve (#539, Slice 3d).
+
+`hp_artifact_solve` is the full self-contained HP solve: bridge the POE target
+into the HP frame (baked transforms), run the numeric kernel (f/g -> pencil ->
+refine -> back-sub), convert tan-half-angles to POE q, POE-FK verify + lm_refine,
+finalize.
+
+Two properties are gated, matching HP's real dispatch contract:
+
+1. **Soundness on real 6R arms** (jaco2, piper): every C++ solution FK-closes.
+   This holds at every pose, including the numerically pathological general-6R
+   DH those arms present (jaco2 has alpha_2 = pi; both are highly ill-conditioned
+   for HP's tan-half-angle elimination). HP is *never dispatched for general 6R*
+   in production -- those route to RR / ikgeo tier-2 -- so completeness there is
+   not the contract, but soundness (no wrong answers) must always hold.
+
+2. **Completeness on well-conditioned HP input** (clean synthetic Tv6 and Tv4
+   DH): every Python-oracle candidate is recovered by the native kernel. This is
+   HP's actual shipping path (symmetric-DH locked-7R sub-chains are
+   well-conditioned). The remaining general-6R degenerate-completeness gap is the
+   monic-vs-dggev eigensolve limitation tracked in #544.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik._kinbody import KinBody
+from ssik.kinematics.poe_fk import poe_forward_kinematics
+from ssik.solvers.husty_pfurner._back_substitute import solve_ik as py_solve_ik
+from ssik.solvers.husty_pfurner._eliminate import precompute_rrr_chain
+
+from ._cpp_backend import _load_ext, cpp_available
+from .test_husty_pfurner_eliminate import _full_6r_chain
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="native extension not built")
+
+# Two clean, well-conditioned HP DH sets that exercise both right-chain dispatch
+# paths: the default Tv6 (w = v_6) and Tv4 (w = v_4, forced by a_4 = 0).
+_CLEAN_DH = {
+    "tv6": dict(
+        a_1=0.30,
+        l_1=0.40,
+        d_2=0.20,
+        a_2=0.50,
+        l_2=-0.30,
+        d_3=0.10,
+        a_3=0.40,
+        l_3=0.20,
+        d_4=0.15,
+        a_4=0.25,
+        l_4=-0.40,
+        d_5=0.10,
+        a_5=0.20,
+        l_5=0.30,
+    ),
+    "tv4": dict(
+        a_1=0.30,
+        l_1=0.40,
+        d_2=0.20,
+        a_2=0.50,
+        l_2=-0.30,
+        d_3=0.10,
+        a_3=0.40,
+        l_3=0.20,
+        d_4=0.15,
+        a_4=0.0,
+        l_4=0.35,
+        d_5=0.10,
+        a_5=0.20,
+        l_5=0.30,
+    ),
+}
+
+
+def _hp_bake(kb: KinBody) -> dict[str, object]:
+    """Bake every HpConsts field from a KinBody, mirroring the setup in
+    husty_pfurner.general_6r.solve (poe_to_dh bridge + alpha~pi twist cap +
+    singular-DH perturbation + precompute_rrr_chain). This is the emit-side
+    geometry (Slice 3e will move it into ssik._native as shared emit/runtime
+    source)."""
+    from ssik.kinematics.poe_to_dh import poe_to_dh
+    from ssik.solvers.husty_pfurner.general_6r import _se3_from_dh_offset
+
+    dh = poe_to_dh(kb)
+    ls = np.tan(0.5 * dh.alpha)
+    ls[:5] = np.clip(ls[:5], -1.0e3, 1.0e3)  # alpha~pi twist cap, mirrors general_6r.solve
+    t_z = np.eye(4)
+    t_z[2, 3] = -float(dh.d[0])
+    t_j6 = _se3_from_dh_offset(a=float(dh.a[5]), alpha=float(dh.alpha[5]), d=float(dh.d[5]))
+
+    st, ep = 1e-9, 1e-3
+    a1, l1, a2, l2 = float(dh.a[0]), float(ls[0]), float(dh.a[1]), float(ls[1])
+    a4, l4, a5, l5 = float(dh.a[3]), float(ls[3]), float(dh.a[4]), float(ls[4])
+    if not (abs(a2) > st and abs(l2) > st) and not (abs(a1) > st and abs(l1) > st):
+        if abs(a2) < st:
+            a2 = ep
+        elif abs(l2) < st:
+            l2 = ep
+    right_tv6 = abs(a4) > st and abs(l4) > st
+    right_tv4 = (abs(a4) < st or abs(l4) < st) and abs(a5) > st and abs(l5) > st
+    if not right_tv6 and not right_tv4:
+        if abs(a5) < st:
+            a5 = ep
+        elif abs(l5) < st:
+            l5 = ep
+
+    pre = precompute_rrr_chain(
+        a_1=a1,
+        l_1=l1,
+        d_2=float(dh.d[1]),
+        a_2=a2,
+        l_2=l2,
+        d_3=float(dh.d[2]),
+        a_3=float(dh.a[2]),
+        l_3=float(ls[2]),
+        d_4=float(dh.d[3]),
+        a_4=a4,
+        l_4=l4,
+        d_5=float(dh.d[4]),
+        a_5=a5,
+        l_5=l5,
+    )
+    return dict(
+        t_u=pre.T_u,
+        t_w_pre=pre.T_w_pre,
+        dh_a=np.array([a1, a2, float(dh.a[2]), a4, a5]),
+        dh_l=np.array([l1, l2, float(ls[2]), l4, l5]),
+        dh_d=np.array([float(dh.d[1]), float(dh.d[2]), float(dh.d[3]), float(dh.d[4])]),
+        theta_offset=np.asarray(dh.theta_offset, dtype=np.float64),
+        t_pre_inv=np.linalg.inv(dh.t_pre),
+        t_post_inv=np.linalg.inv(dh.t_post),
+        t_z_neg_d1=t_z,
+        t_joint6_offset_inv=np.linalg.inv(t_j6),
+        right_parametric_var=1 if pre.right_parametric_var == "v_4" else 0,
+        drop_idx=7,
+    )
+
+
+def _consts(kb: KinBody) -> dict[str, object]:
+    js = kb.joints  # type: ignore[attr-defined]
+    return dict(
+        axes=np.array([j.axis for j in js], dtype=np.float64),
+        t_left=np.array([j.T_left for j in js], dtype=np.float64),
+        t_right=np.array([j.T_right for j in js], dtype=np.float64),
+        types=np.array([0 if j.joint_type == "revolute" else 1 for j in js], dtype=np.int32),
+    )
+
+
+@pytest.mark.parametrize("arm", ["jaco2_ik", "piper_ik"])
+def test_hp_artifact_solve_is_sound(arm: str) -> None:
+    """Every native HP artifact-solve solution FK-closes -- no wrong answers,
+    even on the numerically pathological general-6R DH these arms present."""
+    import importlib
+
+    ext = _load_ext()
+    kb = importlib.import_module(f"ssik.prebuilt.{arm}")._KB
+    if len(kb.joints) != 6:
+        pytest.skip("6R only")
+    bake = _hp_bake(kb)
+    con = _consts(kb)
+    rng = np.random.default_rng(3903)
+    ranges = [j.limits if j.limits else (-np.pi, np.pi) for j in kb.joints]
+    worst_fk = 0.0
+    n_sol = 0
+    for _ in range(150):
+        q = np.array([rng.uniform(lo, hi) for lo, hi in ranges])
+        T = np.asarray(poe_forward_kinematics(kb, q), dtype=np.float64)
+        qs, _resids = ext.hp_artifact_solve_test(
+            con["axes"],
+            con["t_left"],
+            con["t_right"],
+            con["types"],
+            bake["t_u"],
+            bake["t_w_pre"],
+            bake["dh_a"],
+            bake["dh_l"],
+            bake["dh_d"],
+            bake["theta_offset"],
+            bake["t_pre_inv"],
+            bake["t_post_inv"],
+            bake["t_z_neg_d1"],
+            bake["t_joint6_offset_inv"],
+            bake["right_parametric_var"],
+            bake["drop_idx"],
+            T,
+            True,
+        )
+        for row in qs:
+            c = np.asarray(row)
+            fk = float(np.linalg.norm(poe_forward_kinematics(kb, c) - T))
+            worst_fk = max(worst_fk, fk)
+            n_sol += 1
+            assert fk <= 1e-6, f"{arm}: C++ solution FK residual {fk:.2e}"
+    assert n_sol > 0, f"{arm}: native HP produced no solutions"
+    assert worst_fk <= 1e-6
+
+
+@pytest.mark.parametrize("dh_name", list(_CLEAN_DH))
+def test_hp_kernel_complete_on_wellconditioned_dh(dh_name: str) -> None:
+    """On well-conditioned HP DH (the shipping locked-7R contract), the native
+    kernel recovers every Python-oracle (v_1..v_6) candidate."""
+    ext = _load_ext()
+    dh: dict[str, float] = _CLEAN_DH[dh_name]
+    pre = precompute_rrr_chain(**dh)
+    a = tuple(dh[f"a_{i}"] for i in range(1, 6))
+    ls = tuple(dh[f"l_{i}"] for i in range(1, 6))
+    d = tuple(dh[f"d_{i}"] for i in range(2, 6))
+    rpv = 1 if pre.right_parametric_var == "v_4" else 0
+    dh_a, dh_l, dh_d = np.array(a), np.array(ls), np.array(d)
+    rng = np.random.default_rng(42)
+    for _ in range(80):
+        v = tuple(float(np.tan(x)) for x in rng.uniform(-1.4, 1.4, 6))
+        sigma_E = np.asarray(_full_6r_chain(v=v, a=a, ls=ls, d=d), dtype=np.float64)
+        cpp = np.asarray(
+            ext.hp_solve_ik_test(pre.T_u, pre.T_w_pre, sigma_E, dh_a, dh_l, dh_d, rpv)
+        ).reshape(-1, 6)
+        assert len(cpp), f"{dh_name}: native returned no candidates"
+        # True root recovered.
+        tv = np.array(v)
+        assert np.min(np.max(np.abs(cpp - tv), axis=1)) < 1e-4, (
+            f"{dh_name}: native missed the true root"
+        )
+        # Every Python-oracle candidate recovered (oracle subset of C++).
+        oracle = py_solve_ik(
+            pre,
+            sigma_E,
+            a_1=a[0],
+            l_1=ls[0],
+            d_2=d[0],
+            a_2=a[1],
+            l_2=ls[1],
+            d_3=d[1],
+            a_3=a[2],
+            l_3=ls[2],
+            d_4=d[2],
+            a_4=a[3],
+            l_4=ls[3],
+            d_5=d[3],
+            a_5=a[4],
+            l_5=ls[4],
+        )
+        for pt in oracle:
+            pt = np.asarray(pt)
+            assert np.min(np.max(np.abs(cpp - pt), axis=1)) < 1e-4, (
+                f"{dh_name}: native missed a Python-oracle candidate {np.round(pt, 4)}"
+            )

--- a/tests/test_hp_solve_ik_cpp.py
+++ b/tests/test_hp_solve_ik_cpp.py
@@ -1,0 +1,81 @@
+"""Completeness gate for the native HP solve_ik kernel (#539, Slice 3c).
+
+`solve_ik` ties the pipeline together: refined (u,w) pairs -> back-substitution
+-> the (v_1..v_6) tan-half-angle candidates. This is the full HP numeric kernel
+from sigma_E (before the target->sigma_E bridge and POE-FK verify, which are the
+artifact-solve wrapper). Gate: for a reachable pose built from a known joint
+vector v, some candidate must recover v (angle-wise, mod 2pi). Exact set-parity
+isn't the gate -- spurious (u,w) yield spurious candidates that FK-filter out
+downstream.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik.solvers.husty_pfurner._eliminate import precompute_rrr_chain
+
+from ._cpp_backend import _load_ext, cpp_available
+from .test_husty_pfurner_eliminate import _full_6r_chain
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="native extension not built")
+
+_DH_SETS = {
+    "baseline": dict(
+        a_1=0.30,
+        l_1=0.40,
+        d_2=0.20,
+        a_2=0.50,
+        l_2=-0.30,
+        d_3=0.10,
+        a_3=0.40,
+        l_3=0.20,
+        d_4=0.15,
+        a_4=0.25,
+        l_4=-0.40,
+        d_5=0.10,
+        a_5=0.20,
+        l_5=0.30,
+    ),
+    "large_alpha": dict(
+        a_1=0.20,
+        l_1=1.50,
+        d_2=0.30,
+        a_2=0.40,
+        l_2=-1.20,
+        d_3=0.20,
+        a_3=0.30,
+        l_3=0.80,
+        d_4=0.10,
+        a_4=0.20,
+        l_4=-0.90,
+        d_5=0.20,
+        a_5=0.30,
+        l_5=1.10,
+    ),
+}
+
+
+@pytest.mark.parametrize("dh_name", list(_DH_SETS))
+def test_hp_solve_ik_recovers_input(dh_name: str) -> None:
+    ext = _load_ext()
+    dh = _DH_SETS[dh_name]
+    pre = precompute_rrr_chain(**dh)
+    rpv = 1 if pre.right_parametric_var == "v_4" else 0
+    a = tuple(dh[f"a_{i}"] for i in range(1, 6))
+    ls = tuple(dh[f"l_{i}"] for i in range(1, 6))
+    d = tuple(dh[f"d_{i}"] for i in range(2, 6))
+    dh_a, dh_l, dh_d = np.array(a), np.array(ls), np.array(d)
+    rng = np.random.default_rng(3902)
+    for _ in range(400):
+        v = tuple(float(np.tan(x)) for x in rng.uniform(-1.2, 1.2, 6))
+        sigma_E = _full_6r_chain(v=v, a=a, ls=ls, d=d)
+        cands = ext.hp_solve_ik_test(pre.T_u, pre.T_w_pre, sigma_E, dh_a, dh_l, dh_d, rpv)
+        v_in = 2.0 * np.arctan(np.asarray(v))
+        found = any(
+            np.max(np.abs((2.0 * np.arctan(np.asarray(c)) - v_in + np.pi) % (2 * np.pi) - np.pi))
+            < 1e-6
+            for c in cands
+        )
+        assert found, f"{dh_name}: solve_ik did not recover the generating joint vector"

--- a/tests/test_hp_uw_cpp.py
+++ b/tests/test_hp_uw_cpp.py
@@ -1,0 +1,76 @@
+"""Completeness gate for the native HP (u,w) refinement (#539, Slice 3a).
+
+`eliminate_uw_pairs` runs, per Cramer drop index, the f/g stage -> Sylvester
+pencil -> a per-root w seed (`_initial_w_for`) -> a 2x2 Newton on [f;g]=0
+(`_refine_uw_inline`) -> a 2-D cluster-merge, producing the refined (u,w) pairs
+that back-substitution consumes. As with the pencil (test_hp_pencil_cpp), exact
+set-parity with Python isn't the gate -- LAPACK vs Eigen produce different
+*spurious* (u,w) that never survive back-substitution + FK. What must hold is that
+every true root is recovered: for a reachable pose built from joint tan-half
+angles v, u=v_1 is a genuine root, so some refined pair must have u ~ v_1.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ssik.solvers.husty_pfurner._eliminate import precompute_rrr_chain
+
+from ._cpp_backend import _load_ext, cpp_available
+from .test_husty_pfurner_eliminate import _full_6r_chain
+
+pytestmark = pytest.mark.skipif(not cpp_available(), reason="native extension not built")
+
+_DH_SETS = {
+    "baseline": dict(
+        a_1=0.30,
+        l_1=0.40,
+        d_2=0.20,
+        a_2=0.50,
+        l_2=-0.30,
+        d_3=0.10,
+        a_3=0.40,
+        l_3=0.20,
+        d_4=0.15,
+        a_4=0.25,
+        l_4=-0.40,
+        d_5=0.10,
+        a_5=0.20,
+        l_5=0.30,
+    ),
+    "large_alpha": dict(
+        a_1=0.20,
+        l_1=1.50,
+        d_2=0.30,
+        a_2=0.40,
+        l_2=-1.20,
+        d_3=0.20,
+        a_3=0.30,
+        l_3=0.80,
+        d_4=0.10,
+        a_4=0.20,
+        l_4=-0.90,
+        d_5=0.20,
+        a_5=0.30,
+        l_5=1.10,
+    ),
+}
+
+
+@pytest.mark.parametrize("dh_name", list(_DH_SETS))
+def test_hp_uw_recovers_true_root(dh_name: str) -> None:
+    ext = _load_ext()
+    dh = _DH_SETS[dh_name]
+    pre = precompute_rrr_chain(**dh)
+    a = tuple(dh[f"a_{i}"] for i in range(1, 6))
+    ls = tuple(dh[f"l_{i}"] for i in range(1, 6))
+    d = tuple(dh[f"d_{i}"] for i in range(2, 6))
+    rng = np.random.default_rng(539)
+    for _ in range(400):
+        v = tuple(float(np.tan(x)) for x in rng.uniform(-1.4, 1.4, 6))
+        sigma_E = _full_6r_chain(v=v, a=a, ls=ls, d=d)
+        pairs = list(ext.hp_eliminate_uw_pairs_test(pre.T_u, pre.T_w_pre, sigma_E, 1e-3))
+        assert any(abs(uw[0] - v[0]) <= 1e-4 * (1.0 + abs(v[0])) for uw in pairs), (
+            f"{dh_name}: no refined (u,w) pair recovered the true root v1={v[0]:.4f}"
+        )


### PR DESCRIPTION
## Why
Slice 3 of the native C++ Husty-Pfurner (HP) universal-6R kernel (#491 / ADR-0001). Slices 1-2 (#541/#542) landed the f/g stage and the Sylvester pencil + 80x80 eigensolve. This slice completes the numeric kernel end-to-end: pencil roots → (u,w) Newton refinement → back-substitution → joint angles → full self-contained artifact solve (bridge + FK-verify + lm_refine + finalize).

HP is the emit-time-baked, runtime-numeric family: no per-arm sympy→C function (unlike RR); the whole symbolic build runs at build time and bakes numeric tensors into `HpConsts`, so only `sigma_E` (the Study DQ of the target) enters at solve time.

## What
- **3a** — `(u,w)` Newton refinement: `eval_poly2d`, `initial_w_for` (cross-validated f/g root seeding), `refine_uw_inline` (2x2 Newton, monotone-best), `eliminate_uw_pairs` (3-drop union + 2-D cluster-merge).
- **3b** — back-substitution: `solve_2r_chain` (closed-form ZXZ rotation extraction), `back_substitute_one` (Tv1 left; Tv4/Tv6 right dispatch) → `(v_1..v_6)`.
- **3c** — `solve_ik` kernel (refine + back-substitute over all pairs).
- **3d** — `hp_artifact_solve`: bridge the POE target into the HP frame via baked transforms, run the kernel, convert tan-half-angles to POE q, POE-FK verify + `lm_refine`, finalize (limit-gate, rescue, seed). Mirrors `general_6r_artifact_solve`.

### alpha ~ pi twist regularization (shared solver fix)
The tan-half-angle chart is singular at `alpha=pi`, where `l=tan(alpha/2)->+-inf`. A 180deg twist (JACO 2 joint 2) gives `l~1.6e16`, blowing the Cramer f/g coefficients to ~1e132 where float64 loses IK roots (and Eigen vs numpy LU lose *different* ones -> backend-dependent). This is the `alpha=pi` pole of the same chart singularity the existing perturbation handles at `alpha=0`; `general_6r.solve` now caps `|l|` at 1e3 (alpha within 2e-3 rad of pi). The O(1e-3 rad) geometry error is polished out by the downstream 6-D LM on the *unperturbed* POE FK, exactly as for the `alpha=0` perturbation.

## Gate
Parity-gated at every stage (f/g, pencil, (u,w) pairs, back-sub) vs the Python HP reference (existing slice tests). The Slice-3d gate (`tests/test_hp_solve_cpp.py`) matches HP's real dispatch contract:
- **Soundness on real 6R arms** (jaco2, piper): every native solution FK-closes over 150 poses/arm. HP is *never dispatched for general 6R* (those route to RR / ikgeo tier-2), so completeness there is not the contract, but no-wrong-answers always is.
- **Completeness on well-conditioned HP DH** (clean synthetic Tv6 + Tv4): native recovers every Python-oracle `(v_1..v_6)` candidate, 0 missing over 80 poses each -- HP's actual shipping path (symmetric-DH locked-7R sub-chains are well-conditioned).

## Test plan
- `pytest tests/test_hp_*_cpp.py` — 28 passing (fg / pencil / uw / backsub / solve_ik / solve).
- Full HP + jointlock + affected-arm suite: 751 passed, 5 pre-existing xfails, no new failures.
- ruff + mypy clean on changed Python.

## Follow-ups
- #544 — native monic-companion eigensolve recovers fewer roots than LAPACK dggev at degenerate *general-6R* poses (non-shipping; soundness always holds).
- Slice 4 (#540) — kassow native: the HP emitter (`hp_native_geometry` shared bake + `hp_consts()` renderer + a `Matrix<4,8>` literal helper) wired into `_render_jointlock_solve`, since HP's only production consumer is kassow's jointlock inner kernel. Closes #491.

Fixes part of #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)