### PR TITLE
[C++ parallel] Native parallelism layer: jointlock sweep + rescue + batch (#546)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,6 +13,8 @@ endif()
 # so a bare in-tree `cmake ..` still builds without Eigen3Config on the path. No
 # version pin: ssik uses only stable Eigen basics, and pinning a MAJOR (e.g. 3.3)
 # makes SameMajorVersion reject a newer Eigen (5.x on current Homebrew).
+# std::thread (parallel.hpp, #546) needs the platform thread library linked.
+find_package(Threads REQUIRED)
 find_package(Eigen3 QUIET NO_MODULE)
 if(TARGET Eigen3::Eigen)
   set(SSIK_EIGEN Eigen3::Eigen)
@@ -94,6 +96,11 @@ add_test(NAME ur5_fk COMMAND test_ur5_fk)
 add_executable(test_ur5_newton tests/test_ur5_newton.cpp)
 target_link_libraries(test_ur5_newton PRIVATE ssik_cpp)
 add_test(NAME ur5_newton COMMAND test_ur5_newton)
+
+# parallel_for primitive (#546): coverage, no-race, worker-count independence.
+add_executable(test_parallel tests/test_parallel.cpp)
+target_link_libraries(test_parallel PRIVATE ssik_cpp Threads::Threads)
+add_test(NAME parallel COMMAND test_parallel)
 
 # THE GATE (data-driven): every self-contained artifact validated against its
 # Python oracle golden, zero pybind/Python. The arm list is generated into

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -104,6 +104,12 @@ add_executable(test_parallel tests/test_parallel.cpp)
 target_link_libraries(test_parallel PRIVATE ssik_cpp Threads::Threads)
 add_test(NAME parallel COMMAND test_parallel)
 
+# solve_batch equivalence (#546): parallel batch == serial per-pose solve.
+add_executable(test_batch tests/test_batch.cpp)
+target_link_libraries(test_batch PRIVATE ssik_cpp)
+target_include_directories(test_batch PRIVATE gen)
+add_test(NAME batch COMMAND test_batch)
+
 # THE GATE (data-driven): every self-contained artifact validated against its
 # Python oracle golden, zero pybind/Python. The arm list is generated into
 # cpp/gen/artifact_gate.hpp by cpp_emit.py, so onboarding an arm needs no edit

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -40,7 +40,9 @@ target_include_directories(ssik_cpp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gen>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_link_libraries(ssik_cpp INTERFACE ${SSIK_EIGEN})
+# parallel.hpp uses std::thread (jointlock sweep / rescue / batch, #546), so every
+# consumer of the headers links the platform thread library.
+target_link_libraries(ssik_cpp INTERFACE ${SSIK_EIGEN} Threads::Threads)
 target_compile_features(ssik_cpp INTERFACE cxx_std_20)
 
 # Install + export the header-only package so a downstream C++/MoveIt project can

--- a/cpp/cmake/ssik_cppConfig.cmake.in
+++ b/cpp/cmake/ssik_cppConfig.cmake.in
@@ -1,10 +1,12 @@
 @PACKAGE_INIT@
 
-# ssik_cpp is header-only; its only dependency is Eigen (also header-only). The
-# exported ssik::ssik_cpp target links Eigen3::Eigen, so a consumer needs Eigen3
-# findable (brew install eigen / apt install libeigen3-dev).
+# ssik_cpp is header-only. It links Eigen (header-only) and the platform thread
+# library (parallel.hpp uses std::thread, #546), so the exported ssik::ssik_cpp
+# target references Eigen3::Eigen and Threads::Threads -- a consumer needs both
+# findable (brew install eigen / apt install libeigen3-dev; Threads is built in).
 include(CMakeFindDependencyMacro)
 find_dependency(Eigen3 NO_MODULE)
+find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ssik_cppTargets.cmake")
 

--- a/cpp/gen/big_yam_ik.hpp
+++ b/cpp/gen/big_yam_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::big_yam_ik {
@@ -851,6 +852,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::big_yam_ik

--- a/cpp/gen/cr5_ik.hpp
+++ b/cpp/gen/cr5_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::cr5_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::cr5_ik

--- a/cpp/gen/fanuc_crx10ia_ik.hpp
+++ b/cpp/gen/fanuc_crx10ia_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx10ia_ik {
@@ -670,6 +671,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx10ia_ik

--- a/cpp/gen/fanuc_crx10ial_ik.hpp
+++ b/cpp/gen/fanuc_crx10ial_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx10ial_ik {
@@ -736,6 +737,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx10ial_ik

--- a/cpp/gen/fanuc_crx10ialp_ik.hpp
+++ b/cpp/gen/fanuc_crx10ialp_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx10ialp_ik {
@@ -681,6 +682,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx10ialp_ik

--- a/cpp/gen/fanuc_crx20ial_ik.hpp
+++ b/cpp/gen/fanuc_crx20ial_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx20ial_ik {
@@ -681,6 +682,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx20ial_ik

--- a/cpp/gen/fanuc_crx30ia_ik.hpp
+++ b/cpp/gen/fanuc_crx30ia_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx30ia_ik {
@@ -697,6 +698,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx30ia_ik

--- a/cpp/gen/fanuc_crx3ia_ik.hpp
+++ b/cpp/gen/fanuc_crx3ia_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx3ia_ik {
@@ -702,6 +703,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx3ia_ik

--- a/cpp/gen/fanuc_crx5ia_ik.hpp
+++ b/cpp/gen/fanuc_crx5ia_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::fanuc_crx5ia_ik {
@@ -679,6 +680,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_crx5ia_ik

--- a/cpp/gen/fanuc_m710ic_ik.hpp
+++ b/cpp/gen/fanuc_m710ic_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::fanuc_m710ic_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::fanuc_m710ic_ik

--- a/cpp/gen/gen3_lite_ik.hpp
+++ b/cpp/gen/gen3_lite_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::gen3_lite_ik {
@@ -852,6 +853,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::gen3_lite_ik

--- a/cpp/gen/gp8_ik.hpp
+++ b/cpp/gen/gp8_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::gp8_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::gp8_ik

--- a/cpp/gen/hc10_ik.hpp
+++ b/cpp/gen/hc10_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::hc10_ik {
@@ -531,6 +532,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::hc10_ik

--- a/cpp/gen/hh020_ik.hpp
+++ b/cpp/gen/hh020_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::hh020_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::hh020_ik

--- a/cpp/gen/iiwa14_ik.hpp
+++ b/cpp/gen/iiwa14_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::iiwa14_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::iiwa14_ik

--- a/cpp/gen/iiwa7_ik.hpp
+++ b/cpp/gen/iiwa7_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::iiwa7_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::iiwa7_ik

--- a/cpp/gen/irb120_ik.hpp
+++ b/cpp/gen/irb120_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::irb120_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::irb120_ik

--- a/cpp/gen/irb1600_ik.hpp
+++ b/cpp/gen/irb1600_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::irb1600_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::irb1600_ik

--- a/cpp/gen/irb6700_ik.hpp
+++ b/cpp/gen/irb6700_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::irb6700_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::irb6700_ik

--- a/cpp/gen/j2s6s300_ik.hpp
+++ b/cpp/gen/j2s6s300_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::j2s6s300_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::j2s6s300_ik

--- a/cpp/gen/jaco2_ik.hpp
+++ b/cpp/gen/jaco2_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::jaco2_ik {
@@ -730,6 +731,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::jaco2_ik

--- a/cpp/gen/kassow_kr810_ik.hpp
+++ b/cpp/gen/kassow_kr810_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/jointlock_seven_r.hpp"
 
 namespace ssik::kassow_kr810_ik {
@@ -2223,6 +2224,14 @@ inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return jointlock_hp_artifact_solve<16>(consts(), jl_consts(), jl_hp(), jl_hp_sub(),
                                          limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::kassow_kr810_ik

--- a/cpp/gen/kr210_r2700_ik.hpp
+++ b/cpp/gen/kr210_r2700_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::kr210_r2700_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::kr210_r2700_ik

--- a/cpp/gen/kr6_r900_ik.hpp
+++ b/cpp/gen/kr6_r900_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::kr6_r900_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::kr6_r900_ik

--- a/cpp/gen/lrmate200id_ik.hpp
+++ b/cpp/gen/lrmate200id_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::lrmate200id_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::lrmate200id_ik

--- a/cpp/gen/m0609_ik.hpp
+++ b/cpp/gen/m0609_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::m0609_ik {
@@ -767,6 +768,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::m0609_ik

--- a/cpp/gen/m1013_ik.hpp
+++ b/cpp/gen/m1013_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::m1013_ik {
@@ -773,6 +774,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::m1013_ik

--- a/cpp/gen/nova5_ik.hpp
+++ b/cpp/gen/nova5_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::nova5_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::nova5_ik

--- a/cpp/gen/openarm_left_ik.hpp
+++ b/cpp/gen/openarm_left_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::openarm_left_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::openarm_left_ik

--- a/cpp/gen/openarm_right_ik.hpp
+++ b/cpp/gen/openarm_right_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::openarm_right_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::openarm_right_ik

--- a/cpp/gen/piper_ik.hpp
+++ b/cpp/gen/piper_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::piper_ik {
@@ -787,6 +788,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::piper_ik

--- a/cpp/gen/puma560_ik.hpp
+++ b/cpp/gen/puma560_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::puma560_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::puma560_ik

--- a/cpp/gen/r1pro_left_ik.hpp
+++ b/cpp/gen/r1pro_left_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::r1pro_left_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::r1pro_left_ik

--- a/cpp/gen/r1pro_right_ik.hpp
+++ b/cpp/gen/r1pro_right_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::r1pro_right_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::r1pro_right_ik

--- a/cpp/gen/r2000ic210l_ik.hpp
+++ b/cpp/gen/r2000ic210l_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::r2000ic210l_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::r2000ic210l_ik

--- a/cpp/gen/rizon10_ik.hpp
+++ b/cpp/gen/rizon10_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/jointlock_seven_r.hpp"
 
 namespace ssik::rizon10_ik {
@@ -3025,6 +3026,14 @@ inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return jointlock_artifact_solve<16>(consts(), jl_consts(), jl_rr(), jl_coeffs(),
                                       limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::rizon10_ik

--- a/cpp/gen/rizon4_ik.hpp
+++ b/cpp/gen/rizon4_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/jointlock_seven_r.hpp"
 
 namespace ssik::rizon4_ik {
@@ -3386,6 +3387,14 @@ inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return jointlock_artifact_solve<16>(consts(), jl_consts(), jl_rr(), jl_coeffs(),
                                       limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::rizon4_ik

--- a/cpp/gen/rs007n_ik.hpp
+++ b/cpp/gen/rs007n_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::rs007n_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::rs007n_ik

--- a/cpp/gen/rv4fr_ik.hpp
+++ b/cpp/gen/rv4fr_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::rv4fr_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::rv4fr_ik

--- a/cpp/gen/rx160_ik.hpp
+++ b/cpp/gen/rx160_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::rx160_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::rx160_ik

--- a/cpp/gen/standardbots_core_ik.hpp
+++ b/cpp/gen/standardbots_core_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::standardbots_core_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::standardbots_core_ik

--- a/cpp/gen/standardbots_spark_ik.hpp
+++ b/cpp/gen/standardbots_spark_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::standardbots_spark_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::standardbots_spark_ik

--- a/cpp/gen/standardbots_thor_ik.hpp
+++ b/cpp/gen/standardbots_thor_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::standardbots_thor_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::standardbots_thor_ik

--- a/cpp/gen/ur10e_ik.hpp
+++ b/cpp/gen/ur10e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur10e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur10e_ik

--- a/cpp/gen/ur12e_ik.hpp
+++ b/cpp/gen/ur12e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur12e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur12e_ik

--- a/cpp/gen/ur15_ik.hpp
+++ b/cpp/gen/ur15_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur15_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur15_ik

--- a/cpp/gen/ur16e_ik.hpp
+++ b/cpp/gen/ur16e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur16e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur16e_ik

--- a/cpp/gen/ur18_ik.hpp
+++ b/cpp/gen/ur18_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur18_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur18_ik

--- a/cpp/gen/ur20_ik.hpp
+++ b/cpp/gen/ur20_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur20_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur20_ik

--- a/cpp/gen/ur30_ik.hpp
+++ b/cpp/gen/ur30_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur30_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur30_ik

--- a/cpp/gen/ur3e_ik.hpp
+++ b/cpp/gen/ur3e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur3e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur3e_ik

--- a/cpp/gen/ur5_ik.hpp
+++ b/cpp/gen/ur5_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur5_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur5_ik

--- a/cpp/gen/ur5e_ik.hpp
+++ b/cpp/gen/ur5e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur5e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur5e_ik

--- a/cpp/gen/ur7e_ik.hpp
+++ b/cpp/gen/ur7e_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::ur7e_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::ur7e_ik

--- a/cpp/gen/viperx300s_ik.hpp
+++ b/cpp/gen/viperx300s_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::viperx300s_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::viperx300s_ik

--- a/cpp/gen/vs060_ik.hpp
+++ b/cpp/gen/vs060_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::vs060_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::vs060_ik

--- a/cpp/gen/widowx250s_ik.hpp
+++ b/cpp/gen/widowx250s_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/spherical_two_parallel.hpp"
 
 namespace ssik::widowx250s_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return spherical_two_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::widowx250s_ik

--- a/cpp/gen/xarm6_ik.hpp
+++ b/cpp/gen/xarm6_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::xarm6_ik {
@@ -756,6 +757,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::xarm6_ik

--- a/cpp/gen/xmatecr7_ik.hpp
+++ b/cpp/gen/xmatecr7_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::xmatecr7_ik {
@@ -519,6 +520,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::xmatecr7_ik

--- a/cpp/gen/xmatepro7_ik.hpp
+++ b/cpp/gen/xmatepro7_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/srs.hpp"
 
 namespace ssik::xmatepro7_ik {
@@ -129,6 +130,14 @@ inline SrsConsts srs_consts() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return srs_artifact_solve(consts(), srs_consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::xmatepro7_ik

--- a/cpp/gen/xmatesr3_ik.hpp
+++ b/cpp/gen/xmatesr3_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::xmatesr3_ik {
@@ -535,6 +536,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::xmatesr3_ik

--- a/cpp/gen/yam_ik.hpp
+++ b/cpp/gen/yam_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 
 namespace ssik::yam_ik {
@@ -908,6 +909,14 @@ inline void rr_coeffs(const double t12[12], rr_detail::Mat14x9& p_sin,
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return general_6r_artifact_solve(consts(), rr_consts(), rr_coeffs, limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::yam_ik

--- a/cpp/gen/z1_ik.hpp
+++ b/cpp/gen/z1_ik.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/three_parallel.hpp"
 
 namespace ssik::z1_ik {
@@ -99,6 +100,14 @@ inline JointLimits<DOF> limits() {
 inline std::vector<Solution<DOF>> solve(
     const Pose& T, const ArtifactParams<DOF>& p = {}) {
   return three_parallel_artifact_solve(consts(), limits(), T, p);
+}
+
+// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.
+inline std::vector<std::vector<Solution<DOF>>> solve_batch(
+    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {
+  std::vector<std::vector<Solution<DOF>>> out(Ts.size());
+  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });
+  return out;
 }
 
 }  // namespace ssik::z1_ik

--- a/cpp/include/ssik_cpp/parallel.hpp
+++ b/cpp/include/ssik_cpp/parallel.hpp
@@ -1,0 +1,82 @@
+// Backend-wide parallelism primitive for the native artifacts (#546).
+//
+// The native solvers have several embarrassingly-parallel loops with no shared
+// state: the jointlock lock-sweep (N independent 6R sub-chain solves), the
+// T-perturbation rescue (N independent perturbed solves), and batch solving (one
+// independent solve per target pose). All of them fan out through this one
+// `parallel_for`, so the threading policy lives in a single place and stays
+// dependency-free (std::thread only -- no OpenMP flag, no TBB, no std::execution
+// backend), which keeps every shipped `<arm>.hpp` self-contained.
+//
+// Parallelism is a runtime backend property, not per-solve geometry, so the
+// thread cap is a process-global (set once at startup) rather than a field on
+// every ArtifactParams. Default 0 = auto (hardware_concurrency); set 1 to force
+// serial (e.g. inside an already-threaded caller, or for deterministic tests).
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <thread>
+#include <vector>
+
+namespace ssik {
+
+// Process-global worker-thread cap for parallel_for. 0 = auto
+// (std::thread::hardware_concurrency); 1 = force serial; N = at most N workers.
+inline std::atomic<unsigned>& parallel_thread_cap() {
+  static std::atomic<unsigned> cap{0};
+  return cap;
+}
+
+// Set the backend-wide worker cap (0 = auto, 1 = serial). Intended to be called
+// once at startup; a concurrent solve may still observe the old value.
+inline void set_max_threads(unsigned n) {
+  parallel_thread_cap().store(n, std::memory_order_relaxed);
+}
+
+// Effective worker count for a loop of `n` iterations: min(cap-or-hardware, n),
+// floored at 1.
+inline unsigned parallel_worker_count(std::size_t n) {
+  const unsigned cap = parallel_thread_cap().load(std::memory_order_relaxed);
+  unsigned hw = cap != 0 ? cap : std::thread::hardware_concurrency();
+  if (hw == 0) hw = 1;
+  return static_cast<unsigned>(std::min<std::size_t>(hw, n == 0 ? 1 : n));
+}
+
+// Run fn(i) for i in [0, n). Iterations MUST be independent: fn must only write
+// to storage private to its own i (e.g. a pre-sized per-index output slot), so
+// there is no data race and no ordering dependence. Runs serially when n < min_n
+// or only one worker is available; otherwise partitions [0, n) into contiguous
+// chunks, one per worker, with the calling thread taking chunk 0 (so `workers`
+// total threads of execution spawn `workers - 1` std::threads). fn must not throw
+// (an escaped exception in a worker terminates via std::thread's contract).
+//
+// min_n gates out the fixed thread-spawn cost (~tens of us/worker): keep serial
+// unless the loop is either long or its bodies are individually expensive. The
+// coarse native loops (16-sample sweep, 16-perturbation rescue, >=~0.1ms/pose
+// batch) clear this easily; a single fast 6R/SRS solve does not fan out here.
+template <class Fn>
+void parallel_for(std::size_t n, Fn&& fn, std::size_t min_n = 2) {
+  if (n == 0) return;
+  const unsigned workers = n < min_n ? 1u : parallel_worker_count(n);
+  if (workers <= 1) {
+    for (std::size_t i = 0; i < n; ++i) fn(i);
+    return;
+  }
+  const std::size_t chunk = (n + workers - 1) / workers;
+  const auto run_range = [&fn](std::size_t lo, std::size_t hi) {
+    for (std::size_t i = lo; i < hi; ++i) fn(i);
+  };
+  std::vector<std::thread> pool;
+  pool.reserve(workers - 1);
+  for (unsigned w = 1; w < workers; ++w) {
+    const std::size_t lo = std::min(n, static_cast<std::size_t>(w) * chunk);
+    const std::size_t hi = std::min(n, lo + chunk);
+    if (lo < hi) pool.emplace_back(run_range, lo, hi);
+  }
+  run_range(0, std::min(n, chunk));  // calling thread runs chunk 0
+  for (auto& t : pool) t.join();
+}
+
+}  // namespace ssik

--- a/cpp/include/ssik_cpp/parallel.hpp
+++ b/cpp/include/ssik_cpp/parallel.hpp
@@ -44,6 +44,15 @@ inline unsigned parallel_worker_count(std::size_t n) {
   return static_cast<unsigned>(std::min<std::size_t>(hw, n == 0 ? 1 : n));
 }
 
+// Per-thread flag: are we already inside a parallel_for? Nested parallel loops
+// (e.g. the rescue fans out perturbations, and each perturbation runs the
+// jointlock sweep, which itself fans out) would oversubscribe the cores, so only
+// the OUTERMOST parallel_for threads -- inner ones detect the flag and run serial.
+inline bool& parallel_in_region() {
+  thread_local bool in = false;
+  return in;
+}
+
 // Run fn(i) for i in [0, n). Iterations MUST be independent: fn must only write
 // to storage private to its own i (e.g. a pre-sized per-index output slot), so
 // there is no data race and no ordering dependence. Runs serially when n < min_n
@@ -59,13 +68,17 @@ inline unsigned parallel_worker_count(std::size_t n) {
 template <class Fn>
 void parallel_for(std::size_t n, Fn&& fn, std::size_t min_n = 2) {
   if (n == 0) return;
-  const unsigned workers = n < min_n ? 1u : parallel_worker_count(n);
+  const unsigned workers = (n < min_n || parallel_in_region()) ? 1u : parallel_worker_count(n);
   if (workers <= 1) {
     for (std::size_t i = 0; i < n; ++i) fn(i);
     return;
   }
   const std::size_t chunk = (n + workers - 1) / workers;
+  // Each thread of execution marks itself in-region for the duration so a nested
+  // parallel_for on it runs serial. Spawned workers start with a fresh (false)
+  // thread_local and die after join; the calling thread saves/restores its flag.
   const auto run_range = [&fn](std::size_t lo, std::size_t hi) {
+    parallel_in_region() = true;
     for (std::size_t i = lo; i < hi; ++i) fn(i);
   };
   std::vector<std::thread> pool;
@@ -75,7 +88,9 @@ void parallel_for(std::size_t n, Fn&& fn, std::size_t min_n = 2) {
     const std::size_t hi = std::min(n, lo + chunk);
     if (lo < hi) pool.emplace_back(run_range, lo, hi);
   }
+  const bool outer = parallel_in_region();
   run_range(0, std::min(n, chunk));  // calling thread runs chunk 0
+  parallel_in_region() = outer;      // restore (spawned workers' flags die with them)
   for (auto& t : pool) t.join();
 }
 

--- a/cpp/include/ssik_cpp/rescue.hpp
+++ b/cpp/include/ssik_cpp/rescue.hpp
@@ -30,6 +30,7 @@
 
 #include "ssik_cpp/fk.hpp"
 #include "ssik_cpp/newton.hpp"  // lm_refine
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/rotation.hpp"
 
 namespace ssik {
@@ -86,14 +87,16 @@ template <int N, typename SolveFn>
 std::vector<Solution<N>> rescue_via_T_perturbation(SolveFn&& solve_fn, const JointConsts<N>& c,
                                                    const Pose& T_target,
                                                    const RescueParams& p = {}) {
+  const double tight = std::min(1e-12, p.fk_atol);
+  const int n = p.n_perturbations;
+
+  // Phase 1 (serial, cheap): draw the perturbed poses. Kept serial so the shared
+  // PRNG is consumed in the exact same order regardless of thread scheduling --
+  // the recovered set stays bit-identical to the single-threaded rescue.
   std::mt19937_64 rng(p.seed);
   std::normal_distribution<double> normal(0.0, 1.0);
-  const double tight = std::min(1e-12, p.fk_atol);
-
-  std::vector<Solution<N>> refined;
-  std::vector<std::array<double, N>> refined_qs;
-
-  for (int i = 0; i < p.n_perturbations; ++i) {
+  std::vector<Pose> T_perts(n);
+  for (int i = 0; i < n; ++i) {
     const double mult = p.scale_multipliers[i % p.scale_multipliers.size()];
     // Draw dx (translation) then w (so3), matching the Python draw order.
     Eigen::Vector3d dx, w;
@@ -105,25 +108,41 @@ std::vector<Solution<N>> rescue_via_T_perturbation(SolveFn&& solve_fn, const Joi
     Pose dT = Pose::Identity();
     dT.block<3, 3>(0, 0) = R_delta;
     dT.block<3, 1>(0, 3) = dx;
-    const Pose T_pert = T_target * dT;
+    T_perts[i] = T_target * dT;
+  }
 
-    const std::vector<Solution<N>> pert = solve_fn(T_pert);
-    for (const auto& sol : pert) {
+  // Phase 2 (parallel): the expensive part -- re-solve each perturbed pose and
+  // polish every candidate back to T_target. Perturbations are independent
+  // (solve_fn is pure; each writes its own slot), so fan out. When solve_fn is
+  // itself a parallel sweep (jointlock), parallel_for's nesting guard runs that
+  // inner sweep serially -- only this outer level threads.
+  std::vector<std::vector<Solution<N>>> per(n);
+  parallel_for(static_cast<std::size_t>(n), [&](std::size_t idx) {
+    for (const auto& sol : solve_fn(T_perts[idx])) {
       // Polish back to the ORIGINAL T_target: tight (machine precision) then a
       // loose retry for candidates that only reach fk_atol on a genuine ridge.
       auto r = lm_refine<N>(c, sol.q, T_target, tight, p.refinement_max_iters);
       if (!r) r = lm_refine<N>(c, sol.q, T_target, p.fk_atol, p.refinement_max_iters);
       if (!r || r->second > p.fk_atol) continue;
+      per[idx].push_back(Solution<N>{r->first, r->second, Refinement::Rescue});
+    }
+  });
 
+  // Phase 3 (serial): merge in perturbation order + dedup. Same order as the
+  // single-threaded loop, so the surviving set + representatives are identical.
+  std::vector<Solution<N>> refined;
+  std::vector<std::array<double, N>> refined_qs;
+  for (int i = 0; i < n; ++i) {
+    for (const auto& sol : per[i]) {
       bool dup = false;
       for (const auto& e : refined_qs)
-        if (rescue_detail::wrap_dist<N>(r->first, e) < p.dedup_atol) {
+        if (rescue_detail::wrap_dist<N>(sol.q, e) < p.dedup_atol) {
           dup = true;
           break;
         }
       if (dup) continue;
-      refined.push_back(Solution<N>{r->first, r->second, Refinement::Rescue});
-      refined_qs.push_back(r->first);
+      refined.push_back(sol);
+      refined_qs.push_back(sol.q);
     }
   }
   return refined;

--- a/cpp/include/ssik_cpp/solvers/jointlock_seven_r.hpp
+++ b/cpp/include/ssik_cpp/solvers/jointlock_seven_r.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "ssik_cpp/finalize.hpp"
+#include "ssik_cpp/parallel.hpp"
 #include "ssik_cpp/solvers/general_6r.hpp"
 #include "ssik_cpp/solvers/husty_pfurner.hpp"
 
@@ -71,15 +72,17 @@ std::vector<Solution<7>> jointlock_artifact_solve(const JointConsts<7>& c,
                                                   const std::array<RrConsts, NSamples>& rr,
                                                   const CoeffFns& coeffs, const JointLimits<7>& lim,
                                                   const Pose& T, const ArtifactParams<7>& p) {
-  // core: sweep the locked joint, RR-solve each 6R sub-chain, pad to 7-DOF.
+  // core: sweep the locked joint, RR-solve each 6R sub-chain, pad to 7-DOF. The
+  // NSamples RR solves are independent; fan out with each sample writing its own
+  // slot -> no race, merged in sample order (identical dedup to the serial path).
   const auto core = [&](const Pose& tp) {
-    std::vector<Solution<7>> all;
     // Sub-chain JointConsts (POE) is only touched by the 6R refiner, which is off
     // here (the locked sub-chains solve cleanly for the RR-covered arms); a
     // default suffices. If a degenerate sub-chain ever needs the 6R polish, the
     // emitter bakes the 16 sub-chain JointConsts and this passes them.
     static const JointConsts<6> kNoRefineConsts{};
-    for (int i = 0; i < NSamples; ++i) {
+    std::array<std::vector<Solution<7>>, NSamples> per;
+    parallel_for(NSamples, [&](std::size_t i) {
       const auto sub = general_6r_core(kNoRefineConsts, rr[i], coeffs[i], tp, kGeneral6rFkAtol,
                                        kGeneral6rDedupAtol, /*allow_refinement=*/false, 15);
       for (const auto& s6 : sub) {
@@ -94,9 +97,12 @@ std::vector<Solution<7>> jointlock_artifact_solve(const JointConsts<7>& c,
         s7.fk_residual = (fk<7>(c, s7.q) - tp).norm();
         if (s7.fk_residual > kGeneral6rFkAtol) continue;
         s7.refinement = s6.refinement;
-        all.push_back(s7);
+        per[i].push_back(s7);
       }
-    }
+    });
+    std::vector<Solution<7>> all;
+    for (auto& v : per)
+      for (auto& s : v) all.push_back(std::move(s));
     return jointlock_detail::dedup7(all, kGeneral6rDedupAtol);
   };
 
@@ -140,8 +146,11 @@ std::vector<Solution<7>> jointlock_hp_artifact_solve(
     const std::array<HpConsts, NSamples>& hp, const std::array<JointConsts<6>, NSamples>& sub,
     const JointLimits<7>& lim, const Pose& T, const ArtifactParams<7>& p) {
   const auto core = [&](const Pose& tp) {
-    std::vector<Solution<7>> all;
-    for (int i = 0; i < NSamples; ++i) {
+    // The NSamples sub-chain solves are independent (hp_core is pure, reads only
+    // baked consts); fan out with each sample writing its own slot -> no race.
+    // Merge in sample order so dedup7 sees the same order as the serial path.
+    std::array<std::vector<Solution<7>>, NSamples> per;
+    parallel_for(NSamples, [&](std::size_t i) {
       for (const auto& s6 : hp_core(sub[i], hp[i], tp, p.refinement_max_iters)) {
         Solution<7> s7;
         int j = 0;
@@ -152,9 +161,12 @@ std::vector<Solution<7>> jointlock_hp_artifact_solve(
         s7.fk_residual = (fk<7>(c, s7.q) - tp).norm();
         if (s7.fk_residual > kGeneral6rFkAtol) continue;
         s7.refinement = s6.refinement;
-        all.push_back(s7);
+        per[i].push_back(s7);
       }
-    }
+    });
+    std::vector<Solution<7>> all;
+    for (auto& v : per)
+      for (auto& s : v) all.push_back(std::move(s));
     return jointlock_detail::dedup7(all, kGeneral6rDedupAtol);
   };
 

--- a/cpp/tests/test_batch.cpp
+++ b/cpp/tests/test_batch.cpp
@@ -1,0 +1,97 @@
+// solve_batch equivalence (#546): the parallel batch solve must return, for
+// every pose, the same solution set (same count, same solutions in order) as the
+// serial per-pose solve(). Covers a jointlock arm (kassow -- nested: batch outer,
+// sweep inner serial), a 6R arm (jaco2), and an SRS 7R arm (iiwa14).
+//
+// Compared with a wrap-to-pi tolerance, NOT bit-exact: on a heterogeneous CPU
+// (Apple Silicon P/E cores) libm transcendentals (atan/sqrt/trig) differ by ~1
+// ULP between core types, and an lm-refined solution amplifies that seed noise to
+// ~1e-13 as work migrates across cores under threading. Both results are equally
+// valid (identical fk_residual, far inside the FK tolerance); only lm-refined
+// solutions carry it, and the artifact gate's own wrap_close(1e-3) is unaffected.
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include "iiwa14_ik.hpp"
+#include "jaco2_ik.hpp"
+#include "kassow_kr810_ik.hpp"
+
+using namespace ssik;
+
+static int failures = 0;
+
+template <int D, class NS_consts, class NS_limits, class NS_solve, class NS_batch>
+void check_arm(const char* name, NS_consts consts, NS_limits limits, NS_solve solve,
+               NS_batch batch) {
+  auto c = consts();
+  auto lim = limits();
+  std::mt19937 rng(7);
+  std::vector<Pose> Ts;
+  for (int t = 0; t < 60; ++t) {
+    std::array<double, D> q;
+    for (int i = 0; i < D; ++i) {
+      std::uniform_real_distribution<double> u(lim.lo[i], lim.hi[i]);
+      q[i] = u(rng);
+    }
+    Ts.push_back(fk<D>(c, q));
+  }
+  const auto b = batch(Ts, ArtifactParams<D>{});
+  if (b.size() != Ts.size()) {
+    std::printf("FAIL %s: batch size %zu != %zu\n", name, b.size(), Ts.size());
+    ++failures;
+    return;
+  }
+  // wrap-to-pi Linf distance; 1e-9 is far above the ~1e-13 heterogeneous-core FP
+  // noise but far below any distinct IK branch (dedup is 1e-3).
+  const auto wrap_close = [](const std::array<double, D>& a, const std::array<double, D>& b_) {
+    double m = 0.0;
+    for (int j = 0; j < D; ++j) {
+      double d = std::fmod(a[j] - b_[j] + M_PI, 2.0 * M_PI);
+      if (d < 0.0) d += 2.0 * M_PI;
+      m = std::max(m, std::abs(d - M_PI));
+    }
+    return m < 1e-9;
+  };
+  int mism = 0;
+  for (std::size_t i = 0; i < Ts.size(); ++i) {
+    const auto s = solve(Ts[i], ArtifactParams<D>{});
+    bool ok = s.size() == b[i].size();
+    for (std::size_t k = 0; ok && k < s.size(); ++k) ok = ok && wrap_close(s[k].q, b[i][k].q);
+    if (!ok) ++mism;
+  }
+  if (mism) {
+    std::printf("FAIL %s: %d/%zu poses differ batch vs serial\n", name, mism, Ts.size());
+    ++failures;
+  } else {
+    std::printf("%s: solve_batch == serial solve over %zu poses\n", name, Ts.size());
+  }
+}
+
+int main() {
+  check_arm<6>(
+      "jaco2", [] { return jaco2_ik::consts(); }, [] { return jaco2_ik::limits(); },
+      [](const Pose& T, const ArtifactParams<6>& p) { return jaco2_ik::solve(T, p); },
+      [](const std::vector<Pose>& Ts, const ArtifactParams<6>& p) {
+        return jaco2_ik::solve_batch(Ts, p);
+      });
+  check_arm<7>(
+      "iiwa14", [] { return iiwa14_ik::consts(); }, [] { return iiwa14_ik::limits(); },
+      [](const Pose& T, const ArtifactParams<7>& p) { return iiwa14_ik::solve(T, p); },
+      [](const std::vector<Pose>& Ts, const ArtifactParams<7>& p) {
+        return iiwa14_ik::solve_batch(Ts, p);
+      });
+  check_arm<7>(
+      "kassow", [] { return kassow_kr810_ik::consts(); },
+      [] { return kassow_kr810_ik::limits(); },
+      [](const Pose& T, const ArtifactParams<7>& p) { return kassow_kr810_ik::solve(T, p); },
+      [](const std::vector<Pose>& Ts, const ArtifactParams<7>& p) {
+        return kassow_kr810_ik::solve_batch(Ts, p);
+      });
+  if (failures == 0) {
+    std::printf("test_batch: all arms match\n");
+    return 0;
+  }
+  return 1;
+}

--- a/cpp/tests/test_parallel.cpp
+++ b/cpp/tests/test_parallel.cpp
@@ -62,6 +62,27 @@ int main() {
     }
   }
 
+  // 5. Nested parallel_for: inner loops run serial (region flag set) but still
+  //    cover every (outer, inner) pair exactly once.
+  ssik::set_max_threads(8);
+  {
+    const std::size_t no = 12, ni = 50;
+    std::vector<std::atomic<int>> hit(no * ni);
+    for (auto& h : hit) h.store(0);
+    std::atomic<int> inner_saw_region{0};
+    ssik::parallel_for(no, [&](std::size_t o) {
+      ssik::parallel_for(ni, [&](std::size_t i) {
+        if (ssik::parallel_in_region()) inner_saw_region.fetch_add(1, std::memory_order_relaxed);
+        hit[o * ni + i].fetch_add(1, std::memory_order_relaxed);
+      });
+    });
+    bool once = true;
+    for (auto& h : hit) once = once && (h.load() == 1);
+    check(once, "nested parallel_for covers every pair exactly once");
+    check(inner_saw_region.load() == static_cast<int>(no * ni),
+          "inner parallel_for runs inside the region flag (serial nesting)");
+  }
+
   ssik::set_max_threads(0);  // restore auto
   if (failures == 0) {
     std::printf("test_parallel: all checks passed\n");

--- a/cpp/tests/test_parallel.cpp
+++ b/cpp/tests/test_parallel.cpp
@@ -1,0 +1,72 @@
+// Unit test for the parallel_for primitive (#546): every index runs exactly once
+// with no data race, results are independent of worker count, and the serial
+// fallback (min_n gate, cap=1) matches.
+#include <atomic>
+#include <cstdio>
+#include <numeric>
+#include <vector>
+
+#include "ssik_cpp/parallel.hpp"
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+  if (!ok) {
+    std::printf("FAIL: %s\n", what);
+    ++failures;
+  }
+}
+
+int main() {
+  // 1. Full coverage + correct per-index writes (disjoint slots => no race).
+  for (unsigned cap : {0u, 1u, 2u, 4u, 8u}) {
+    ssik::set_max_threads(cap);
+    const std::size_t n = 10000;
+    std::vector<long> out(n, -1);
+    ssik::parallel_for(n, [&](std::size_t i) { out[i] = static_cast<long>(i) * 2; });
+    bool ok = true;
+    for (std::size_t i = 0; i < n; ++i) ok = ok && (out[i] == static_cast<long>(i) * 2);
+    check(ok, "every index written exactly once with the right value");
+  }
+
+  // 2. Exactly-once: an atomic counter must equal n (no double-run, no skip).
+  ssik::set_max_threads(8);
+  for (std::size_t n : {std::size_t{0}, std::size_t{1}, std::size_t{7}, std::size_t{97},
+                        std::size_t{1000}}) {
+    std::atomic<std::size_t> runs{0};
+    ssik::parallel_for(n, [&](std::size_t) { runs.fetch_add(1, std::memory_order_relaxed); });
+    check(runs.load() == n, "iteration count equals n");
+  }
+
+  // 3. min_n gate forces serial (single-threaded) below the threshold.
+  ssik::set_max_threads(8);
+  {
+    std::vector<std::size_t> order;
+    ssik::parallel_for(
+        5, [&](std::size_t i) { order.push_back(i); }, /*min_n=*/16);
+    std::vector<std::size_t> expect(5);
+    std::iota(expect.begin(), expect.end(), 0);
+    check(order == expect, "min_n gate runs serially in-order");
+  }
+
+  // 4. Result independent of worker count (sum over a parallel reduction pattern).
+  {
+    const std::size_t n = 5000;
+    long ref = 0;
+    for (unsigned cap : {1u, 3u, 8u}) {
+      ssik::set_max_threads(cap);
+      std::vector<long> part(n);
+      ssik::parallel_for(n, [&](std::size_t i) { part[i] = static_cast<long>(i * i % 7); });
+      const long s = std::accumulate(part.begin(), part.end(), 0L);
+      if (cap == 1u) ref = s;
+      check(s == ref, "reduction result independent of worker count");
+    }
+  }
+
+  ssik::set_max_threads(0);  // restore auto
+  if (failures == 0) {
+    std::printf("test_parallel: all checks passed\n");
+    return 0;
+  }
+  std::printf("test_parallel: %d failures\n", failures);
+  return 1;
+}

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -140,6 +140,10 @@ class CythonBuildHook(BuildHookInterface):  # type: ignore[type-arg]
                             ],
                             language="c++",
                             extra_compile_args=["-std=c++20", "-O2"],
+                            # parallel.hpp (rescue / jointlock sweep, #546) uses
+                            # std::thread -> link pthread on Linux (macOS libSystem
+                            # already has it; this block only runs on Linux/macOS).
+                            extra_link_args=([] if sys.platform == "darwin" else ["-pthread"]),
                         ),
                     ]
                     native_built = True

--- a/scripts/build_cpp_ext.py
+++ b/scripts/build_cpp_ext.py
@@ -59,6 +59,10 @@ def build(out_dir: Path) -> Path:
     ]
     if sys.platform == "darwin":
         cmd += ["-undefined", "dynamic_lookup"]
+    else:
+        # parallel.hpp (rescue / jointlock sweep, #546) uses std::thread, which
+        # needs the pthread library linked on Linux (macOS has it in libSystem).
+        cmd += ["-pthread"]
 
     print("[build_cpp_ext]", " ".join(cmd))
     subprocess.run(cmd, check=True)

--- a/scripts/cpp_emit.py
+++ b/scripts/cpp_emit.py
@@ -534,6 +534,24 @@ def _mat4x8_pair(tensor: np.ndarray) -> str:
     return "{\n      " + _mat4x8(t[:, :, 0]) + ",\n      " + _mat4x8(t[:, :, 1]) + "}"
 
 
+def _render_batch() -> list[str]:
+    """Family-agnostic parallel batch solve: solve() over many targets, one
+    independent solve per target fanned out through parallel_for (#546). For the
+    fast 6R/SRS arms (no internal sweep) this is where threading pays off; for the
+    jointlock arms the nesting guard runs each solve's sweep serially, so batching
+    parallelizes across poses instead (better load balance). Result[i] == solve(
+    Ts[i], p), so it is exactly equivalent to a serial loop of solve()."""
+    return [
+        "// Parallel batch solve: result[i] == solve(Ts[i], p), fanned across poses.",
+        "inline std::vector<std::vector<Solution<DOF>>> solve_batch(",
+        "    const std::vector<Pose>& Ts, const ArtifactParams<DOF>& p = {}) {",
+        "  std::vector<std::vector<Solution<DOF>>> out(Ts.size());",
+        "  parallel_for(Ts.size(), [&](std::size_t i) { out[i] = solve(Ts[i], p); });",
+        "  return out;",
+        "}",
+    ]
+
+
 def emit(arm: str, out_dir: Path, n_parity: int = 200, seed: int = 0) -> None:
     mod = importlib.import_module(f"ssik.prebuilt.{arm}")
     kb = mod._KB
@@ -557,6 +575,7 @@ def emit(arm: str, out_dir: Path, n_parity: int = 200, seed: int = 0) -> None:
         "#pragma once",
         "",
         "#include <vector>" if rendered_solve else "",
+        '#include "ssik_cpp/parallel.hpp"' if rendered_solve else "",  # solve_batch
         header_include,
         "",
         f"namespace ssik::{ns} {{",
@@ -576,7 +595,7 @@ def emit(arm: str, out_dir: Path, n_parity: int = 200, seed: int = 0) -> None:
         lines.append(f"  c.type[{i}] = JointType::{jt};")
     lines += ["  return c;", "}"]
     if rendered_solve:
-        lines += ["", *_render_limits(joints), "", *rendered_solve[1]]
+        lines += ["", *_render_limits(joints), "", *rendered_solve[1], "", *_render_batch()]
     lines += ["", f"}}  // namespace ssik::{ns}", ""]
     art = out_dir / f"{arm}.hpp"
     art.write_text("\n".join(lines))


### PR DESCRIPTION
## Why
Careful profiling of the native kassow HP artifact (#547) found it ~3x slower than Python (52 vs 18ms), 85% in the 80x80 eigensolve, which cannot be squeezed losslessly in Eigen (balancing hurt, RealSchur is identical, fewer Cramer drops loses roots -- see #544). The win is parallelism: the native solvers have several embarrassingly-parallel loops with no shared state. This adds one dependency-free primitive and applies it uniformly.

## What
- **`parallel_for` primitive** (`cpp/include/ssik_cpp/parallel.hpp`): header-only `std::thread`, no OpenMP/TBB/`std::execution` -- keeps every `<arm>.hpp` self-contained. Serial below a size gate; process-global thread cap (`set_max_threads`; 0=auto, 1=serial); a thread-local nesting guard so only the OUTERMOST loop threads (nested loops run serial -- no oversubscription). Unit-tested (coverage, no-race, worker-count independence, nesting).
- **Jointlock sweep**: both RR (`jointlock_artifact_solve`) and HP (`jointlock_hp_artifact_solve`) fan the N independent sub-chain solves out, each writing its own slot, merged in sample order -> byte-identical to serial.
- **Rescue** (`rescue_via_T_perturbation`, all families): serial RNG draws (identical perturbations) -> parallel solve+refine -> ordered merge+dedup -> bit-identical set. The nesting guard runs a jointlock arm's inner sweep serially so only the perturbation loop threads.
- **Batch** (`solve_batch(Ts, p)`, emitted per arm): one independent `solve()` per pose across `parallel_for`; the win for the fast 6R/SRS arms with no sweep. `result[i] == solve(Ts[i], p)`.

## Measured (10-core arm64)
| | serial | parallel | speedup |
|---|---|---|---|
| kassow (HP jointlock) | 47.6 ms | **10.2 ms** | 4.7x (now < Python 18ms) |
| rizon4 (RR jointlock) | 4.68 ms | 1.13 ms | 4.1x |
| jaco2 batch (2000 poses) | 776 ms | 159 ms | 4.9x |

## Reproducibility note
Parallel `solve()` is bit-reproducible on homogeneous CPUs. On a heterogeneous CPU (Apple Silicon P/E cores) libm transcendentals differ ~1 ULP between core types, and an lm-refined solution amplifies that to ~1e-13 as threaded work migrates across cores -- benign (both results equally valid, identical `fk_residual`, far inside the FK tolerance; only lm-refined solutions carry it, and every gate uses `wrap_close(1e-3)`). `set_max_threads(1)` gives exact reproducibility. `test_batch` compares with a 1e-9 tolerance accordingly.

## Test plan
- Full 63-arm artifact gate green (results unchanged -- parallelism is exact/ordered).
- `test_parallel` (primitive + nesting), `test_batch` (solve_batch == serial for jointlock/6R/SRS).
- `ssik_cpp` links `Threads::Threads` (INTERFACE); the pybind test ext + shipped wheel ext link `-pthread` on Linux.

Addresses #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)